### PR TITLE
feat!: use an either in the loyalty codec

### DIFF
--- a/src/main/java/dev/amble/ait/data/Loyalty.java
+++ b/src/main/java/dev/amble/ait/data/Loyalty.java
@@ -2,15 +2,14 @@ package dev.amble.ait.data;
 
 import java.util.Optional;
 
+import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 public record Loyalty(int level, Type type) {
 
-    public static final Codec<Loyalty> CODEC = RecordCodecBuilder.create(instance -> instance
-            .group(Codec.STRING.optionalFieldOf("type").forGetter(loyalty -> Optional.of(loyalty.type.toString())),
-                    Codec.INT.optionalFieldOf("level").forGetter(loyalty -> Optional.of(loyalty.level)))
-            .apply(instance, (Loyalty::deserialize)));
+    public static final Codec<Loyalty> CODEC = Codec.either(Codec.STRING, Codec.INT).xmap(either -> either
+            .mapLeft(Type::get).map(Loyalty::new, Loyalty::fromLevel), loyalty -> Either.right(loyalty.level));
 
     public Loyalty(Type type) {
         this(type.level, type);


### PR DESCRIPTION
## About the PR
This PR streamlines the use of the loyalty codec.

## Why / Balance
The previous implementation was dumb.

## Technical details
This PR utilizes `Codec.either`.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Everything that uses the loyalty codec must use the new codec.
E.g.
```json
"loyalty": {
    "type": "OWNER"
}
```
should be
```json
"loyalty": "OWNER"
```
