### PR TITLE
feat: split world blacklist into travel and open world blacklists

### DIFF
--- a/src/main/java/dev/amble/ait/config/AITConfig.java
+++ b/src/main/java/dev/amble/ait/config/AITConfig.java
@@ -34,7 +34,10 @@ public class AITConfig implements ConfigData {
         public boolean TNT_CAN_TELEPORT_THROUGH_DOOR = true;
 
         @ConfigEntry.Gui.RequiresRestart
-        public List<String> WORLDS_BLACKLIST = List.of(
+        public List<String> WORLDS_BLACKLIST = List.of();
+
+        @ConfigEntry.Gui.RequiresRestart
+        public List<String> TRAVEL_BLACKLIST = List.of(
                 AITDimensions.TIME_VORTEX_WORLD.getValue().toString());
 
         public int TRAVEL_PER_TICK = 2;

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/DimensionControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/DimensionControl.java
@@ -22,7 +22,6 @@ import dev.amble.ait.core.tardis.control.Control;
 import dev.amble.ait.core.tardis.handler.travel.TravelHandler;
 import dev.amble.ait.core.tardis.util.AsyncLocatorUtil;
 import dev.amble.ait.core.util.WorldUtil;
-import dev.amble.ait.data.schema.console.variant.renaissance.*;
 
 public class DimensionControl extends Control {
 
@@ -40,10 +39,10 @@ public class DimensionControl extends Control {
         CachedDirectedGlobalPos dest = travel.destination();
 
         CompletableFuture<Void> future = CompletableFuture.supplyAsync(() -> {
-            List<ServerWorld> dims = WorldUtil.getOpenWorlds();
+            List<ServerWorld> dims = WorldUtil.getTravelWorlds();
 
-            int index = WorldUtil.worldIndex(WorldUtil.isBlacklisted(dest.getWorld())
-                    ? world.getServer().getOverworld() : dest.getWorld());
+            int index = WorldUtil.travelWorldIndex(!WorldUtil.isTravelValid(dest.getWorld())
+                    ? WorldUtil.getOverworld() : dest.getWorld());
 
             if (leftClick) {
                 index = (dims.size() + index - 1) % dims.size();

--- a/src/main/java/dev/amble/ait/registry/impl/MoodEventPoolRegistry.java
+++ b/src/main/java/dev/amble/ait/registry/impl/MoodEventPoolRegistry.java
@@ -80,7 +80,7 @@ public class MoodEventPoolRegistry {
         //The ones i commented out do not work
 
         CHANGE_DIM = register(MoodDictatedEvent.Builder.create(AITMod.id("change_dim"), tardis -> {
-            List<ServerWorld> listOfDims = WorldUtil.getOpenWorlds();
+            List<ServerWorld> listOfDims = WorldUtil.getTravelWorlds();
             ServerWorld randomWorld = listOfDims.get(random.nextInt(listOfDims.size()));
 
             tardis.travel().forceDestination(cached -> cached.world(randomWorld));


### PR DESCRIPTION
## About the PR
This PR splits the `WORLDS_BLACKLIST` option in the config into 2: `WORLDS_BLACKLIST` and `TRAVEL_BLACKLIST`. 

Fixes #1152.

## Why / Balance
This is used in environment projector and the dimension control. You shouldn't be able to travel into the time vortex dimension, but the time vortex dimension should otherwise be available.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: `TRAVEL_BLACKLIST` config option to blacklist worlds from travel.