### PR TITLE
ci: use short label names, as they are in github

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,8 @@
-"Changes: Textures":
+"C: Textures":
   - changed-files:
       - any-glob-to-any-file: 'src/main/resources/assets/textures/**/*.png'
 
-"Changes: Structures":
+"C: Structures":
   - changed-files:
       - any-glob-to-any-file:
           - 'src/main/resources/data/ait/structures/**/*.nbt'
@@ -15,11 +15,11 @@
 #  - changed-files:
 #      - any-glob-to-any-file: '**/*.glsl'
 
-"Changes: Audio":
+"C: Audio":
   - changed-files:
       - any-glob-to-any-file: 'src/main/resources/assets/textures/**/*.ogg'
 
-"Changes: No Java":
+"C: No Java":
   - changed-files:
       # Equiv to any-glob-to-all as long as this has one matcher. If ALL changed files are not C# files, then apply label.
       - all-globs-to-all-files: "!src/main/java/**/*.java"


### PR DESCRIPTION
## About the PR
This PR makes it so the labeler workflow applies "C: No Java" or "C: Structures" and etc insted of "Changes: whatever"

## Why / Balance
We use the short label names on github.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
