### PR TITLE
fix: dont subtract artron when in growth

### DIFF
--- a/src/main/java/dev/amble/ait/core/engine/impl/DematCircuit.java
+++ b/src/main/java/dev/amble/ait/core/engine/impl/DematCircuit.java
@@ -12,7 +12,8 @@ public class DematCircuit extends DurableSubSystem implements StructureHolder {
         TardisEvents.DEMAT.register(tardis -> {
             DematCircuit circuit = tardis.subsystems().demat();
 
-            return (circuit.isEnabled() && !circuit.isBroken()) ? TardisEvents.Interaction.PASS : TardisEvents.Interaction.FAIL;
+            return circuit.isEnabled() && !circuit.isBroken()
+                    ? TardisEvents.Interaction.PASS : TardisEvents.Interaction.FAIL;
         });
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/handler/FuelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/FuelHandler.java
@@ -155,10 +155,16 @@ public class FuelHandler extends KeyedTardisComponent implements ArtronHolder, T
     }
 
     private void tickMat() {
+        if (tardis.isGrowth())
+            return;
+
         this.removeFuel(20 * 5 * this.tardis.travel().instability());
     }
 
     private void tickFlight() {
+        if (tardis.isGrowth())
+            return;
+
         TravelHandler travel = this.tardis.travel();
         this.removeFuel(20 * (4 ^ travel.speed()) * travel.instability());
 

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -369,9 +369,9 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
         this.state.set(State.MAT);
         this.waiting = true;
 
-        CompletableFuture<?> future = CompletableFuture.supplyAsync(() -> {
-            return WorldUtil.locateSafe(finalPos, this.vGroundSearch.get(), this.hGroundSearch.get());
-        }).thenAccept(pos -> {
+        CompletableFuture<?> future = CompletableFuture.supplyAsync(() ->
+                WorldUtil.locateSafe(finalPos, this.vGroundSearch.get(), this.hGroundSearch.get())
+        ).thenAccept(pos -> {
             this.waiting = false;
             this.tardis.door().closeDoors();
 

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
@@ -243,7 +243,7 @@ public abstract class TravelHandlerBase extends KeyedTardisComponent implements 
     }
 
     public enum State implements Ordered {
-        LANDED, DEMAT(null, TravelHandler::finishDemat), FLIGHT(), MAT(
+        LANDED, DEMAT(null, TravelHandler::finishDemat), FLIGHT, MAT(
                 null, TravelHandler::finishRemat);
 
         public static final Codec<State> CODEC = Codecs.NON_EMPTY_STRING.flatXmap(s -> {


### PR DESCRIPTION
## About the PR
This PR makes it so `FuelHandler` doesn't subtract the power during materialization or flight when the tardis is in growth.

## Why / Balance
See #1160

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
