### PR TITLE
fix: add the world to proper world list, ignore tardis dimension

### DIFF
--- a/src/main/java/dev/amble/ait/core/util/WorldUtil.java
+++ b/src/main/java/dev/amble/ait/core/util/WorldUtil.java
@@ -133,7 +133,7 @@ public class WorldUtil {
 
         for (ServerWorld world : server.getWorlds()) {
             if (predicate.test(world))
-                OPEN_WORLDS.add(world);
+                worlds.add(world);
         }
     }
 
@@ -143,12 +143,12 @@ public class WorldUtil {
     }
 
     public static boolean isOpen(ServerWorld world) {
-        return TardisServerWorld.isTardisDimension(world)
+        return !TardisServerWorld.isTardisDimension(world)
                 && !OPEN_BLACKLIST.contains(world.getRegistryKey().getValue());
     }
 
     public static boolean isTravelValid(ServerWorld world) {
-        return TardisServerWorld.isTardisDimension(world)
+        return !TardisServerWorld.isTardisDimension(world)
                 && !TRAVEL_BLACKLIST.contains(world.getRegistryKey().getValue());
     }
 


### PR DESCRIPTION
## About the PR
This PR fixes one of the previous PRs. It updates the filter to point to the proper world list, as well as invert the "is tardis dimension" check.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
