### PR TITLE
ci: automagically assign reviewers based on PR size

### DIFF
--- a/.github/workflows/pr-labeler-size.yml
+++ b/.github/workflows/pr-labeler-size.yml
@@ -7,8 +7,12 @@ permissions:
 jobs:
   size-label:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false }}
+    outputs:
+      label: ${{ steps.label.outputs.sizeLabel }}
     steps:
       - name: size-label
+        id: label
         uses: "pascalgn/size-label-action@v0.5.5"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -22,3 +26,15 @@ jobs:
               "1000": "L",
               "5000": "XL"
             }
+      - if: ${{ contains(github.event.pull_request.labels.*.name, 'size/XS') || contains(github.event.pull_request.labels.*.name, 'size/S') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          url: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$url" --add-reviewer Loqor,MaketendoDev,duzos
+      - if: ${{ contains(github.event.pull_request.labels.*.name, 'size/M') || contains(github.event.pull_request.labels.*.name, 'size/L') || contains(github.event.pull_request.labels.*.name, 'size/XL') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          url: ${{ github.event.pull_request.html_url }}
+        run: | 
+          gh pr edit "$url" --add-reviewer DrTheodor,duzos


### PR DESCRIPTION
## About the PR
This PR changes the workflows to automatically set reviewers depending on PR size.

## Why / Balance
As requested by @duzos.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
