### PR TITLE
ci: use proper file glob for structures, textures and sound in labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 "C: Textures":
   - changed-files:
-      - any-glob-to-any-file: 'src/main/resources/assets/textures/**/*.png'
+      - any-glob-to-any-file: 'src/main/resources/assets/*/textures/**/*.png'
 
 "C: Structures":
   - changed-files:
@@ -17,7 +17,7 @@
 
 "C: Audio":
   - changed-files:
-      - any-glob-to-any-file: 'src/main/resources/assets/textures/**/*.ogg'
+      - any-glob-to-any-file: 'src/main/resources/assets/*/sounds/**/*.ogg'
 
 "C: No Java":
   - changed-files:


### PR DESCRIPTION
## About the PR
This PR fixes wrong file globs for labeler CI.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
