### PR TITLE
fix: use client tardis ref in door models

### DIFF
--- a/src/main/java/dev/amble/ait/client/models/coral/CoralGrowthDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/coral/CoralGrowthDoorModel.java
@@ -100,9 +100,6 @@ public class CoralGrowthDoorModel extends DoorModel {
     @Override
     public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity door, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (door.tardis().get() == null)
-            return;
-
         matrices.push();
         matrices.translate(0, -1.5f, 0f);
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180f));

--- a/src/main/java/dev/amble/ait/client/models/doors/BookshelfDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/BookshelfDoorModel.java
@@ -46,13 +46,9 @@ public class BookshelfDoorModel extends DoorModel {
     @Override
     public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (doorEntity.tardis().isEmpty())
-            return;
-
-        DoorHandler door = doorEntity.tardis().get().door();
+        DoorHandler door = tardis.door();
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-
             this.bookshelf.getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? 4.75F : 0.0F;
             this.bookshelf.getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen()) ? -4.75F : 0.0F;
         } else {

--- a/src/main/java/dev/amble/ait/client/models/doors/BoothDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/BoothDoorModel.java
@@ -82,10 +82,10 @@ public class BoothDoorModel extends DoorModel {
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         matrices.push();
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS)
-            this.k2.getChild("Door").yaw = linkableBlockEntity.tardis().get().door().isOpen() ? 1.575F : 0.0F;
+            this.k2.getChild("Door").yaw = tardis.door().isOpen() ? 1.575F : 0.0F;
         else {
             float maxRot = 90f;
-            this.k2.getChild("Door").yaw = (float) Math.toRadians(maxRot*linkableBlockEntity.tardis().get().door().getLeftRot());
+            this.k2.getChild("Door").yaw = (float) Math.toRadians(maxRot*tardis.door().getLeftRot());
         }
 
         matrices.scale(1f, 1f, 1f);

--- a/src/main/java/dev/amble/ait/client/models/doors/CapsuleDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/CapsuleDoorModel.java
@@ -111,10 +111,9 @@ public class CapsuleDoorModel extends DoorModel {
         matrices.translate(0, -1.5f, 0);
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180f));
 
-        DoorHandler door = linkableBlockEntity.tardis().get().door();
+        DoorHandler door = tardis.door();
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-
             this.body.getChild("doors").getChild("door_left").yaw = (door.isLeftOpen() || door.isOpen()) ? -5F : 0.0F;
             this.body.getChild("doors").getChild("door_right").yaw = (door.isRightOpen() || door.areBothOpen())
                     ? 5F

--- a/src/main/java/dev/amble/ait/client/models/doors/ClassicDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/ClassicDoorModel.java
@@ -91,7 +91,7 @@ public class ClassicDoorModel extends DoorModel {
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180));
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = doorEntity.tardis().get().door();
+            DoorHandler door = tardis.door();
 
             this.classic.getChild("Doors").getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -5F : 0.0F;
             this.classic.getChild("Doors").getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
@@ -99,8 +99,8 @@ public class ClassicDoorModel extends DoorModel {
                     : 0.0F;
         } else {
             float maxRot = 90f;
-            this.classic.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot*doorEntity.tardis().get().door().getLeftRot());
-            this.classic.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*doorEntity.tardis().get().door().getRightRot());
+            this.classic.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot*tardis.door().getLeftRot());
+            this.classic.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*tardis.door().getRightRot());
         }
 
         super.renderWithAnimations(tardis, doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);

--- a/src/main/java/dev/amble/ait/client/models/doors/ClassicHudolinDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/ClassicHudolinDoorModel.java
@@ -84,7 +84,7 @@ public class ClassicHudolinDoorModel extends DoorModel {
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180));
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = doorEntity.tardis().get().door();
+            DoorHandler door = tardis.door();
 
             this.hudolin.getChild("Doors").getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -5F : 0.0F;
             this.hudolin.getChild("Doors").getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
