### PR TITLE
refactor: use a single tardis instance per console/door/exterior renderer pass

### DIFF
--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -517,7 +517,7 @@ public class AITModClient implements ClientModInitializer {
         MatrixStack stack = context.matrixStack();
         boolean bl = TardisServerWorld.isTardisDimension(world);
         if (bl) {
-            Tardis tardis = ClientTardisUtil.getCurrentTardis();
+            ClientTardis tardis = ClientTardisUtil.getCurrentTardis();
             if (tardis == null || tardis.getDesktop() == null) return;
             ClientExteriorVariantSchema variant = tardis.getExterior().getVariant().getClient();
             DoorModel model = variant.getDoor().model();

--- a/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
@@ -1,6 +1,8 @@
 package dev.amble.ait.client.boti;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import dev.amble.ait.client.renderers.doors.DoorRenderer;
+import dev.amble.ait.client.tardis.ClientTardis;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.MinecraftClient;
@@ -26,7 +28,7 @@ import dev.amble.ait.core.tardis.handler.travel.TravelHandlerBase;
 import dev.amble.ait.data.schema.exterior.ClientExteriorVariantSchema;
 
 public class TardisDoorBOTI extends BOTI {
-    public static void renderInteriorDoorBoti(Tardis tardis, DoorBlockEntity door, ClientExteriorVariantSchema variant, MatrixStack stack, Identifier frameTex, SinglePartEntityModel frame, ModelPart mask, int light) {
+    public static void renderInteriorDoorBoti(ClientTardis tardis, DoorBlockEntity door, ClientExteriorVariantSchema variant, MatrixStack stack, Identifier frameTex, SinglePartEntityModel frame, ModelPart mask, int light) {
         if (!variant.parent().hasPortals()) return;
 
         if (!AITMod.CONFIG.CLIENT.ENABLE_TARDIS_BOTI)
@@ -105,7 +107,8 @@ public class TardisDoorBOTI extends BOTI {
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
 
-        ((DoorModel) frame).renderWithAnimations(door, frame.getPart(), stack, botiProvider.getBuffer(AITRenderLayers.getBotiInterior(variant.texture())), light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F);
+        // TODO: use DoorRenderer/ClientLightUtil instead.
+        ((DoorModel) frame).renderWithAnimations(tardis, door, frame.getPart(), stack, botiProvider.getBuffer(AITRenderLayers.getBotiInterior(variant.texture())), light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F);
         //((DoorModel) frame).render(stack, botiProvider.getBuffer(AITRenderLayers.getBotiInterior(variant.texture())), light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F);
         botiProvider.draw();
         stack.pop();
@@ -113,8 +116,8 @@ public class TardisDoorBOTI extends BOTI {
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
         if (variant.emission() != null)
-            ((DoorModel) frame).renderWithAnimations(door, frame.getPart(), stack, botiProvider.getBuffer((DependencyChecker.hasIris() ? AITRenderLayers.tardisEmissiveCullZOffset(variant.emission(), true) : AITRenderLayers.getBeaconBeam(variant.emission(), true))), 0xf000f0, OverlayTexture.DEFAULT_UV, tardis.alarm().enabled().get() ? !tardis.fuel().hasPower() ? 0.25f : 1f : 1f, tardis.alarm().enabled().get() ? !tardis.fuel().hasPower() ? 0.01f : 0.3f : 1f,
-                    tardis.alarm().enabled().get() ? !tardis.fuel().hasPower() ? 0.01f : 0.3f : 1f, 1f);
+            ((DoorModel) frame).renderWithAnimations(tardis, door, frame.getPart(), stack, botiProvider.getBuffer((DependencyChecker.hasIris() ? AITRenderLayers.tardisEmissiveCullZOffset(variant.emission(), true) : AITRenderLayers.getBeaconBeam(variant.emission(), true))), 0xf000f0, OverlayTexture.DEFAULT_UV, tardis.alarm().enabled().get() ? !tardis.fuel().hasPower() ? 0.25f : 1f : 1f,
+                    tardis.alarm().enabled().get() ? !tardis.fuel().hasPower() ? 0.01f : 0.3f : 1f, tardis.alarm().enabled().get() ? !tardis.fuel().hasPower() ? 0.01f : 0.3f : 1f, 1f);
         //((DoorModel) frame).render(stack, botiProvider.getBuffer(AITRenderLayers.getBotiInteriorEmission(variant.emission())), 0xf000f0, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F);
         botiProvider.draw();
         stack.pop();

--- a/src/main/java/dev/amble/ait/client/models/consoles/AlnicoConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/AlnicoConsoleModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
@@ -1402,13 +1403,8 @@ public class AlnicoConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
-
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -1486,7 +1482,7 @@ public class AlnicoConsoleModel extends ConsoleModel {
                 .getChild("bone26");
         direction.yaw += (1.5708f * tardis.travel().destination().getRotation());
 
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/consoles/ConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/ConsoleModel.java
@@ -2,6 +2,7 @@ package dev.amble.ait.client.models.consoles;
 
 import java.util.function.Function;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -41,8 +42,8 @@ public abstract class ConsoleModel extends SinglePartEntityModel {
             this.updateAnimation(console.ANIM_STATE, this.getAnimationForState(state), console.getAge());
     }
 
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         root.render(matrices, vertices, light, overlay, red, green, blue, pAlpha);
     }
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/CopperConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/CopperConsoleModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
@@ -1749,14 +1750,8 @@ public class CopperConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (!console.isLinked()) return;
-
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
         matrices.push();
         matrices.translate(0.5f, -1.52f, -0.5f);
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(150f));
@@ -1830,7 +1825,7 @@ public class CopperConsoleModel extends ConsoleModel {
         ModelPart antigravs = this.copper.getChild("controls").getChild("panel_4").getChild("rot16").getChild("lever8").getChild("bone103");
         antigravs.roll += tardis.travel().antigravs().get() ? 0f : -1f;
 
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/CoralConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/CoralConsoleModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
@@ -2421,13 +2422,8 @@ public class CoralConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
-
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -2534,7 +2530,7 @@ public class CoralConsoleModel extends ConsoleModel {
         ModelPart hammer = controls.getChild("p_ctrl_6").getChild("bone62").getChild("hammer").getChild("bone40");
         hammer.hidden = tardis.extra().consoleHammerInserted() ? false : true;
 
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/CrystallineConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/CrystallineConsoleModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
@@ -1209,12 +1210,7 @@ public class CrystallineConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
-
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -1322,7 +1318,7 @@ public class CrystallineConsoleModel extends ConsoleModel {
 //        ModelPart fastReturnLever = this.console.getChild("panel4").getChild("controls4").getChild("tinyswitch");
 
 
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/HartnellConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/HartnellConsoleModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -1380,15 +1381,8 @@ public class HartnellConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (!console.isLinked()) return;
-
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
-
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -1576,7 +1570,7 @@ public class HartnellConsoleModel extends ConsoleModel {
         ModelPart autoPilot = this.bone.getChild("panels").getChild("p_1").getChild("bone38").getChild("bone36")
                 .getChild("bone37").getChild("st_switch").getChild("bone26");
         autoPilot.yaw = !tardis.travel().autopilot() ? autoPilot.yaw + 1 : autoPilot.yaw;
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/HourglassConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/HourglassConsoleModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
@@ -1607,13 +1608,8 @@ public class HourglassConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
-
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -1712,7 +1708,7 @@ public class HourglassConsoleModel extends ConsoleModel {
 //        ModelPart fastReturnCover = this.console.getChild("panel4").getChild("controls4").getChild("tinyswitchcover");
 //        ModelPart fastReturnLever = this.console.getChild("panel4").getChild("controls4").getChild("tinyswitch");
 
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/HudolinConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/HudolinConsoleModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
@@ -923,16 +924,11 @@ public class HudolinConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
-
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/RenaissanceConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/RenaissanceConsoleModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
@@ -1357,13 +1358,8 @@ public class RenaissanceConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
-
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -1426,7 +1422,7 @@ public class RenaissanceConsoleModel extends ConsoleModel {
 //        ModelPart fastReturnCover = this.console.getChild("panel4").getChild("controls4").getChild("tinyswitchcover");
 //        ModelPart fastReturnLever = this.console.getChild("panel4").getChild("controls4").getChild("tinyswitch");
 
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/SteamConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/SteamConsoleModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -1477,13 +1478,8 @@ public class SteamConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
-
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -1559,7 +1555,7 @@ public class SteamConsoleModel extends ConsoleModel {
                 .getChild("bone48");
         autopilot.roll = autopilot.roll - (tardis.travel().autopilot() ? 1.5708f : 0);
 
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/ToyotaConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/ToyotaConsoleModel.java
@@ -1,6 +1,7 @@
 // Made with Blockbench 4.9.3
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
@@ -1640,13 +1641,8 @@ public class ToyotaConsoleModel extends ConsoleModel {
     }
 
     @Override
-    public void renderWithAnimations(ConsoleBlockEntity console, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        Tardis tardis = console.tardis().get();
-
-        if (tardis == null)
-            return;
-
+    public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -1765,7 +1761,7 @@ public class ToyotaConsoleModel extends ConsoleModel {
         ModelPart fastReturnCover = this.toyota.getChild("panel4").getChild("controls4").getChild("tinyswitchcover");
         ModelPart fastReturnLever = this.toyota.getChild("panel4").getChild("controls4").getChild("tinyswitch");
 
-        super.renderWithAnimations(console, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/coral/CoralGrowthDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/coral/CoralGrowthDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.coral;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -97,7 +98,7 @@ public class CoralGrowthDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity door, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity door, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (door.tardis().get() == null)
             return;
@@ -106,7 +107,7 @@ public class CoralGrowthDoorModel extends DoorModel {
         matrices.translate(0, -1.5f, 0f);
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180f));
 
-        super.renderWithAnimations(door, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, door, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/coral/CoralGrowthExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/coral/CoralGrowthExteriorModel.java
@@ -571,13 +571,8 @@ public class CoralGrowthExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
-        ClientTardis tardis = (ClientTardis) exterior.tardis().get();
-
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         boolean isNotLanded = tardis.interiorChangingHandler().queued().get() || tardis.travel().getState() != TravelHandlerBase.State.LANDED;
         boolean hasCage = tardis.interiorChangingHandler().hasCage();
         seven.getChild("corallybits").visible = !hasCage && tardis.interiorChangingHandler().plasmicMaterialAmount() == 0;
@@ -587,9 +582,9 @@ public class CoralGrowthExteriorModel extends ExteriorModel {
 
         float alpha = ((float) tardis.interiorChangingHandler().plasmicMaterialAmount() / 8f);
 
-        super.renderWithAnimations(exterior, isNotLanded ? six : seven, matrices, vertices, light, overlay, red, green, blue, pAlpha);
-        if (hasCage) super.renderWithAnimations(exterior, cage, matrices, vertices, light, overlay, red, green, blue, pAlpha);
-        super.renderWithAnimations(exterior, perimeter, matrices, vertices, light, overlay, red, green, blue,
+        super.renderWithAnimations(exterior, tardis, isNotLanded ? six : seven, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        if (hasCage) super.renderWithAnimations(exterior, tardis, cage, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, perimeter, matrices, vertices, light, overlay, red, green, blue,
                 alpha >= 1 ? pAlpha : alpha);
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/BookshelfDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/BookshelfDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -43,7 +44,7 @@ public class BookshelfDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (doorEntity.tardis().isEmpty())
             return;
@@ -64,7 +65,7 @@ public class BookshelfDoorModel extends DoorModel {
         matrices.scale(1F, 1F, 1F);
         matrices.translate(0, -1.5, 0);
 
-        super.renderWithAnimations(doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/BoothDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/BoothDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -77,7 +78,7 @@ public class BoothDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS)
@@ -91,7 +92,7 @@ public class BoothDoorModel extends DoorModel {
         matrices.translate(0, -1.5f, 0);
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180f));
 
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/doors/CapsuleDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/CapsuleDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -103,7 +104,7 @@ public class CapsuleDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
 
@@ -127,7 +128,7 @@ public class CapsuleDoorModel extends DoorModel {
         if (AITMod.CONFIG.CLIENT.ENABLE_TARDIS_BOTI)
             this.getPart().getChild("middle").getChild("back").visible = false;
 
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/doors/ClassicDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/ClassicDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -82,7 +83,7 @@ public class ClassicDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.scale(0.64F, 0.64F, 0.64F);
@@ -102,7 +103,7 @@ public class ClassicDoorModel extends DoorModel {
             this.classic.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*doorEntity.tardis().get().door().getRightRot());
         }
 
-        super.renderWithAnimations(doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/doors/ClassicHudolinDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/ClassicHudolinDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -75,7 +76,7 @@ public class ClassicHudolinDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.scale(0.64F, 0.64F, 0.64F);
@@ -95,7 +96,7 @@ public class ClassicHudolinDoorModel extends DoorModel {
             this.hudolin.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*doorEntity.tardis().get().door().getRightRot());
         }
 
-        super.renderWithAnimations(doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/doors/DalekModDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/DalekModDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -37,7 +38,7 @@ public class DalekModDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
             DoorHandler door = doorEntity.tardis().get().door();
@@ -57,7 +58,7 @@ public class DalekModDoorModel extends DoorModel {
         matrices.translate(0, -1.5, 0.1);
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180));
 
-        super.renderWithAnimations(doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/DoomDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/DoomDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -37,12 +38,12 @@ public class DoomDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0, -0.75f, 0);
         matrices.scale(0.5f, 0.5f, 0.5f);
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/DoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/DoorModel.java
@@ -2,6 +2,7 @@ package dev.amble.ait.client.models.doors;
 
 import java.util.function.Function;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -27,11 +28,8 @@ public abstract class DoorModel extends SinglePartEntityModel {
         super(function);
     }
 
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (linkableBlockEntity.tardis().isEmpty())
-            return;
-
         root.render(matrices, vertices, light, overlay, red, green, blue, pAlpha);
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/EasterHeadDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/EasterHeadDoorModel.java
@@ -1,6 +1,7 @@
 package dev.amble.ait.client.models.doors;
 
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -38,14 +39,14 @@ public class EasterHeadDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0, -1.5f, 0);
 
         this.bottom.pivotY = linkableBlockEntity.tardis().get().door().isOpen() ? 22 : 54;
 
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/doors/GeometricDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/GeometricDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -38,7 +39,7 @@ public class GeometricDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         DoorHandler door = doorEntity.tardis().get().door();
 
@@ -48,7 +49,7 @@ public class GeometricDoorModel extends DoorModel {
         matrices.scale(1F, 1F, 1F);
         matrices.translate(0, -1.5, 0);
 
-        super.renderWithAnimations(doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/PipeDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/PipeDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -28,16 +29,13 @@ public class PipeDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0, -1f, 0);
         matrices.multiply(RotationAxis.NEGATIVE_X.rotationDegrees(90f));
-        Tardis tardis = linkableBlockEntity.tardis().get();
-
-        if (tardis == null) return;
 
         this.tardis.pivotY = !tardis.door().isOpen() ? -22f : -8f;
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/PlinthDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/PlinthDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -43,7 +44,7 @@ public class PlinthDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0, -1.5f, 0);
@@ -55,7 +56,7 @@ public class PlinthDoorModel extends DoorModel {
             float maxRot = 90f;
             plinth.getChild("door").yaw = -(float) Math.toRadians(maxRot*linkableBlockEntity.tardis().get().door().getLeftRot());
         }
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/doors/PoliceBoxCoralDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/PoliceBoxCoralDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -166,13 +167,11 @@ public class PoliceBoxCoralDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        Tardis tardis = doorEntity.tardis().get();
-        if (tardis == null) return;
         DoorHandler door = tardis.door();
-        if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
 
+        if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
             this.TARDIS.getChild("Doors").getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -5F : 0.0F;
             this.TARDIS.getChild("Doors").getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
                     ? 5F
@@ -188,7 +187,7 @@ public class PoliceBoxCoralDoorModel extends DoorModel {
         matrices.translate(0, -1.5f, -0.35);
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180));
 
-        super.renderWithAnimations(doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/PoliceBoxDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/PoliceBoxDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -76,10 +77,10 @@ public class PoliceBoxDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = doorEntity.tardis().get().door();
+            DoorHandler door = tardis.door();
 
             this.TARDIS.getChild("Doors").getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -5F : 0.0F;
             this.TARDIS.getChild("Doors").getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
@@ -96,7 +97,7 @@ public class PoliceBoxDoorModel extends DoorModel {
         matrices.translate(0, -1.5, 0.35);
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180));
 
-        super.renderWithAnimations(doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/PresentDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/PresentDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -39,7 +40,7 @@ public class PresentDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
             DoorHandler door = linkableBlockEntity.tardis().get().door();
 
@@ -57,7 +58,7 @@ public class PresentDoorModel extends DoorModel {
         matrices.translate(0, -1.5, 0);
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180));
 
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/doors/RenegadeDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/RenegadeDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -80,7 +81,7 @@ public class RenegadeDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0, -1.5f, 0);
@@ -92,7 +93,7 @@ public class RenegadeDoorModel extends DoorModel {
             float maxRot = 90f;
             renegade.getChild("door").yaw = (float) Math.toRadians(maxRot*linkableBlockEntity.tardis().get().door().getLeftRot());
         }
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/doors/StallionDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/StallionDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -69,7 +70,7 @@ public class StallionDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.scale(0.95f, 0.95f, 0.95f);
@@ -87,7 +88,7 @@ public class StallionDoorModel extends DoorModel {
             body.getChild("door").getChild("door_two").yaw = (float) Math.toRadians(maxRightRot*linkableBlockEntity.tardis().get().door().getLeftRot());
         }
 
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/doors/TardimDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/TardimDoorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -62,7 +63,7 @@ public class TardimDoorModel extends DoorModel {
     }
 
     @Override
-    public void renderWithAnimations(AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         matrices.translate(0, -1.5f, 0);
@@ -81,7 +82,7 @@ public class TardimDoorModel extends DoorModel {
             this.tardis.getChild("right_door").yaw = (float) Math.toRadians(maxRot*handler.getRightRot());
         }
 
-        super.renderWithAnimations(linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/BookshelfExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/BookshelfExteriorModel.java
@@ -2,6 +2,7 @@ package dev.amble.ait.client.models.exteriors; // Made with Blockbench 4.10.1
 // Exported for Minecraft version 1.17+ for Yarn
 // Paste this class into your mod and generate all required imports
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -151,8 +152,8 @@ public class BookshelfExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (!exterior.isLinked())
             return;
 
@@ -162,7 +163,7 @@ public class BookshelfExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/BoothExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/BoothExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -87,8 +88,8 @@ public class BoothExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -97,7 +98,7 @@ public class BoothExteriorModel extends ExteriorModel {
         matrices.translate(0, -1.5f, 0);
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/CapsuleExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/CapsuleExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -127,8 +128,8 @@ public class CapsuleExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -137,7 +138,7 @@ public class CapsuleExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/ClassicExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/ClassicExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -131,8 +132,8 @@ public class ClassicExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -142,7 +143,7 @@ public class ClassicExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/ClassicHudolinExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/ClassicHudolinExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -125,8 +126,8 @@ public class ClassicHudolinExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -136,7 +137,7 @@ public class ClassicHudolinExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/DoomExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/DoomExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -32,15 +33,15 @@ public class DoomExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
         matrices.push();
         matrices.translate(0, -1.05f, 0);
         matrices.scale(0.7f, 0.7f, 0.7f);
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/EasterHeadModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/EasterHeadModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -51,8 +52,8 @@ public class EasterHeadModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -60,7 +61,7 @@ public class EasterHeadModel extends ExteriorModel {
         matrices.translate(0, -1.5f, 0);
         this.head.getChild("door").pitch = (exterior.tardis().get().door().isOpen()) ? -45f : 0f;
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/ExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/ExteriorModel.java
@@ -4,6 +4,7 @@ import static dev.amble.ait.core.tardis.animation.ExteriorAnimation.*;
 
 import java.util.function.Function;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.render.RenderLayer;
@@ -33,16 +34,11 @@ public abstract class ExteriorModel extends SinglePartEntityModel {
         super(function);
     }
 
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
-        Tardis tardis = exterior.tardis().get();
-
-        if (tardis == null)
-            return;
-
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
         float newAlpha = alpha;
 
-        if (tardis.cloak().cloaked().get() && !ZeitonHighEffect.isHigh(MinecraftClient.getInstance().player)) {
+        if (tardis.cloak().cloaked().get()) {
             PlayerEntity player = MinecraftClient.getInstance().player;
 
             if (!(tardis.loyalty().get(player).isOf(Loyalty.Type.COMPANION))) {

--- a/src/main/java/dev/amble/ait/client/models/exteriors/GeometricExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/GeometricExteriorModel.java
@@ -2,6 +2,7 @@ package dev.amble.ait.client.models.exteriors; // Made with Blockbench 4.10.1
 // Exported for Minecraft version 1.17+ for Yarn
 // Paste this class into your mod and generate all required imports
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -54,8 +55,8 @@ public class GeometricExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -65,7 +66,7 @@ public class GeometricExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/JakeTheDogExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/JakeTheDogExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -47,7 +48,7 @@ public class JakeTheDogExteriorModel  extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
@@ -56,7 +57,7 @@ public class JakeTheDogExteriorModel  extends ExteriorModel {
         matrices.translate(0, -1.5f, 0);
         jake.getChild("door").pivotZ = exterior.tardis().get().door().isOpen() ? 2.0f : 0f;
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PipeExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PipeExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -33,13 +34,13 @@ public class PipeExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
         matrices.push();
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180f));
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, alpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PlinthExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PlinthExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -44,8 +45,8 @@ public class PlinthExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -54,7 +55,7 @@ public class PlinthExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PoliceBoxCoralModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PoliceBoxCoralModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -133,8 +134,8 @@ public class PoliceBoxCoralModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -144,7 +145,7 @@ public class PoliceBoxCoralModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PoliceBoxModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PoliceBoxModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -172,8 +173,8 @@ public class PoliceBoxModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -183,7 +184,7 @@ public class PoliceBoxModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PresentExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PresentExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -36,7 +37,7 @@ public class PresentExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
@@ -46,7 +47,7 @@ public class PresentExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/RenegadeExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/RenegadeExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -84,8 +85,8 @@ public class RenegadeExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -94,7 +95,7 @@ public class RenegadeExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/SiegeModeModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/SiegeModeModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -37,14 +38,14 @@ public class SiegeModeModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
         matrices.push();
         matrices.translate(0, -1.5, 0);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/StallionExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/StallionExteriorModel.java
@@ -1,6 +1,7 @@
 package dev.amble.ait.client.models.exteriors;
 
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -131,14 +132,14 @@ public class StallionExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
         matrices.push();
         matrices.scale(0.95f, 0.95f, 0.95f);
         matrices.translate(0, -1.5f, 0);
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, alpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/TardimExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/TardimExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -63,8 +64,8 @@ public class TardimExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
-            VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+                                     VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
 
@@ -73,7 +74,7 @@ public class TardimExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/advent/DalekModExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/advent/DalekModExteriorModel.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.models.exteriors.advent;
 
+import dev.amble.ait.client.tardis.ClientTardis;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.entity.animation.Animation;
@@ -140,7 +141,7 @@ public class DalekModExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (exterior.tardis().isEmpty())
             return;
@@ -151,7 +152,7 @@ public class DalekModExteriorModel extends ExteriorModel {
 
         this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/renderers/doors/DoorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/doors/DoorRenderer.java
@@ -1,5 +1,7 @@
 package dev.amble.ait.client.renderers.doors;
 
+import dev.amble.ait.client.tardis.ClientTardis;
+import dev.amble.ait.data.datapack.DatapackConsole;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.block.entity.BlockEntityRenderer;
@@ -39,20 +41,13 @@ public class DoorRenderer<T extends DoorBlockEntity> implements BlockEntityRende
         Profiler profiler = entity.getWorld().getProfiler();
         profiler.push("door");
 
-        profiler.push("render");
-
-        Tardis tardis = entity.tardis().get();
-
-        if (tardis.siege() != null && tardis.siege().isActive())
-            return;
-
+        ClientTardis tardis = entity.tardis().get().asClient();
         this.renderDoor(profiler, tardis, entity, matrices, vertexConsumers, light, overlay);
-        profiler.pop();
 
         profiler.pop();
     }
 
-    private void renderDoor(Profiler profiler, Tardis tardis, T entity, MatrixStack matrices,
+    private void renderDoor(Profiler profiler, ClientTardis tardis, T entity, MatrixStack matrices,
             VertexConsumerProvider vertexConsumers, int light, int overlay) {
         this.updateModel(tardis);
 
@@ -70,7 +65,7 @@ public class DoorRenderer<T extends DoorBlockEntity> implements BlockEntityRende
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(k));
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180f));
 
-        model.renderWithAnimations(entity, model.getPart(), matrices,
+        model.renderWithAnimations(tardis, entity, model.getPart(), matrices,
                 vertexConsumers.getBuffer(AITRenderLayers.getEntityTranslucentCull(texture)), light, overlay, 1, 1,
                 1, 1);
 
@@ -82,12 +77,20 @@ public class DoorRenderer<T extends DoorBlockEntity> implements BlockEntityRende
 
         profiler.push("emission");
 
-        boolean alarms = tardis.alarm().enabled().get();
+        Identifier emissive = this.variant.emission();
 
-        if (!variant.equals(ClientExteriorVariantRegistry.DOOM))
-            ClientLightUtil.renderEmissivable(tardis.fuel().hasPower(), model::renderWithAnimations,
-                this.variant.emission(), entity, model.getPart(), matrices, vertexConsumers, 0xf000f0, overlay, alarms ? !tardis.fuel().hasPower() ? 0.25f : 1f : 1f, alarms ? !tardis.fuel().hasPower() ? 0.01f : 0.3f : 1f,
-                    alarms ? !tardis.fuel().hasPower() ? 0.01f : 0.3f : 1f, 1f);
+        if (emissive != null && !emissive.equals(DatapackConsole.EMPTY)) {
+            boolean power = tardis.fuel().hasPower();
+            boolean alarms = tardis.alarm().enabled().get();
+
+            float red = alarms ? !power ? 0.25f : 1f : 1f;
+            float green = alarms ? !power ? 0.01f : 0.3f : 1f;
+            float blue = alarms ? !power ? 0.01f : 0.3f : 1f;
+
+            ClientLightUtil.renderEmissive((v, l) -> model.renderWithAnimations(
+                    tardis, entity, model.getPart(), matrices, v, l, overlay, red, green, blue, 1f
+            ), emissive, vertexConsumers);
+        }
 
         profiler.swap("biome");
 
@@ -96,9 +99,9 @@ public class DoorRenderer<T extends DoorBlockEntity> implements BlockEntityRende
             Identifier biomeTexture = biome.getBiomeKey().get(this.variant.overrides());
 
             if (biomeTexture != null && !texture.equals(biomeTexture)) {
-                model.renderWithAnimations(entity, model.getPart(), matrices,
-                        vertexConsumers.getBuffer(AITRenderLayers.getEntityCutoutNoCullZOffset(biomeTexture)), light,
-                        overlay, 1, 1, 1, 1);
+                model.renderWithAnimations(tardis, entity, model.getPart(),
+                        matrices, vertexConsumers.getBuffer(AITRenderLayers.getEntityCutoutNoCullZOffset(biomeTexture)),
+                        light, overlay, 1, 1, 1, 1);
             }
         }
 

--- a/src/main/java/dev/amble/ait/client/renderers/entities/FlightTardisRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/FlightTardisRenderer.java
@@ -95,10 +95,11 @@ public class FlightTardisRenderer extends EntityRenderer<FlightTardisEntity> {
         if (variant.emission() != null && tardis.fuel().hasPower()) {
             boolean alarms = tardis.alarm().enabled().get();
 
-            ClientLightUtil.renderEmissivable(tardis.fuel().hasPower(), model::renderEntity,
-                    variant.emission(), entity, this.model.getPart(), matrices,
-                    vertexConsumers, light, OverlayTexture.DEFAULT_UV, 1, alarms ? 0.3f : 1,
-                    alarms ? 0.3f : 1, 1);
+            float color = alarms ? 0.3f : 1f;
+
+            ClientLightUtil.renderEmissivable(tardis.fuel().hasPower(), (v, l) -> model.renderEntity(
+                    entity, this.model.getPart(), matrices, v, l, OverlayTexture.DEFAULT_UV, color, color, color, 1
+            ), variant.emission(), vertexConsumers);
         }
 
         BiomeHandler biome = tardis.handler(TardisComponent.Id.BIOME);

--- a/src/main/java/dev/amble/ait/client/renderers/exteriors/ExteriorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/exteriors/ExteriorRenderer.java
@@ -1,6 +1,8 @@
 package dev.amble.ait.client.renderers.exteriors;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import dev.amble.ait.client.tardis.ClientTardis;
+import dev.amble.ait.core.effects.ZeitonHighEffect;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 
 import net.minecraft.block.BlockState;
@@ -31,7 +33,6 @@ import dev.amble.ait.core.blockentities.ExteriorBlockEntity;
 import dev.amble.ait.core.blocks.ExteriorBlock;
 import dev.amble.ait.core.tardis.Tardis;
 import dev.amble.ait.core.tardis.handler.BiomeHandler;
-import dev.amble.ait.core.tardis.handler.CloakHandler;
 import dev.amble.ait.data.datapack.DatapackConsole;
 import dev.amble.ait.data.schema.exterior.ClientExteriorVariantSchema;
 import dev.amble.ait.registry.impl.exterior.ClientExteriorVariantRegistry;
@@ -59,22 +60,23 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
 
         profiler.push("find_tardis");
 
-        if (!entity.isLinked()) return;
+        if (!entity.isLinked())
+            return;
 
-        Tardis tardis = entity.tardis().get();
-
+        ClientTardis tardis = entity.tardis().get().asClient();
 
         profiler.swap("render");
 
-        if (entity.getAlpha() > 0 || !tardis.<CloakHandler>handler(TardisComponent.Id.CLOAK).cloaked().get())
+        if (entity.getAlpha() > 0 && (!tardis.cloak().cloaked().get() || ZeitonHighEffect.isHigh(MinecraftClient.getInstance().player)))
             this.renderExterior(profiler, tardis, entity, tickDelta, matrices, vertexConsumers, light, overlay);
+
         profiler.pop();
 
         profiler.pop();
     }
 
-    private void renderExterior(Profiler profiler, Tardis tardis, T entity, float tickDelta, MatrixStack matrices,
-            VertexConsumerProvider vertexConsumers, int light, int overlay) {
+    private void renderExterior(Profiler profiler, ClientTardis tardis, T entity, float tickDelta, MatrixStack matrices,
+                                VertexConsumerProvider vertexConsumers, int light, int overlay) {
         final float alpha = entity.getAlpha();
         RenderSystem.enableCull();
         RenderSystem.enableBlend();
@@ -103,9 +105,9 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
 
             matrices.push();
             matrices.translate(0.5f, 0.5f, 0.5f);
-            SIEGE_MODEL.renderWithAnimations(entity, SIEGE_MODEL.getPart(), matrices,
-                    vertexConsumers.getBuffer(AITRenderLayers.getEntityTranslucentCull(tardis.siege().texture().get())),
-                    light, overlay, 1, 1, 1, 1);
+            SIEGE_MODEL.renderWithAnimations(entity, tardis, SIEGE_MODEL.getPart(),
+                    matrices,
+                    vertexConsumers.getBuffer(AITRenderLayers.getEntityTranslucentCull(tardis.siege().texture().get())), light, overlay, 1, 1, 1, 1);
 
             matrices.pop();
             profiler.pop();
@@ -167,9 +169,9 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
         if (tardis.selfDestruct().isQueued())
             matrices.scale(0.7f, 0.7f, 0.7f);
 
-        model.renderWithAnimations(entity, this.model.getPart(), matrices,
-                vertexConsumers.getBuffer(AITRenderLayers.getEntityTranslucentCull(texture)), light, overlay, 1, 1, 1,
-                alpha);
+        model.renderWithAnimations(entity, tardis, this.model.getPart(),
+                matrices, vertexConsumers.getBuffer(AITRenderLayers.getEntityTranslucentCull(texture)), light, overlay, 1, 1,
+                1, alpha);
 
         //System.out.println( variant.hasTransparentDoors());
 
@@ -186,35 +188,44 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
 
         profiler.push("emission");
         boolean alarms = tardis.alarm().enabled().get();
-        float u;
-        float t;
-        float s;
 
-        if ((tardis.stats().getName() != null && "partytardis".equals(tardis.stats().getName().toLowerCase()) ||(!tardis.extra().getInsertedDisc().isEmpty()))) {
-            int m = 25;
-            int n = MinecraftClient.getInstance().player.age / 25 + MinecraftClient.getInstance().player.getId();
-            int o = DyeColor.values().length;
-            int p = n % o;
-            int q = (n + 1) % o;
-            float r = ((float)(MinecraftClient.getInstance().player.age % 25) + h) / 25f;
-            float[] fs = SheepEntity.getRgbColor(DyeColor.byId(p));
-            float[] gs = SheepEntity.getRgbColor(DyeColor.byId(q));
-            s = fs[0] * (1f - r) + gs[0] * r;
-            t = fs[1] * (1f - r) + gs[1] * r;
-            u = fs[2] * (1f - r) + gs[2] * r;
-        } else {
-            float[] hs = new float[]{ 1.0f, 1.0f, 1.0f };
-            s = hs[0];
-            t = hs[1];
-            u = hs[2];
+
+        if (alpha > 0.105f && emission != null && !emission.equals(DatapackConsole.EMPTY)) {
+            float u;
+            float t;
+            float s;
+
+            if ((tardis.stats().getName() != null && "partytardis".equals(tardis.stats().getName().toLowerCase()) ||(!tardis.extra().getInsertedDisc().isEmpty()))) {
+                int m = 25;
+                int n = MinecraftClient.getInstance().player.age / 25 + MinecraftClient.getInstance().player.getId();
+                int o = DyeColor.values().length;
+                int p = n % o;
+                int q = (n + 1) % o;
+                float r = ((float)(MinecraftClient.getInstance().player.age % 25) + h) / 25f;
+                float[] fs = SheepEntity.getRgbColor(DyeColor.byId(p));
+                float[] gs = SheepEntity.getRgbColor(DyeColor.byId(q));
+                s = fs[0] * (1f - r) + gs[0] * r;
+                t = fs[1] * (1f - r) + gs[1] * r;
+                u = fs[2] * (1f - r) + gs[2] * r;
+            } else {
+                float[] hs = new float[]{ 1.0f, 1.0f, 1.0f };
+                s = hs[0];
+                t = hs[1];
+                u = hs[2];
+            }
+
+            float colorAlpha = 1 - alpha;
+
+            boolean power = tardis.fuel().hasPower();
+
+            float red = alarms ? !power ? 0.25f : s - colorAlpha : s - colorAlpha;
+            float green = alarms ? !power ? 0.01f : 0.3f : t - colorAlpha;
+            float blue = alarms ? !power ? 0.01f : 0.3f : u - colorAlpha;
+
+            ClientLightUtil.renderEmissive((v, l) -> model.renderWithAnimations(
+                    entity, tardis, this.model.getPart(), matrices, v, l, overlay, red, green, blue, alpha
+            ), emission, vertexConsumers);
         }
-
-        float colorAlpha = 1 - alpha;
-
-        if (alpha > 0.105f && emission != null && !(emission.equals(DatapackConsole.EMPTY)))
-            ClientLightUtil.renderEmissivable(tardis.fuel().hasPower(), model::renderWithAnimations, emission, entity,
-                    this.model.getPart(), matrices, vertexConsumers, 0xf000f0, overlay, alarms ? !tardis.fuel().hasPower() ? 0.25f : s - colorAlpha : s - colorAlpha, alarms ? !tardis.fuel().hasPower() ? 0.01f : 0.3f : t - colorAlpha,
-                    alarms ? !tardis.fuel().hasPower() ? 0.01f : 0.3f : u - colorAlpha, alpha);
 
         profiler.swap("biome");
 
@@ -224,9 +235,9 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
                 Identifier biomeTexture = handler.getBiomeKey().get(this.variant.overrides());
 
                 if (alpha > 0.105f && (biomeTexture != null && !texture.equals(biomeTexture))) {
-                    model.renderWithAnimations(entity, this.model.getPart(), matrices,
-                            vertexConsumers.getBuffer(AITRenderLayers.tardisEmissiveCullZOffset(biomeTexture, false)),
-                            light, overlay, 1, 1, 1, alpha);
+                    model.renderWithAnimations(entity, tardis, this.model.getPart(),
+                            matrices,
+                            vertexConsumers.getBuffer(AITRenderLayers.tardisEmissiveCullZOffset(biomeTexture, false)), light, overlay, 1, 1, 1, alpha);
                 }
 
             }

--- a/src/main/java/dev/amble/ait/client/renderers/machines/AstralMapRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/AstralMapRenderer.java
@@ -18,7 +18,7 @@ import dev.amble.ait.client.models.machines.AstralMapModel;
 import dev.amble.ait.client.util.ClientLightUtil;
 import dev.amble.ait.core.blockentities.AstralMapBlockEntity;
 
-public class AstralMapRenderer<T extends AstralMapBlockEntity> implements BlockEntityRenderer<T>, ClientLightUtil.Renderable<AstralMapBlockEntity> {
+public class AstralMapRenderer<T extends AstralMapBlockEntity> implements BlockEntityRenderer<T> {
 
     public static final Identifier TEXTURE = new Identifier(AITMod.MOD_ID,
             "textures/blockentities/machines/astral_map.png");
@@ -56,10 +56,5 @@ public class AstralMapRenderer<T extends AstralMapBlockEntity> implements BlockE
                 vertexConsumers.getBuffer(RenderLayer.getEndGateway()),
                 light, overlay, 1.0F, 1.0F, 1.0F, 1.0F);
         matrices.pop();
-    }
-
-    @Override
-    public void render(AstralMapBlockEntity entity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
-        root.render(matrices, vertices, light, overlay, red, green, blue, alpha);
     }
 }

--- a/src/main/java/dev/amble/ait/client/renderers/machines/EngineRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/EngineRenderer.java
@@ -24,7 +24,7 @@ import dev.amble.ait.core.tardis.Tardis;
 // Made with Blockbench 4.8.3
 // Exported for Minecraft version 1.17+ for Yarn
 // Paste this class into your mod and generate all required imports
-public class EngineRenderer<T extends EngineBlockEntity> implements BlockEntityRenderer<T>, ClientLightUtil.Renderable<EngineBlockEntity> {
+public class EngineRenderer<T extends EngineBlockEntity> implements BlockEntityRenderer<T> {
 
     public static final Identifier ENGINE_TEXTURE = new Identifier(AITMod.MOD_ID,
             ("textures/blockentities/machines/engine.png"));
@@ -62,10 +62,5 @@ public class EngineRenderer<T extends EngineBlockEntity> implements BlockEntityR
         }
 
         matrices.pop();
-    }
-
-    @Override
-    public void render(EngineBlockEntity entity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
-        root.render(matrices, vertices, light, overlay, red, green, blue, alpha);
     }
 }

--- a/src/main/java/dev/amble/ait/client/renderers/machines/FabricatorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/FabricatorRenderer.java
@@ -53,9 +53,9 @@ public class FabricatorRenderer<T extends FabricatorBlockEntity> implements Bloc
                 1.0F, 1.0F, 1.0F);
 
         if (entity.isValid()) {
-            ClientLightUtil.renderEmissive(ClientLightUtil.Renderable.create(fabricatorModel::render),
-                    EMISSIVE_FABRICATOR_TEXTURE, entity, fabricatorModel.getPart(), matrices, vertexConsumers, light,
-                    overlay, 1, 1, 1, 1);
+            ClientLightUtil.renderEmissive((v, l) -> fabricatorModel.render(
+                    matrices, v, l, overlay, 1, 1, 1, 1
+            ), EMISSIVE_FABRICATOR_TEXTURE, vertexConsumers);
         }
 
         matrices.pop();

--- a/src/main/java/dev/amble/ait/client/renderers/machines/GenericSubSystemRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/GenericSubSystemRenderer.java
@@ -21,7 +21,7 @@ import dev.amble.ait.core.engine.StructureHolder;
 import dev.amble.ait.core.engine.SubSystem;
 import dev.amble.ait.core.engine.block.generic.GenericStructureSystemBlockEntity;
 
-public class GenericSubSystemRenderer<T extends GenericStructureSystemBlockEntity> implements BlockEntityRenderer<T>, ClientLightUtil.Renderable<T> {
+public class GenericSubSystemRenderer<T extends GenericStructureSystemBlockEntity> implements BlockEntityRenderer<T> {
     private GenericSubSystemModel model;
 
     public GenericSubSystemRenderer(BlockEntityRendererFactory.Context ctx) {
@@ -67,10 +67,5 @@ public class GenericSubSystemRenderer<T extends GenericStructureSystemBlockEntit
         }
 
         matrices.pop();
-    }
-
-    @Override
-    public void render(T entity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
-        root.render(matrices, vertices, light, overlay, red, green, blue, alpha);
     }
 }

--- a/src/main/java/dev/amble/ait/client/renderers/machines/PowerConverterRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/PowerConverterRenderer.java
@@ -18,7 +18,7 @@ import dev.amble.ait.client.util.ClientLightUtil;
 import dev.amble.ait.core.blocks.PlaqueBlock;
 import dev.amble.ait.core.blocks.PowerConverterBlock;
 
-public class PowerConverterRenderer<T extends PowerConverterBlock.BlockEntity> implements BlockEntityRenderer<T>, ClientLightUtil.Renderable<PowerConverterBlock.BlockEntity> {
+public class PowerConverterRenderer<T extends PowerConverterBlock.BlockEntity> implements BlockEntityRenderer<T> {
 
     public static final Identifier TEXTURE = new Identifier(AITMod.MOD_ID,
             ("textures/blockentities/machines/power_converter.png"));;
@@ -46,10 +46,5 @@ public class PowerConverterRenderer<T extends PowerConverterBlock.BlockEntity> i
                 light, overlay, 1.0F, 1.0F, 1.0F, 1.0F);
 
         matrices.pop();
-    }
-
-    @Override
-    public void render(PowerConverterBlock.BlockEntity entity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
-        root.render(matrices, vertices, light, overlay, red, green, blue, alpha);
     }
 }

--- a/src/main/java/dev/amble/ait/client/screens/MonitorScreen.java
+++ b/src/main/java/dev/amble/ait/client/screens/MonitorScreen.java
@@ -378,9 +378,9 @@ public class MonitorScreen extends ConsoleScreen {
                 LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, base, base, base, 1f);
 
         if (hasPower && emissive != null && !(emissive.equals(DatapackConsole.EMPTY))) {
-            ClientLightUtil.renderEmissive(ClientLightUtil.Renderable.create(model::render), emissive, null,
-                    model.getPart(), stack, context.getVertexConsumers(), LightmapTextureManager.MAX_LIGHT_COORDINATE,
-                    OverlayTexture.DEFAULT_UV, base, tinted, tinted, 1f);
+            ClientLightUtil.renderEmissive((v, l) -> model.render(
+                    stack, v, l, OverlayTexture.DEFAULT_UV, base, tinted, tinted, 1
+            ), emissive, context.getVertexConsumers());
         }
 
         stack.pop();
@@ -405,7 +405,6 @@ public class MonitorScreen extends ConsoleScreen {
         context.drawCenteredTextWithShadow(this.textRenderer, isExtUnlocked ? "" : "\uD83D\uDD12", x, y, 0xFFFFFF);
 
         stack.pop();
-
 
         stack.pop();
     }

--- a/src/main/java/dev/amble/ait/client/util/ClientLightUtil.java
+++ b/src/main/java/dev/amble/ait/client/util/ClientLightUtil.java
@@ -14,28 +14,20 @@ import dev.amble.ait.compat.DependencyChecker;
 
 public class ClientLightUtil {
 
-    public static <T> void renderEmissivable(boolean emissive, Renderable<T> renderable, @Nullable Identifier texture,
-            T entity, ModelPart root, MatrixStack matrices, VertexConsumerProvider vertices, int light, int overlay,
-            float red, float green, float blue, float alpha) {
-        ClientLightUtil.renderEmissivable(emissive, renderable, texture, texture, entity, root, matrices, vertices,
-                0xf000f0, overlay, red, green, blue, alpha);
+    public static <T> void renderEmissivable(boolean emissive, Renderable<T> renderable, @Nullable Identifier texture, VertexConsumerProvider vertices) {
+        ClientLightUtil.renderEmissivable(emissive, renderable, texture, texture, vertices);
     }
 
     public static <T> void renderEmissivable(boolean emissive, Renderable<T> renderable, @Nullable Identifier base,
-            @Nullable Identifier glowing, T entity, ModelPart root, MatrixStack matrices,
-            VertexConsumerProvider vertices, int light, int overlay, float red, float green, float blue, float alpha) {
+            @Nullable Identifier glowing, VertexConsumerProvider vertices) {
         if (emissive) {
-            ClientLightUtil.renderEmissive(renderable, glowing, entity, root, matrices, vertices, 0xf000f0, overlay, red,
-                    green, blue, alpha);
+            ClientLightUtil.renderEmissive(renderable, glowing, vertices);
         } else {
-            ClientLightUtil.render(renderable, base, entity, root, matrices, vertices, 0xf000f0, overlay, red, green, blue,
-                    alpha);
+            ClientLightUtil.render(renderable, base, vertices);
         }
     }
 
-    public static <T> void renderEmissive(Renderable<T> renderable, @Nullable Identifier emissive, T entity,
-            ModelPart root, MatrixStack matrices, VertexConsumerProvider vertices, int light, int overlay, float red,
-            float green, float blue, float alpha) {
+    public static <T> void renderEmissive(Renderable<T> renderable, @Nullable Identifier emissive, VertexConsumerProvider vertices) {
         if (emissive == null)
             return;
 
@@ -43,47 +35,22 @@ public class ClientLightUtil {
                 ? AITRenderLayers.tardisEmissiveCullZOffset(emissive, true)
                 : AITRenderLayers.getBeaconBeam(emissive, true);
 
-        light = 0xf000f0;
-        ClientLightUtil.render(renderable, entity, root, matrices, layer, vertices, 0xf000f0, overlay, red, green, blue,
-                alpha);
+        ClientLightUtil.render(renderable, layer, vertices);
     }
 
-    private static <T> void render(Renderable<T> renderable, @Nullable Identifier texture, T entity, ModelPart root,
-            MatrixStack matrices, VertexConsumerProvider vertices, int light, int overlay, float red, float green,
-            float blue, float alpha) {
+    private static <T> void render(Renderable<T> renderable, @Nullable Identifier texture, VertexConsumerProvider vertices) {
         if (texture == null)
             return;
 
-        ClientLightUtil.render(renderable, entity, root, matrices, AITRenderLayers.getEntityTranslucentCull(texture),
-                vertices, 0xf000f0, overlay, red, green, blue, alpha);
+        ClientLightUtil.render(renderable, AITRenderLayers.getEntityTranslucentCull(texture), vertices);
     }
 
-    private static <T> void render(Renderable<T> renderable, T entity, ModelPart root, MatrixStack matrices,
-            RenderLayer layer, VertexConsumerProvider vertices, int light, int overlay, float red, float green,
-            float blue, float alpha) {
-        ClientLightUtil.render(renderable, entity, root, matrices, vertices.getBuffer(layer), 0xf000f0, overlay, red,
-                green, blue, alpha);
-    }
-
-    private static <T> void render(Renderable<T> renderable, T entity, ModelPart root, MatrixStack matrices,
-            VertexConsumer consumer, int light, int overlay, float red, float green, float blue, float alpha) {
-        renderable.render(entity, root, matrices, consumer, 0xf000f0, overlay, red, green, blue, alpha);
+    private static <T> void render(Renderable<T> renderable, RenderLayer layer, VertexConsumerProvider vertices) {
+        renderable.render(vertices.getBuffer(layer), 0xf000f0);
     }
 
     @FunctionalInterface
     public interface Renderable<T> {
-        void render(T entity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay,
-                float red, float green, float blue, float alpha);
-
-        static <T> Renderable<T> create(ModelRenderable renderable) {
-            return (entity, root, matrices, vertices, light, overlay, red, green, blue, alpha) -> renderable
-                    .render(matrices, vertices, 0xf000f0, overlay, red, green, blue, alpha);
-        }
-    }
-
-    @FunctionalInterface
-    public interface ModelRenderable {
-        void render(MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green,
-                float blue, float alpha);
+        void render(VertexConsumer vertices, int light);
     }
 }

--- a/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
+++ b/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
@@ -13,7 +13,11 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.util.Identifier;
@@ -29,6 +33,7 @@ import dev.amble.ait.core.tardis.TardisExterior;
 import dev.amble.ait.core.tardis.handler.SonicHandler;
 import dev.amble.ait.core.world.TardisServerWorld;
 import dev.amble.ait.data.schema.sonic.SonicSchema;
+import org.jetbrains.annotations.Nullable;
 
 @Environment(EnvType.CLIENT)
 public class ClientTardisUtil {


### PR DESCRIPTION
## About the PR
This PR refactors the console, door and exterior renderers to pass down a single client tardis instance down to the renderers/models.

You don't have to check if a tardis is linked and yada yada. Just use the tardis parameter.

## Why / Balance
We frequently had NPEs related to race conditions pop up. It's not really the time to figure them out right before release so... this should do. 

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- Changed method signatures in `ClientLightUtil`
- Removed `ClientLightUtil.ModelRenderer`
- Added a `ClientTardis tardis` parameter to `ConsoleRenderer`, `DoorRenderer`, `ExteriorRenderer`, as well as `ConsoleModel`, `DoorModel` and `ExteriorModel`.