### PR TITLE
Sonic block and entity scanning

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -1,9 +1,13 @@
 package dev.amble.ait.core.item.sonic;
 
+import dev.amble.ait.core.AITSounds;
+import dev.amble.ait.core.AITTags;
+import dev.amble.ait.data.schema.sonic.SonicSchema;
 import net.minecraft.block.*;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.particle.BlockStateParticleEffect;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
@@ -16,10 +20,6 @@ import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.event.GameEvent;
-
-import dev.amble.ait.core.AITSounds;
-import dev.amble.ait.core.AITTags;
-import dev.amble.ait.data.schema.sonic.SonicSchema;
 
 public class OverloadSonicMode extends SonicMode {
 
@@ -83,6 +83,12 @@ public class OverloadSonicMode extends SonicMode {
             return;
         }
 
+        if (block instanceof GlassBlock
+                || block instanceof StainedGlassPaneBlock) {
+            breakBlock(world, pos, user, state, blockHit);
+            return;
+        }
+
         if (block instanceof ButtonBlock) {
             activateBlock(world, pos, user, state, blockHit);
             return;
@@ -100,6 +106,19 @@ public class OverloadSonicMode extends SonicMode {
 
     private void activateBlock(ServerWorld world, BlockPos pos, LivingEntity user, BlockState state, BlockHitResult blockHitResult) {
         state.onUse(world, (PlayerEntity) user, user.getActiveHand(), blockHitResult);
+        this.playFx(world, pos);
+    }
+
+    private void breakBlock(ServerWorld world, BlockPos pos, LivingEntity user, BlockState state, BlockHitResult blockHitResult) {
+        world.playSound(null, pos, state.getSoundGroup().getBreakSound(), SoundCategory.BLOCKS, 1.0F, 1.0F);
+
+        // Spawn block break particles
+        ((ServerWorld) world).spawnParticles(
+                new BlockStateParticleEffect(ParticleTypes.BLOCK, state),
+                pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5,
+                10, 0.5, 0.5, 0.5, 0.1
+        );
+        world.breakBlock(pos, false);
         this.playFx(world, pos);
     }
 

--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -1,8 +1,5 @@
 package dev.amble.ait.core.item.sonic;
 
-import dev.amble.ait.core.AITSounds;
-import dev.amble.ait.core.AITTags;
-import dev.amble.ait.data.schema.sonic.SonicSchema;
 import net.minecraft.block.*;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -20,6 +17,10 @@ import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.event.GameEvent;
+
+import dev.amble.ait.core.AITSounds;
+import dev.amble.ait.core.AITTags;
+import dev.amble.ait.data.schema.sonic.SonicSchema;
 
 public class OverloadSonicMode extends SonicMode {
 

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -1,17 +1,5 @@
 package dev.amble.ait.core.item.sonic;
 
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.server.world.ServerWorld;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.text.Text;
-import net.minecraft.util.*;
-import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.hit.HitResult;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.World;
-
 import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.core.item.SonicItem;
 import dev.amble.ait.core.tardis.Tardis;
@@ -21,6 +9,22 @@ import dev.amble.ait.core.world.TardisServerWorld;
 import dev.amble.ait.data.landing.LandingPadRegion;
 import dev.amble.ait.data.landing.LandingPadSpot;
 import dev.amble.ait.data.schema.sonic.SonicSchema;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Hand;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.EntityHitResult;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.World;
 
 public class ScanningSonicMode extends SonicMode {
     private static final Text RIFT_FOUND = Text.translatable("message.ait.sonic.riftfound").formatted(Formatting.AQUA)
@@ -54,6 +58,9 @@ public class ScanningSonicMode extends SonicMode {
 
         if (hitResult instanceof BlockHitResult blockHit)
             return this.scanRegion(stack, world, user, blockHit.getBlockPos());
+
+        if (hitResult instanceof EntityHitResult entityHit)
+            return this.scanEntities(stack, world, user, entityHit.getEntity());
 
         return false;
     }
@@ -90,6 +97,22 @@ public class ScanningSonicMode extends SonicMode {
         if (TardisServerWorld.isTardisDimension(world)) {
             sendTardisInfo(tardis, (ServerWorld) world, pos, user, stack);
             return true;
+        }
+
+        return false;
+    }
+
+    public boolean scanEntities(ItemStack stack, World world, PlayerEntity user, Entity entity) {
+        if (world.isClient())
+            return true;
+
+        if (user == null)
+            return false;
+
+        if (entity instanceof LivingEntity) {
+            String health = String.valueOf(((LivingEntity) entity).getHealth());
+            String maxhealth = String.valueOf(((LivingEntity) entity).getMaxHealth());
+            user.sendMessage(Text.literal("♥:").append(health).append("/").append(maxhealth).formatted(Formatting.YELLOW), true);
         }
 
         return false;

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -56,16 +56,28 @@ public class ScanningSonicMode extends SonicMode {
         return this.process(stack, world, user);
     }
 
+    @Override
+    public void tick(ItemStack stack, World world, LivingEntity user, int ticks, int ticksLeft) {
+        if (!(world instanceof ServerWorld serverWorld) || !(user instanceof PlayerEntity player) || ticks % 10 != 0)
+            return;
+
+        this.process(stack, world, player);
+    }
+
+
+
     public boolean process(ItemStack stack, World world, PlayerEntity user) {
         HitResult hitResult = SonicMode.getHitResult(user);
 
         if (hitResult instanceof BlockHitResult blockHit) {
             return this.scanBlocks(stack, world, user, blockHit.getBlockPos());
-        } else if (hitResult instanceof EntityHitResult entityHit) {
-            return this.scanEntities(stack, world, user, entityHit.getEntity());
-        } else {
-            return this.scanRegion(stack, world, user, BlockPos.ofFloored(hitResult.getPos()));
         }
+
+        if (hitResult instanceof EntityHitResult entityHit) {
+            return this.scanEntities(stack, world, user, entityHit.getEntity());
+        }
+
+        return this.scanRegion(stack, world, user, BlockPos.ofFloored(hitResult.getPos()));
     }
 
 
@@ -79,18 +91,18 @@ public class ScanningSonicMode extends SonicMode {
 
         String blastRes = String.format("%.2f", block.getBlastResistance());
 
-        String toolRequirement = "Any Tool";
+        String toolRequirement = "item.sonic.scanning.any_tool";
         if (state.isIn(BlockTags.NEEDS_DIAMOND_TOOL)) {
-            toolRequirement = "Diamond Tool";
+            toolRequirement = "item.sonic.scanning.diamond_tool";
         } else if (state.isIn(BlockTags.NEEDS_IRON_TOOL)) {
-            toolRequirement = "Iron Tool";
+            toolRequirement = "item.sonic.scanning.iron_tool";
         } else if (state.isIn(BlockTags.NEEDS_STONE_TOOL)) {
-            toolRequirement = "Stone Tool";
+            toolRequirement = "item.sonic.scanning.stone_tool";
         } else if (!block.getDefaultState().isToolRequired()) {
-            toolRequirement = "Hand (No Tool)";
+            toolRequirement = "item.sonic.scanning.no_tool";
         }
 
-        Text message = Text.literal("\uD83D\uDD25: " + blastRes + " ⛏: " + toolRequirement).formatted(Formatting.YELLOW)
+        Text message = Text.literal("\uD83D\uDD25: " + blastRes + " ⛏: ").append(Text.translatable(toolRequirement)).formatted(Formatting.YELLOW)
                 .formatted(Formatting.GOLD);
         user.sendMessage(message, true);
 

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -1,14 +1,5 @@
 package dev.amble.ait.core.item.sonic;
 
-import dev.amble.ait.core.AITSounds;
-import dev.amble.ait.core.item.SonicItem;
-import dev.amble.ait.core.tardis.Tardis;
-import dev.amble.ait.core.world.LandingPadManager;
-import dev.amble.ait.core.world.RiftChunkManager;
-import dev.amble.ait.core.world.TardisServerWorld;
-import dev.amble.ait.data.landing.LandingPadRegion;
-import dev.amble.ait.data.landing.LandingPadSpot;
-import dev.amble.ait.data.schema.sonic.SonicSchema;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
@@ -28,6 +19,16 @@ import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
+
+import dev.amble.ait.core.AITSounds;
+import dev.amble.ait.core.item.SonicItem;
+import dev.amble.ait.core.tardis.Tardis;
+import dev.amble.ait.core.world.LandingPadManager;
+import dev.amble.ait.core.world.RiftChunkManager;
+import dev.amble.ait.core.world.TardisServerWorld;
+import dev.amble.ait.data.landing.LandingPadRegion;
+import dev.amble.ait.data.landing.LandingPadSpot;
+import dev.amble.ait.data.schema.sonic.SonicSchema;
 
 public class ScanningSonicMode extends SonicMode {
     private static final Text RIFT_FOUND = Text.translatable("message.ait.sonic.riftfound").formatted(Formatting.AQUA)

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1,5 +1,30 @@
 package dev.amble.ait.datagen;
 
+import static dev.amble.ait.core.AITItems.isUnlockedOnThisDay;
+import static net.minecraft.data.server.recipe.RecipeProvider.*;
+
+import java.util.Calendar;
+import java.util.concurrent.CompletableFuture;
+
+import dev.amble.lib.datagen.lang.AmbleLanguageProvider;
+import dev.amble.lib.datagen.lang.LanguageType;
+import dev.amble.lib.datagen.sound.AmbleSoundProvider;
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.data.server.recipe.CookingRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.ShapedRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.ShapelessRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.SmithingTransformRecipeJsonBuilder;
+import net.minecraft.item.Items;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.book.RecipeCategory;
+import net.minecraft.registry.RegistryBuilder;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.RegistryWrapper;
+
 import dev.amble.ait.AITMod;
 import dev.amble.ait.core.AITBlocks;
 import dev.amble.ait.core.AITEntityTypes;
@@ -13,29 +38,6 @@ import dev.amble.ait.module.planet.core.PlanetBlocks;
 import dev.amble.ait.module.planet.core.PlanetItems;
 import dev.amble.ait.module.planet.core.world.PlanetConfiguredFeatures;
 import dev.amble.ait.module.planet.core.world.PlanetPlacedFeatures;
-import dev.amble.lib.datagen.lang.AmbleLanguageProvider;
-import dev.amble.lib.datagen.lang.LanguageType;
-import dev.amble.lib.datagen.sound.AmbleSoundProvider;
-import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
-import net.minecraft.block.Blocks;
-import net.minecraft.data.server.recipe.CookingRecipeJsonBuilder;
-import net.minecraft.data.server.recipe.ShapedRecipeJsonBuilder;
-import net.minecraft.data.server.recipe.ShapelessRecipeJsonBuilder;
-import net.minecraft.data.server.recipe.SmithingTransformRecipeJsonBuilder;
-import net.minecraft.item.Items;
-import net.minecraft.recipe.Ingredient;
-import net.minecraft.recipe.book.RecipeCategory;
-import net.minecraft.registry.RegistryBuilder;
-import net.minecraft.registry.RegistryKeys;
-import net.minecraft.registry.RegistryWrapper;
-
-import java.util.Calendar;
-import java.util.concurrent.CompletableFuture;
-
-import static dev.amble.ait.core.AITItems.isUnlockedOnThisDay;
-import static net.minecraft.data.server.recipe.RecipeProvider.*;
 
 public class AITModDataGenerator implements DataGeneratorEntrypoint {
 

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1,28 +1,5 @@
 package dev.amble.ait.datagen;
 
-import static dev.amble.ait.core.AITItems.isUnlockedOnThisDay;
-import static net.minecraft.data.server.recipe.RecipeProvider.*;
-import static net.minecraft.data.server.recipe.RecipeProvider.createSlabRecipe;
-
-import java.util.Calendar;
-import java.util.concurrent.CompletableFuture;
-
-import dev.amble.lib.datagen.lang.AmbleLanguageProvider;
-import dev.amble.lib.datagen.lang.LanguageType;
-import dev.amble.lib.datagen.sound.AmbleSoundProvider;
-import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
-import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
-
-import net.minecraft.block.Blocks;
-import net.minecraft.data.server.recipe.*;
-import net.minecraft.item.Items;
-import net.minecraft.recipe.Ingredient;
-import net.minecraft.recipe.book.RecipeCategory;
-import net.minecraft.registry.RegistryBuilder;
-import net.minecraft.registry.RegistryKeys;
-import net.minecraft.registry.RegistryWrapper;
-
 import dev.amble.ait.AITMod;
 import dev.amble.ait.core.AITBlocks;
 import dev.amble.ait.core.AITEntityTypes;
@@ -36,6 +13,29 @@ import dev.amble.ait.module.planet.core.PlanetBlocks;
 import dev.amble.ait.module.planet.core.PlanetItems;
 import dev.amble.ait.module.planet.core.world.PlanetConfiguredFeatures;
 import dev.amble.ait.module.planet.core.world.PlanetPlacedFeatures;
+import dev.amble.lib.datagen.lang.AmbleLanguageProvider;
+import dev.amble.lib.datagen.lang.LanguageType;
+import dev.amble.lib.datagen.sound.AmbleSoundProvider;
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.minecraft.block.Blocks;
+import net.minecraft.data.server.recipe.CookingRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.ShapedRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.ShapelessRecipeJsonBuilder;
+import net.minecraft.data.server.recipe.SmithingTransformRecipeJsonBuilder;
+import net.minecraft.item.Items;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.book.RecipeCategory;
+import net.minecraft.registry.RegistryBuilder;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.RegistryWrapper;
+
+import java.util.Calendar;
+import java.util.concurrent.CompletableFuture;
+
+import static dev.amble.ait.core.AITItems.isUnlockedOnThisDay;
+import static net.minecraft.data.server.recipe.RecipeProvider.*;
 
 public class AITModDataGenerator implements DataGeneratorEntrypoint {
 
@@ -967,6 +967,14 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         // Death
         provider.addTranslation("death.attack.tardis_squash", "%1$s got squashed by a TARDIS!");
         provider.addTranslation("death.attack.space_suffocation", "%1$s got blown up due to lack of Oxygen!");
+
+        // Sonic Scanning Mode
+        provider.addTranslation("item.sonic.scanning.any_tool", "Any Tool");
+        provider.addTranslation("item.sonic.scanning.diamond_tool", "Diamond Tool");
+        provider.addTranslation("item.sonic.scanning.iron_tool", "Iron Tool");
+        provider.addTranslation("item.sonic.scanning.stone_tool", "Stone Tool");
+        provider.addTranslation("item.sonic.scanning.no_tool", "Hand (No Tool)");
+
 
         // TARDIS Control Actionbar Title
         provider.addTranslation("tardis.message.protocol_813.travel", "Hail Mary: Protocol 813 is active, please prepare for departure.");


### PR DESCRIPTION
## About the PR
Added a way to scan entity health and blocks to see what tool they need and their blast res plus also shatter glass

## Why / Balance
saturn wanted it and it gives scanning mode more use



## Media
⚔

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- add: Added Glass Blocks to be shattered
- add: Added Entity Health Scanning
- add: Added Block Tool Requirement Scanning
-->