@@ -92,8 +92,8 @@ public class ClassicHudolinDoorModel extends DoorModel {
                     : 0.0F;
         } else {
             float maxRot = 90f;
-            this.hudolin.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot*doorEntity.tardis().get().door().getLeftRot());
-            this.hudolin.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*doorEntity.tardis().get().door().getRightRot());
+            this.hudolin.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot*tardis.door().getLeftRot());
+            this.hudolin.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*tardis.door().getRightRot());
         }
 
         super.renderWithAnimations(tardis, doorEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);

--- a/src/main/java/dev/amble/ait/client/models/doors/DalekModDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/DalekModDoorModel.java
@@ -41,7 +41,7 @@ public class DalekModDoorModel extends DoorModel {
     public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = doorEntity.tardis().get().door();
+            DoorHandler door = tardis.door();
 
             this.dalekmod.getChild("Doors").getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -5.0f : 0.0F;
             this.dalekmod.getChild("Doors").getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
@@ -49,8 +49,8 @@ public class DalekModDoorModel extends DoorModel {
                     : 0.0F;
         } else {
             float maxRot = 80f;
-        this.dalekmod.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot*doorEntity.tardis().get().door().getLeftRot());
-        this.dalekmod.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*doorEntity.tardis().get().door().getRightRot());
+        this.dalekmod.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot*tardis.door().getLeftRot());
+        this.dalekmod.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*tardis.door().getRightRot());
         }
 
         matrices.push();

--- a/src/main/java/dev/amble/ait/client/models/doors/EasterHeadDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/EasterHeadDoorModel.java
@@ -44,7 +44,7 @@ public class EasterHeadDoorModel extends DoorModel {
         matrices.push();
         matrices.translate(0, -1.5f, 0);
 
-        this.bottom.pivotY = linkableBlockEntity.tardis().get().door().isOpen() ? 22 : 54;
+        this.bottom.pivotY = tardis.door().isOpen() ? 22 : 54;
 
         super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 

--- a/src/main/java/dev/amble/ait/client/models/doors/GeometricDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/GeometricDoorModel.java
@@ -41,7 +41,7 @@ public class GeometricDoorModel extends DoorModel {
     @Override
     public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        DoorHandler door = doorEntity.tardis().get().door();
+        DoorHandler door = tardis.door();
 
         this.geometric.getChild("door").pivotZ = door.isOpen() ? 2.05f : 1f;
 

--- a/src/main/java/dev/amble/ait/client/models/doors/PlinthDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/PlinthDoorModel.java
@@ -51,10 +51,10 @@ public class PlinthDoorModel extends DoorModel {
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180f));
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            plinth.getChild("door").yaw = linkableBlockEntity.tardis().get().door().isOpen() ? -1.75f : 0f;
+            plinth.getChild("door").yaw = tardis.door().isOpen() ? -1.75f : 0f;
         } else {
             float maxRot = 90f;
-            plinth.getChild("door").yaw = -(float) Math.toRadians(maxRot*linkableBlockEntity.tardis().get().door().getLeftRot());
+            plinth.getChild("door").yaw = -(float) Math.toRadians(maxRot*tardis.door().getLeftRot());
         }
         super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 

--- a/src/main/java/dev/amble/ait/client/models/doors/PoliceBoxDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/PoliceBoxDoorModel.java
@@ -79,17 +79,17 @@ public class PoliceBoxDoorModel extends DoorModel {
     @Override
     public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity doorEntity, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = tardis.door();
+        DoorHandler door = tardis.door();
 
+        if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
             this.TARDIS.getChild("Doors").getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -5F : 0.0F;
             this.TARDIS.getChild("Doors").getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
                     ? 5F
                     : 0.0F;
         } else {
             float maxRot = 90f;
-            this.TARDIS.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot*doorEntity.tardis().get().door().getLeftRot());
-            this.TARDIS.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*doorEntity.tardis().get().door().getRightRot());
+            this.TARDIS.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot*door.getLeftRot());
+            this.TARDIS.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*door.getRightRot());
         }
 
         matrices.push();

