### PR TITLE
perf: use async to find safe position before remat 

### DIFF
--- a/src/main/java/dev/amble/ait/api/TardisEvents.java
+++ b/src/main/java/dev/amble/ait/api/TardisEvents.java
@@ -73,13 +73,13 @@ public final class TardisEvents {
 
     public static final Event<BeforeLand> BEFORE_LAND = EventFactory.createArrayBacked(BeforeLand.class, callbacks -> (tardis, pos) -> {
         for (BeforeLand callback : callbacks) {
-            Result<CachedDirectedGlobalPos> value = callback.onLanded(tardis, pos);
+            Result<CachedDirectedGlobalPos> result = callback.onLanded(tardis, pos);
 
-            if (value.type() != Interaction.PASS)
-                return value;
+            if (result.type() != Interaction.PASS)
+                return result;
 
-            if (value.result().isPresent())
-                pos = value.result().get();
+            if (result.value().isPresent())
+                pos = result.value().get();
         }
 
         return new Result<>(Interaction.SUCCESS, pos);
@@ -555,7 +555,7 @@ public final class TardisEvents {
             this(inter, Optional.ofNullable(t));
         }
 
-        public Optional<T> result() {
+        public Optional<T> value() {
             return t;
         }
     }

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/AnimatedTravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/AnimatedTravelHandler.java
@@ -16,11 +16,11 @@ public abstract class AnimatedTravelHandler extends ProgressiveTravelHandler {
 
         State state = this.getState();
 
-        if (state.animated())
+        if (this.shouldTickAnimation())
             this.tickAnimationProgress(state);
     }
 
-    private void tickAnimationProgress(State state) {
+    protected void tickAnimationProgress(State state) {
         if (this.animationTicks++ < tardis.stats().getTravelEffects().get(state).length())
             return;
 
@@ -37,4 +37,6 @@ public abstract class AnimatedTravelHandler extends ProgressiveTravelHandler {
     public int getMaxAnimTicks() {
         return tardis.stats().getTravelEffects().get(this.getState()).length();
     }
+
+    public abstract boolean shouldTickAnimation();
 }

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -1,5 +1,7 @@
 package dev.amble.ait.core.tardis.handler.travel;
 
+import dev.amble.ait.core.tardis.util.AsyncLocatorUtil;
+import dev.amble.ait.data.Exclude;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.drtheo.scheduler.api.Scheduler;
 import dev.drtheo.scheduler.api.TimeUnit;
@@ -36,9 +38,15 @@ import dev.amble.ait.core.util.ForcedChunkUtil;
 import dev.amble.ait.core.util.WorldUtil;
 import dev.amble.ait.core.world.RiftChunkManager;
 
+import java.util.concurrent.CompletableFuture;
+
 public final class TravelHandler extends AnimatedTravelHandler implements CrashableTardisTravel {
 
+    @Exclude
     private boolean travelCooldown;
+
+    @Exclude
+    private boolean waiting;
 
     public static final Identifier CANCEL_DEMAT_SOUND = AITMod.id("cancel_demat_sound");
 
@@ -92,6 +100,11 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
     public TravelHandler() {
         super(Id.TRAVEL);
+    }
+
+    @Override
+    public boolean shouldTickAnimation() {
+        return !this.waiting && this.getState().animated();
     }
 
     @Override
@@ -254,6 +267,7 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
         this.forceDemat(sound);
     }
+
     public void dematerialize() {
         this.dematerialize(null);
     }
@@ -341,35 +355,43 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
         if (this.tardis.sequence().hasActiveSequence())
             this.tardis.sequence().setActiveSequence(null, true);
 
-        CachedDirectedGlobalPos pos = this.getProgress();
-        TardisEvents.Result<CachedDirectedGlobalPos> result = TardisEvents.BEFORE_LAND.invoker().onLanded(this.tardis, pos);
+        CachedDirectedGlobalPos initialPos = this.getProgress();
+        TardisEvents.Result<CachedDirectedGlobalPos> result = TardisEvents.BEFORE_LAND.invoker()
+                .onLanded(this.tardis, initialPos);
 
         if (result.type() == TardisEvents.Interaction.FAIL) {
             this.crash();
             return;
         }
 
-        pos = result.result().orElse(pos);
-
-        pos = WorldUtil.locateSafe(pos, this.vGroundSearch.get(), this.hGroundSearch.get());
-
-        this.tardis.door().closeDoors();
+        CachedDirectedGlobalPos finalPos = result.value().orElse(initialPos);
 
         this.state.set(State.MAT);
-        SoundEvent sound = tardis.stats().getTravelEffects().get(this.getState()).sound();
+        this.waiting = true;
 
-        if (this.isCrashing())
-            sound = AITSounds.EMERG_MAT;
+        CompletableFuture<?> future = CompletableFuture.supplyAsync(() -> {
+            return WorldUtil.locateSafe(finalPos, this.vGroundSearch.get(), this.hGroundSearch.get());
+        }).thenAccept(pos -> {
+            this.waiting = false;
+            this.tardis.door().closeDoors();
 
-        this.destination(pos);
-        this.forcePosition(this.destination());
+            SoundEvent sound = tardis.stats().getTravelEffects().get(this.getState()).sound();
 
-        // Play materialize sound at the destination
-        this.position().getWorld().playSound(null, this.position().getPos(), sound, SoundCategory.BLOCKS);
+            if (this.isCrashing())
+                sound = AITSounds.EMERG_MAT;
 
-        this.tardis.getDesktop().playSoundAtEveryConsole(sound, SoundCategory.BLOCKS, 2f, 1f);
-        //System.out.println(sound.getId());
-        this.placeExterior(true); // we schedule block update in #finishRemat
+            this.destination(pos);
+            this.forcePosition(this.destination());
+
+            // Play materialize sound at the destination
+            this.position().getWorld().playSound(null, this.position().getPos(), sound, SoundCategory.BLOCKS);
+
+            this.tardis.getDesktop().playSoundAtEveryConsole(sound, SoundCategory.BLOCKS, 2f, 1f);
+            //System.out.println(sound.getId());
+            this.placeExterior(true); // we schedule block update in #finishRemat
+        });
+
+        AsyncLocatorUtil.LOCATING_EXECUTOR_SERVICE.submit(() -> future);
     }
 
     public void finishRemat() {


### PR DESCRIPTION
## About the PR
Instead of doing safe pos search on the main thread of remat, do it off the main thread and then run the rest of the code synchronously.
This also should fix #1148.

## Technical details
The PR uses AsyncLocatorUtil's executor service. To stop the animation from playing, a new field was brought in to `TravelHandler`: `waiting`. `AnimatedTravelHandler` got a `shouldTickAnimation` abstract method, which replaces the previously hardcoded if statement.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- `TardisEvents.Result.result()` -> `TardisEvents.Result.value()`

**Changelog**
:cl:
- fix: Rematerialization is no longer as heavy on performance as it was before