### PR TITLE
Property same reference fix check

### DIFF
--- a/src/main/java/dev/amble/ait/data/properties/Property.java
+++ b/src/main/java/dev/amble/ait/data/properties/Property.java
@@ -112,7 +112,7 @@ public class Property<T> {
             }
 
             return result;
-        });
+        }, false);
 
         public static final Type<ItemStack> ITEM_STACK = new Type<>(ItemStack.class, PacketByteBuf::writeItemStack,
                 PacketByteBuf::readItemStack);
@@ -120,11 +120,17 @@ public class Property<T> {
         private final Class<?> clazz;
         private final BiConsumer<PacketByteBuf, T> encoder;
         private final Function<PacketByteBuf, T> decoder;
+        private final boolean sameRef;
 
         public Type(Class<?> clazz, BiConsumer<PacketByteBuf, T> encoder, Function<PacketByteBuf, T> decoder) {
+            this(clazz, encoder, decoder, true);
+        }
+
+        public Type(Class<?> clazz, BiConsumer<PacketByteBuf, T> encoder, Function<PacketByteBuf, T> decoder, boolean sameRef) {
             this.clazz = clazz;
             this.encoder = encoder;
             this.decoder = decoder;
+            this.sameRef = sameRef;
         }
 
         public void encode(PacketByteBuf buf, T value) {
@@ -137,6 +143,10 @@ public class Property<T> {
 
         public Class<?> getClazz() {
             return clazz;
+        }
+
+        public boolean isSameRef() {
+            return sameRef;
         }
 
         public static <T extends Enum<T>> Type<T> forEnum(Class<T> clazz) {

--- a/src/main/java/dev/amble/ait/data/properties/Value.java
+++ b/src/main/java/dev/amble/ait/data/properties/Value.java
@@ -79,7 +79,7 @@ public class Value<T> implements Disposable {
     }
 
     public void set(T value, boolean sync) {
-        if (this.value == value)
+        if (this.value == value && property.getType().isSameRef())
             return;
 
         this.value = value;


### PR DESCRIPTION
## About the PR
This PR fixes problems with syncing properties that use collections (e.g. unlockables).

## Technical details
Now all property types can provide a `sameRef` flag (defaults to true). If it's `true` the reference check will be enforced.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