--- a/src/main/java/dev/amble/ait/client/models/doors/PresentDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/PresentDoorModel.java
@@ -41,17 +41,17 @@ public class PresentDoorModel extends DoorModel {
 
     @Override
     public void renderWithAnimations(ClientTardis tardis, AbstractLinkableBlockEntity linkableBlockEntity, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = linkableBlockEntity.tardis().get().door();
+        DoorHandler door = tardis.door();
 
+        if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
             this.present.getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? 8F : 0.0F;
             this.present.getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
                     ? -8F
                     : 0.0F;
         } else {
             float maxRot = 90f;
-            this.present.getChild("left_door").yaw = (float) Math.toRadians(maxRot*linkableBlockEntity.tardis().get().door().getLeftRot());
-            this.present.getChild("right_door").yaw = (float) -Math.toRadians(maxRot*linkableBlockEntity.tardis().get().door().getRightRot());
+            this.present.getChild("left_door").yaw = (float) Math.toRadians(maxRot*door.getLeftRot());
+            this.present.getChild("right_door").yaw = (float) -Math.toRadians(maxRot*door.getRightRot());
         }
 
         matrices.push();

--- a/src/main/java/dev/amble/ait/client/models/doors/RenegadeDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/RenegadeDoorModel.java
@@ -88,10 +88,10 @@ public class RenegadeDoorModel extends DoorModel {
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180f));
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            renegade.getChild("door").yaw = linkableBlockEntity.tardis().get().door().isOpen() ? 1.75f : 0f;
+            renegade.getChild("door").yaw = tardis.door().isOpen() ? 1.75f : 0f;
         } else {
             float maxRot = 90f;
-            renegade.getChild("door").yaw = (float) Math.toRadians(maxRot*linkableBlockEntity.tardis().get().door().getLeftRot());
+            renegade.getChild("door").yaw = (float) Math.toRadians(maxRot*tardis.door().getLeftRot());
         }
         super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 

--- a/src/main/java/dev/amble/ait/client/models/doors/StallionDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/StallionDoorModel.java
@@ -78,14 +78,14 @@ public class StallionDoorModel extends DoorModel {
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180f));
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            body.getChild("door").yaw = linkableBlockEntity.tardis().get().door().isOpen() ? -1.35f : 0f;
-            body.getChild("door").getChild("door_two").yaw = linkableBlockEntity.tardis().get().door().isOpen() ? 2.65f : 0f;
+            body.getChild("door").yaw = tardis.door().isOpen() ? -1.35f : 0f;
+            body.getChild("door").getChild("door_two").yaw = tardis.door().isOpen() ? 2.65f : 0f;
         } else {
             float maxLeftRot = 87f;
             float maxRightRot = 150f;
 
-            body.getChild("door").yaw = -(float) Math.toRadians(maxLeftRot*linkableBlockEntity.tardis().get().door().getLeftRot());
-            body.getChild("door").getChild("door_two").yaw = (float) Math.toRadians(maxRightRot*linkableBlockEntity.tardis().get().door().getLeftRot());
+            body.getChild("door").yaw = -(float) Math.toRadians(maxLeftRot*tardis.door().getLeftRot());
+            body.getChild("door").getChild("door_two").yaw = (float) Math.toRadians(maxRightRot*tardis.door().getLeftRot());
         }
 
         super.renderWithAnimations(tardis, linkableBlockEntity, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);

--- a/src/main/java/dev/amble/ait/client/models/doors/TardimDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/TardimDoorModel.java
@@ -70,14 +70,14 @@ public class TardimDoorModel extends DoorModel {
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180f));
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler handler = linkableBlockEntity.tardis().get().door();
+            DoorHandler handler = tardis.door();
 
             this.tardis.getChild("left_door").yaw = (handler.isLeftOpen() || handler.isOpen()) ? -1.575f : 0.0F;
             this.tardis.getChild("right_door").yaw = (handler.isRightOpen() || handler.areBothOpen()) ? 1.575f : 0.0F;
         } else {
             float maxRot = 90f;
 
-            DoorHandler handler = linkableBlockEntity.tardis().get().door();
+            DoorHandler handler = tardis.door();
             this.tardis.getChild("left_door").yaw = (float) -Math.toRadians(maxRot*handler.getLeftRot());
             this.tardis.getChild("right_door").yaw = (float) Math.toRadians(maxRot*handler.getRightRot());
         }


### PR DESCRIPTION
## About the PR
This is a follow up PR to the client tardis refs PR. It updates the door models to use the client tardis ref instead of getting it from the block entity.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
