### PR TITLE
fix: tardis dimension should be excluded from travelling (#1121)

### DIFF
--- a/src/main/java/dev/amble/ait/core/util/WorldUtil.java
+++ b/src/main/java/dev/amble/ait/core/util/WorldUtil.java
@@ -1,7 +1,6 @@
 package dev.amble.ait.core.util;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.util.ServerLifecycleHooks;
@@ -50,20 +49,16 @@ import dev.amble.ait.mixin.server.EnderDragonFightAccessor;
 @SuppressWarnings("deprecation")
 public class WorldUtil {
 
-    private static final List<Identifier> blacklisted = new ArrayList<>();
-    private static List<ServerWorld> worlds;
+    private static final Set<Identifier> BLACKLIST = new HashSet<>();
+    private static final List<ServerWorld> OPEN_WORLDS = new ArrayList<>();
     private static final int SAFE_RADIUS = 3;
 
     private static ServerWorld OVERWORLD;
     private static ServerWorld TIME_VORTEX;
 
     public static void init() {
-        for (String id : AITMod.CONFIG.SERVER.WORLDS_BLACKLIST) {
-            blacklisted.add(Identifier.tryParse(id));
-        }
-
-        ServerLifecycleEvents.SERVER_STARTED.register(server -> worlds = getDimensions(server));
-        ServerLifecycleEvents.SERVER_STOPPING.register(server -> worlds = null);
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> generateWorldCache(server));
+        ServerLifecycleEvents.SERVER_STOPPING.register(server -> OPEN_WORLDS.clear());
 
         ServerWorldEvents.UNLOAD.register((server, world) -> {
             if (world.getRegistryKey() == World.OVERWORLD)
@@ -84,11 +79,6 @@ public class WorldUtil {
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
             OVERWORLD = server.getOverworld();
             TIME_VORTEX = server.getWorld(AITDimensions.TIME_VORTEX_WORLD);
-
-            // blacklist all tardises
-            for (ServerWorld world : getDimensions(server)) {
-                if (TardisServerWorld.isTardisDimension(world)) blacklist(world);
-            }
         });
 
         ServerEntityWorldChangeEvents.AFTER_ENTITY_CHANGE_WORLD.register((originalEntity, newEntity, origin, destination) -> {
@@ -103,11 +93,11 @@ public class WorldUtil {
     }
 
     private static void scheduleVortexFall(LivingEntity entity) {
-        int worldIndex = TIME_VORTEX.getRandom().nextInt(worlds.size());
+        int worldIndex = TIME_VORTEX.getRandom().nextInt(OPEN_WORLDS.size());
 
         Scheduler.get().runTaskLater(() -> {
             if (entity.getWorld() == TIME_VORTEX)
-                TeleportUtil.teleport(entity, worlds.get(worldIndex), entity.getPos(), entity.getYaw());
+                TeleportUtil.teleport(entity, OPEN_WORLDS.get(worldIndex), entity.getPos(), entity.getYaw());
         }, TimeUnit.SECONDS, 5);
     }
 
@@ -119,35 +109,33 @@ public class WorldUtil {
         return TIME_VORTEX;
     }
 
-    public static List<ServerWorld> getDimensions(MinecraftServer server) {
-        List<ServerWorld> worlds = new ArrayList<>();
+    private static void generateWorldCache(MinecraftServer server) {
+        OPEN_WORLDS.clear();
+        BLACKLIST.clear();
+
+        for (String rawId : AITMod.CONFIG.SERVER.WORLDS_BLACKLIST) {
+            Identifier id = Identifier.tryParse(rawId);
+
+            if (id == null)
+                continue;
+
+            BLACKLIST.add(id);
+        }
 
         for (ServerWorld world : server.getWorlds()) {
-            if (isOpen(world.getRegistryKey()))
-                worlds.add(world);
+            if (!isBlacklisted(world))
+                OPEN_WORLDS.add(world);
         }
-
-        return worlds;
     }
 
-    public static boolean isOpen(RegistryKey<World> world) {
-        for (Identifier blacklisted : blacklisted) {
-            if (world.getValue().equals(blacklisted))
-                return false;
-        }
-
-        return true;
-    }
-    public static void blacklist(RegistryKey<World> world) {
-        blacklisted.add(world.getValue());
-    }
-    public static void blacklist(World world) {
-        blacklist(world.getRegistryKey());
+    public static boolean isBlacklisted(ServerWorld world) {
+        return world == null || TardisServerWorld.isTardisDimension(world)
+                || BLACKLIST.contains(world.getRegistryKey().getValue());
     }
 
     public static int worldIndex(ServerWorld world) {
-        for (int i = 0; i < worlds.size(); i++) {
-            if (world == worlds.get(i))
+        for (int i = 0; i < OPEN_WORLDS.size(); i++) {
+            if (world == OPEN_WORLDS.get(i))
                 return i;
         }
 
@@ -155,7 +143,7 @@ public class WorldUtil {
     }
 
     public static List<ServerWorld> getOpenWorlds() {
-        return worlds;
+        return OPEN_WORLDS;
     }
 
     public static CachedDirectedGlobalPos locateSafe(CachedDirectedGlobalPos cached,

--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -30,11 +30,10 @@ import dev.amble.ait.AITMod;
 import dev.amble.ait.core.AITDimensions;
 import dev.amble.ait.core.tardis.ServerTardis;
 import dev.amble.ait.core.tardis.manager.ServerTardisManager;
-import dev.amble.ait.core.util.WorldUtil;
 
 public class TardisServerWorld extends MultiDimServerWorld {
 
-    private static final String NAMESPACE = AITMod.MOD_ID + "-tardis";
+    public static final String NAMESPACE = AITMod.MOD_ID + "-tardis";
 
     private ServerTardis tardis;
 
@@ -55,13 +54,11 @@ public class TardisServerWorld extends MultiDimServerWorld {
     }
 
     public static ServerWorld create(ServerTardis tardis) {
-        AITMod.LOGGER.info("Creating Tardis Dimension for Tardis {}", tardis.getUuid());
+        AITMod.LOGGER.info("Creating a dimension for TARDIS {}", tardis.getUuid());
         TardisServerWorld created = (TardisServerWorld) MultiDim.get(ServerLifecycleHooks.get())
                 .add(AITDimensions.TARDIS_WORLD_BLUEPRINT, idForTardis(tardis));
 
         created.setTardis(tardis);
-
-        WorldUtil.blacklist(created);
         return created;
     }
 
@@ -75,6 +72,10 @@ public class TardisServerWorld extends MultiDimServerWorld {
 
     private static Identifier idForTardis(ServerTardis tardis) {
         return new Identifier(NAMESPACE, tardis.getUuid().toString());
+    }
+
+    public static boolean isTardisDimension(RegistryKey<World> key) {
+        return NAMESPACE.equals(key.getValue().getNamespace());
     }
 
     public static boolean isTardisDimension(World world) {


### PR DESCRIPTION
## About the PR
This PR fixes #1121.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- `WorldUtil.worlds` is now `WorldUtil.WORLDS`
- `WorldUtil.blacklisted` is now `WorldUtil.BLACKLIST`
- Removed `WorldUtil.isOpen`, use `WorldUtil.isBlacklisted` instead

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: ignore tardis dimensions when generating world cache

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1134 
- <kbd>&nbsp;1&nbsp;</kbd> #1133 👈 
<!-- GitButler Footer Boundary Bottom -->

