### PR TITLE
ci: disable spotless failure by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,8 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 spotless {
+    enforceCheck = false
+
     format 'misc', {
         // define the files to apply `misc` to
         target '*.gradle', '.gitattributes', '.gitignore'


### PR DESCRIPTION
## About the PR
Remove spotless check that fails the build. 

## Why / Balance
Instead of enforcing formatting on EVERY build, apply it every once in a while in a separate PR.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
