### PR TITLE
fix: respect world blacklist for environment projector

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/EnvironmentProjectorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/EnvironmentProjectorBlockEntity.java
@@ -15,14 +15,11 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import dev.amble.ait.AITMod;
-import dev.amble.ait.api.link.v2.TardisRef;
 import dev.amble.ait.api.link.v2.block.InteriorLinkableBlockEntity;
 import dev.amble.ait.core.AITBlockEntityTypes;
 import dev.amble.ait.core.blocks.EnvironmentProjectorBlock;
@@ -39,8 +36,7 @@ public class EnvironmentProjectorBlockEntity extends InteriorLinkableBlockEntity
         super(AITBlockEntityTypes.ENVIRONMENT_PROJECTOR_BLOCK_ENTITY_TYPE, pos, state);
     }
 
-    public void neighborUpdate(BlockState state, World world, BlockPos pos, Block sourceBlock, BlockPos sourcePos,
-            boolean notify) {
+    public void neighborUpdate(BlockState state, World world, BlockPos pos) {
         boolean powered = world.isReceivingRedstonePower(pos);
 
         if (powered != state.get(POWERED)) {
@@ -57,18 +53,11 @@ public class EnvironmentProjectorBlockEntity extends InteriorLinkableBlockEntity
                 Block.NOTIFY_LISTENERS);
     }
 
-    public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
-            BlockHitResult hit) {
-
+    public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player) {
         if (!this.isLinked())
             return ActionResult.FAIL;
 
-        TardisRef ref = this.tardis();
-
-        if (ref.isEmpty())
-            return ActionResult.PASS;
-
-        Tardis tardis = ref.get();
+        Tardis tardis = this.tardis().get();
 
         if (player.isSneaking()) {
             this.switchSkybox(tardis, state, player);

--- a/src/main/java/dev/amble/ait/core/blockentities/EnvironmentProjectorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/EnvironmentProjectorBlockEntity.java
@@ -4,6 +4,7 @@ import static dev.amble.ait.core.blocks.EnvironmentProjectorBlock.*;
 
 import java.util.Iterator;
 
+import dev.amble.ait.core.util.WorldUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
@@ -121,7 +122,7 @@ public class EnvironmentProjectorBlockEntity extends InteriorLinkableBlockEntity
     }
 
     private static ServerWorld findNext(MinecraftServer server, RegistryKey<World> last) {
-        Iterator<ServerWorld> iter = server.getWorlds().iterator();
+        Iterator<ServerWorld> iter = WorldUtil.getOpenWorlds().iterator();
 
         ServerWorld first = iter.next();
         ServerWorld found = first;

--- a/src/main/java/dev/amble/ait/core/blocks/EnvironmentProjectorBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/EnvironmentProjectorBlock.java
@@ -60,17 +60,17 @@ public class EnvironmentProjectorBlock extends Block implements BlockEntityProvi
 
     @Override
     public void neighborUpdate(BlockState state, World world, BlockPos pos, Block sourceBlock, BlockPos sourcePos,
-            boolean notify) {
+                               boolean notify) {
         if (world.isClient())
             return;
 
         if (world.getBlockEntity(pos) instanceof EnvironmentProjectorBlockEntity projector)
-            projector.neighborUpdate(state, world, pos, sourceBlock, sourcePos, notify);
+            projector.neighborUpdate(state, world, pos);
     }
 
     @Override
     public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
-            BlockHitResult hit) {
+                              BlockHitResult hit) {
         if (world.isClient())
             return ActionResult.PASS;
 
@@ -78,7 +78,7 @@ public class EnvironmentProjectorBlock extends Block implements BlockEntityProvi
             return ActionResult.PASS;
 
         if (world.getBlockEntity(pos) instanceof EnvironmentProjectorBlockEntity projector)
-            return projector.onUse(state, world, pos, player, hand, hit);
+            return projector.onUse(state, world, pos, player);
 
         return ActionResult.PASS;
     }
@@ -94,7 +94,7 @@ public class EnvironmentProjectorBlock extends Block implements BlockEntityProvi
     }
 
     public static void toggle(Tardis tardis, @Nullable PlayerEntity player, World world, BlockPos pos, BlockState state,
-            boolean active) {
+                              boolean active) {
         if (world.getBlockEntity(pos) instanceof EnvironmentProjectorBlockEntity projector)
             projector.toggle(tardis, active);
 

--- a/src/main/java/dev/amble/ait/core/util/WorldUtil.java
+++ b/src/main/java/dev/amble/ait/core/util/WorldUtil.java
@@ -1,7 +1,6 @@
 package dev.amble.ait.core.util;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.util.ServerLifecycleHooks;
@@ -50,20 +49,16 @@ import dev.amble.ait.mixin.server.EnderDragonFightAccessor;
 @SuppressWarnings("deprecation")
 public class WorldUtil {
 
-    private static final List<Identifier> blacklisted = new ArrayList<>();
-    private static List<ServerWorld> worlds;
+    private static final Set<Identifier> BLACKLIST = new HashSet<>();
+    private static final List<ServerWorld> OPEN_WORLDS = new ArrayList<>();
     private static final int SAFE_RADIUS = 3;
 
     private static ServerWorld OVERWORLD;
     private static ServerWorld TIME_VORTEX;
 
     public static void init() {
-        for (String id : AITMod.CONFIG.SERVER.WORLDS_BLACKLIST) {
-            blacklisted.add(Identifier.tryParse(id));
-        }
-
-        ServerLifecycleEvents.SERVER_STARTED.register(server -> worlds = getDimensions(server));
-        ServerLifecycleEvents.SERVER_STOPPING.register(server -> worlds = null);
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> generateWorldCache(server));
+        ServerLifecycleEvents.SERVER_STOPPING.register(server -> OPEN_WORLDS.clear());
 
         ServerWorldEvents.UNLOAD.register((server, world) -> {
             if (world.getRegistryKey() == World.OVERWORLD)
@@ -84,11 +79,6 @@ public class WorldUtil {
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
             OVERWORLD = server.getOverworld();
             TIME_VORTEX = server.getWorld(AITDimensions.TIME_VORTEX_WORLD);
-
-            // blacklist all tardises
-            for (ServerWorld world : getDimensions(server)) {
-                if (TardisServerWorld.isTardisDimension(world)) blacklist(world);
-            }
         });
 
         ServerEntityWorldChangeEvents.AFTER_ENTITY_CHANGE_WORLD.register((originalEntity, newEntity, origin, destination) -> {
@@ -103,11 +93,11 @@ public class WorldUtil {
     }
 
     private static void scheduleVortexFall(LivingEntity entity) {
-        int worldIndex = TIME_VORTEX.getRandom().nextInt(worlds.size());
+        int worldIndex = TIME_VORTEX.getRandom().nextInt(OPEN_WORLDS.size());
 
         Scheduler.get().runTaskLater(() -> {
             if (entity.getWorld() == TIME_VORTEX)
-                TeleportUtil.teleport(entity, worlds.get(worldIndex), entity.getPos(), entity.getYaw());
+                TeleportUtil.teleport(entity, OPEN_WORLDS.get(worldIndex), entity.getPos(), entity.getYaw());
         }, TimeUnit.SECONDS, 5);
     }
 
@@ -119,35 +109,33 @@ public class WorldUtil {
         return TIME_VORTEX;
     }
 
-    public static List<ServerWorld> getDimensions(MinecraftServer server) {
-        List<ServerWorld> worlds = new ArrayList<>();
+    private static void generateWorldCache(MinecraftServer server) {
+        OPEN_WORLDS.clear();
+        BLACKLIST.clear();
+
+        for (String rawId : AITMod.CONFIG.SERVER.WORLDS_BLACKLIST) {
+            Identifier id = Identifier.tryParse(rawId);
+
+            if (id == null)
+                continue;
+
+            BLACKLIST.add(id);
+        }
 
         for (ServerWorld world : server.getWorlds()) {
-            if (isOpen(world.getRegistryKey()))
-                worlds.add(world);
+            if (!isBlacklisted(world))
+                OPEN_WORLDS.add(world);
         }
-
-        return worlds;
     }
 
-    public static boolean isOpen(RegistryKey<World> world) {
-        for (Identifier blacklisted : blacklisted) {
-            if (world.getValue().equals(blacklisted))
-                return false;
-        }
-
-        return true;
-    }
-    public static void blacklist(RegistryKey<World> world) {
-        blacklisted.add(world.getValue());
-    }
-    public static void blacklist(World world) {
-        blacklist(world.getRegistryKey());
+    public static boolean isBlacklisted(ServerWorld world) {
+        return world == null || TardisServerWorld.isTardisDimension(world)
+                || BLACKLIST.contains(world.getRegistryKey().getValue());
     }
 
     public static int worldIndex(ServerWorld world) {
-        for (int i = 0; i < worlds.size(); i++) {
-            if (world == worlds.get(i))
+        for (int i = 0; i < OPEN_WORLDS.size(); i++) {
+            if (world == OPEN_WORLDS.get(i))
                 return i;
         }
 
@@ -155,7 +143,7 @@ public class WorldUtil {
     }
 
     public static List<ServerWorld> getOpenWorlds() {
-        return worlds;
+        return OPEN_WORLDS;
     }
 
     public static CachedDirectedGlobalPos locateSafe(CachedDirectedGlobalPos cached,

--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -30,11 +30,10 @@ import dev.amble.ait.AITMod;
 import dev.amble.ait.core.AITDimensions;
 import dev.amble.ait.core.tardis.ServerTardis;
 import dev.amble.ait.core.tardis.manager.ServerTardisManager;
-import dev.amble.ait.core.util.WorldUtil;
 
 public class TardisServerWorld extends MultiDimServerWorld {
 
-    private static final String NAMESPACE = AITMod.MOD_ID + "-tardis";
+    public static final String NAMESPACE = AITMod.MOD_ID + "-tardis";
 
     private ServerTardis tardis;
 
@@ -55,13 +54,11 @@ public class TardisServerWorld extends MultiDimServerWorld {
     }
 
     public static ServerWorld create(ServerTardis tardis) {
-        AITMod.LOGGER.info("Creating Tardis Dimension for Tardis {}", tardis.getUuid());
+        AITMod.LOGGER.info("Creating a dimension for TARDIS {}", tardis.getUuid());
         TardisServerWorld created = (TardisServerWorld) MultiDim.get(ServerLifecycleHooks.get())
                 .add(AITDimensions.TARDIS_WORLD_BLUEPRINT, idForTardis(tardis));
 
         created.setTardis(tardis);
-
-        WorldUtil.blacklist(created);
         return created;
     }
 
@@ -75,6 +72,10 @@ public class TardisServerWorld extends MultiDimServerWorld {
 
     private static Identifier idForTardis(ServerTardis tardis) {
         return new Identifier(NAMESPACE, tardis.getUuid().toString());
+    }
+
+    public static boolean isTardisDimension(RegistryKey<World> key) {
+        return NAMESPACE.equals(key.getValue().getNamespace());
     }
 
     public static boolean isTardisDimension(World world) {


### PR DESCRIPTION
## About the PR
Use `WorldUtil` to ignore blacklisted dimensions from appearing in environment projector.

## Why / Balance
TARDIS dimensions would quickly build up and clutter the environment projector.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: use filtered world list in environment projector
- refactor: remove unused parameters from environment projector block entity


<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1134 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1133 
<!-- GitButler Footer Boundary Bottom -->

