### PR TITLE
feat: music discs spawn in structures

### DIFF
--- a/src/main/resources/data/ait/loot_tables/chests/cult_chest_one.json
+++ b/src/main/resources/data/ait/loot_tables/chests/cult_chest_one.json
@@ -118,6 +118,36 @@
           "type": "minecraft:item",
           "name": "ait:photon_accelerator",
           "weight": 5
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:good_man_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:venus_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:earth_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:wonderful_time_in_space_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:mercury_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:drifting_music_disc",
+          "weight": 1
         }
       ],
       "rolls": 15

--- a/src/main/resources/data/ait/loot_tables/chests/space_ship.json
+++ b/src/main/resources/data/ait/loot_tables/chests/space_ship.json
@@ -93,6 +93,36 @@
           "type": "minecraft:item",
           "name": "ait:handles",
           "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:good_man_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:venus_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:earth_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:wonderful_time_in_space_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:mercury_music_disc",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:drifting_music_disc",
+          "weight": 1
         }
       ],
       "rolls": 15


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
I made music discs spawn in AIT structures

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This makes it so players who are adventuring and find AIT structures are also bound to find our discs.

## Technical details
<!-- Summary of code changes for easier review. -->
I added the items to the loot tables

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->
X

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- feat: AIT discs spawn in AIT structures