### PR TITLE
refactor: use passed client tardis ref in exterior models

### DIFF
--- a/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
@@ -85,7 +85,7 @@ public class TardisExteriorBOTI extends BOTI {
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
 
-        ((ExteriorModel) frame).renderDoors(exterior, frame.getPart(), stack, botiProvider.getBuffer(AITRenderLayers.getBotiInterior(variant.texture())), light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F, true);
+        ((ExteriorModel) frame).renderDoors(tardis, exterior, frame.getPart(), stack, botiProvider.getBuffer(AITRenderLayers.getBotiInterior(variant.texture())), light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F, true);
         botiProvider.draw();
         stack.pop();
 
@@ -96,7 +96,7 @@ public class TardisExteriorBOTI extends BOTI {
             BiomeHandler handler = exterior.tardis().get().handler(TardisComponent.Id.BIOME);
             Identifier biomeTexture = handler.getBiomeKey().get(variant.overrides());
             if (biomeTexture != null)
-                ((ExteriorModel) frame).renderDoors(exterior, frame.getPart(), stack,
+                ((ExteriorModel) frame).renderDoors(tardis, exterior, frame.getPart(), stack,
                         botiProvider.getBuffer(AITRenderLayers.getEntityCutoutNoCullZOffset(biomeTexture)),
                         light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F, true);
         }
@@ -135,7 +135,7 @@ public class TardisExteriorBOTI extends BOTI {
             float green = exterior.tardis().get().alarm().enabled().get() ? !power ? 0.01f : 0.3f : t;
             float blue = exterior.tardis().get().alarm().enabled().get() ? !power ? 0.01f : 0.3f : u ;
 
-            ((ExteriorModel) frame).renderDoors(exterior, frame.getPart(), stack, botiProvider.getBuffer(DependencyChecker.hasIris() ? AITRenderLayers.tardisEmissiveCullZOffset(variant.emission(), true) : AITRenderLayers.getBeaconBeam(variant.emission(), true)), 0xf000f0,
+            ((ExteriorModel) frame).renderDoors(tardis, exterior, frame.getPart(), stack, botiProvider.getBuffer(DependencyChecker.hasIris() ? AITRenderLayers.tardisEmissiveCullZOffset(variant.emission(), true) : AITRenderLayers.getBeaconBeam(variant.emission(), true)), 0xf000f0,
                     OverlayTexture.DEFAULT_UV, red, green, blue, 1, true);
             botiProvider.draw();
         }

--- a/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
@@ -2,6 +2,7 @@ package dev.amble.ait.client.boti;
 
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import dev.amble.ait.client.tardis.ClientTardis;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.MinecraftClient;
@@ -34,10 +35,10 @@ public class TardisExteriorBOTI extends BOTI {
         if (MinecraftClient.getInstance().world == null
                 || MinecraftClient.getInstance().player == null) return;
 
-
-
         if (!exterior.isLinked())
             return;
+
+        ClientTardis tardis = exterior.tardis().get().asClient();;
 
         stack.push();
 

--- a/src/main/java/dev/amble/ait/client/models/coral/CoralGrowthExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/coral/CoralGrowthExteriorModel.java
@@ -571,7 +571,7 @@ public class CoralGrowthExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
         boolean isNotLanded = tardis.interiorChangingHandler().queued().get() || tardis.travel().getState() != TravelHandlerBase.State.LANDED;
         boolean hasCage = tardis.interiorChangingHandler().hasCage();
@@ -582,9 +582,9 @@ public class CoralGrowthExteriorModel extends ExteriorModel {
 
         float alpha = ((float) tardis.interiorChangingHandler().plasmicMaterialAmount() / 8f);
 
-        super.renderWithAnimations(exterior, tardis, isNotLanded ? six : seven, matrices, vertices, light, overlay, red, green, blue, pAlpha);
-        if (hasCage) super.renderWithAnimations(exterior, tardis, cage, matrices, vertices, light, overlay, red, green, blue, pAlpha);
-        super.renderWithAnimations(exterior, tardis, perimeter, matrices, vertices, light, overlay, red, green, blue,
+        super.renderWithAnimations(tardis, exterior, isNotLanded ? six : seven, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        if (hasCage) super.renderWithAnimations(tardis, exterior, cage, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, perimeter, matrices, vertices, light, overlay, red, green, blue,
                 alpha >= 1 ? pAlpha : alpha);
     }
 
@@ -604,7 +604,7 @@ public class CoralGrowthExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
 
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/BookshelfExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/BookshelfExteriorModel.java
@@ -152,18 +152,15 @@ public class BookshelfExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (!exterior.isLinked())
-            return;
-
         matrices.push();
         matrices.scale(1F, 1F, 1F);
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }
@@ -199,19 +196,16 @@ public class BookshelfExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+        DoorHandler door = tardis.door();
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = exterior.tardis().get().door();
-
             this.bookshelf.getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -4.75F : 0.0F;
             this.bookshelf.getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen()) ? 4.75F : 0.0F;
         } else {
             float maxRot = 90f;
-            this.bookshelf.getChild("left_door").yaw = -(float) Math.toRadians(maxRot * exterior.tardis().get().door().getLeftRot());
-            this.bookshelf.getChild("right_door").yaw = (float) Math.toRadians(maxRot * exterior.tardis().get().door().getRightRot());
+            this.bookshelf.getChild("left_door").yaw = -(float) Math.toRadians(maxRot * door.getLeftRot());
+            this.bookshelf.getChild("right_door").yaw = (float) Math.toRadians(maxRot * door.getRightRot());
         }
 
 //        if (isBOTI) {

--- a/src/main/java/dev/amble/ait/client/models/exteriors/BoothExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/BoothExteriorModel.java
@@ -88,17 +88,14 @@ public class BoothExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.scale(1f, 1f, 1f);
         matrices.translate(0, -1.5f, 0);
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -108,15 +105,12 @@ public class BoothExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS)
-            this.k2.getChild("Door").yaw = exterior.tardis().get().door().isOpen() ? 1.575F : 0.0F;
+            this.k2.getChild("Door").yaw = tardis.door().isOpen() ? 1.575F : 0.0F;
         else {
             float maxRot = 90f;
-            this.k2.getChild("Door").yaw = (float) Math.toRadians(maxRot * exterior.tardis().get().door().getLeftRot());
+            this.k2.getChild("Door").yaw = (float) Math.toRadians(maxRot * tardis.door().getLeftRot());
         }
 
         if (isBOTI) {

--- a/src/main/java/dev/amble/ait/client/models/exteriors/CapsuleExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/CapsuleExteriorModel.java
@@ -128,17 +128,14 @@ public class CapsuleExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -175,12 +172,9 @@ public class CapsuleExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler handler = exterior.tardis().get().door();
+            DoorHandler handler = tardis.door();
 
             this.body.getChild("doors").getChild("left_door").yaw = (handler.isLeftOpen() || handler.isOpen()) ? -5F : 0.0F;
             this.body.getChild("doors").getChild("right_door").yaw = (handler.isRightOpen() || handler.areBothOpen())
@@ -188,8 +182,8 @@ public class CapsuleExteriorModel extends ExteriorModel {
                     : 0.0F;
         } else {
             float maxRot = 90f;
-            this.body.getChild("doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot * exterior.tardis().get().door().getLeftRot());
-            this.body.getChild("doors").getChild("right_door").yaw = -(float) Math.toRadians(maxRot * exterior.tardis().get().door().getRightRot());
+            this.body.getChild("doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot * tardis.door().getLeftRot());
+            this.body.getChild("doors").getChild("right_door").yaw = -(float) Math.toRadians(maxRot * tardis.door().getRightRot());
         }
 
         if (isBOTI) {

--- a/src/main/java/dev/amble/ait/client/models/exteriors/ClassicExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/ClassicExteriorModel.java
@@ -132,18 +132,15 @@ public class ClassicExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.scale(0.64F, 0.64F, 0.64F);
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }
@@ -154,12 +151,9 @@ public class ClassicExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = exterior.tardis().get().door();
+            DoorHandler door = tardis.door();
 
             this.classic.getChild("Doors").getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -5F : 0.0F;
             this.classic.getChild("Doors").getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
@@ -168,7 +162,7 @@ public class ClassicExteriorModel extends ExteriorModel {
         } else {
             float maxRot = 90f;
 
-            DoorHandler door = exterior.tardis().get().door();
+            DoorHandler door = tardis.door();
             this.classic.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot * door.getLeftRot());
             this.classic.getChild("Doors").getChild("right_door").yaw = -(float) Math.toRadians(maxRot * door.getRightRot());
         }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/ClassicHudolinExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/ClassicHudolinExteriorModel.java
@@ -126,18 +126,15 @@ public class ClassicHudolinExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.scale(0.64F, 0.64F, 0.64F);
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -147,12 +144,9 @@ public class ClassicHudolinExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = exterior.tardis().get().door();
+            DoorHandler door = tardis.door();
 
             this.classic.getChild("Doors").getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -5F : 0.0F;
             this.classic.getChild("Doors").getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
@@ -161,7 +155,7 @@ public class ClassicHudolinExteriorModel extends ExteriorModel {
         } else {
             float maxRot = 90f;
 
-            DoorHandler door = exterior.tardis().get().door();
+            DoorHandler door = tardis.door();
             this.classic.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot * door.getLeftRot());
             this.classic.getChild("Doors").getChild("right_door").yaw = -(float) Math.toRadians(maxRot * door.getRightRot());
         }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/DoomExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/DoomExteriorModel.java
@@ -33,15 +33,12 @@ public class DoomExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.translate(0, -1.05f, 0);
         matrices.scale(0.7f, 0.7f, 0.7f);
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -66,7 +63,7 @@ public class DoomExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
 
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/EasterHeadModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/EasterHeadModel.java
@@ -52,16 +52,13 @@ public class EasterHeadModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.translate(0, -1.5f, 0);
-        this.head.getChild("door").pitch = (exterior.tardis().get().door().isOpen()) ? -45f : 0f;
+        this.head.getChild("door").pitch = (tardis.door().isOpen()) ? -45f : 0f;
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -89,7 +86,7 @@ public class EasterHeadModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
 
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/ExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/ExteriorModel.java
@@ -32,14 +32,14 @@ public abstract class ExteriorModel extends SinglePartEntityModel {
         super(function);
     }
 
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
         float newAlpha = alpha;
 
         if (tardis.cloak().cloaked().get()) {
             PlayerEntity player = MinecraftClient.getInstance().player;
 
-            if (!(tardis.loyalty().get(player).isOf(Loyalty.Type.COMPANION))) {
+            if (!tardis.loyalty().get(player).isOf(Loyalty.Type.COMPANION)) {
                 newAlpha = 0f;
 
                 root.render(matrices, vertices, light, overlay, red, green, blue, newAlpha);
@@ -71,6 +71,6 @@ public abstract class ExteriorModel extends SinglePartEntityModel {
 
     public abstract Animation getAnimationForDoorState(DoorHandler.AnimationDoorState state);
 
-    public abstract void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
+    public abstract void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI);
 }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/GeometricExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/GeometricExteriorModel.java
@@ -55,18 +55,15 @@ public class GeometricExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.scale(1F, 1F, 1F);
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }
@@ -88,10 +85,8 @@ public class GeometricExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty()) return;
-
-        DoorHandler door = exterior.tardis().get().door();
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+        DoorHandler door = tardis.door();
 
         this.geometric.getChild("door").pivotZ = door.isOpen() ? -16f : 0f;
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/JakeTheDogExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/JakeTheDogExteriorModel.java
@@ -48,16 +48,13 @@ public class JakeTheDogExteriorModel  extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.translate(0, -1.5f, 0);
-        jake.getChild("door").pivotZ = exterior.tardis().get().door().isOpen() ? 2.0f : 0f;
+        jake.getChild("door").pivotZ = tardis.door().isOpen() ? 2.0f : 0f;
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -84,7 +81,7 @@ public class JakeTheDogExteriorModel  extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
 
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PipeExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PipeExteriorModel.java
@@ -34,13 +34,13 @@ public class PipeExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
         matrices.push();
         matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180f));
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, alpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha);
         matrices.pop();
     }
 
@@ -70,15 +70,7 @@ public class PipeExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        Tardis tardis = exterior.tardis().get();
-
-        if (tardis == null) return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         this.tardis.pivotY = !tardis.door().isOpen() ? -14F : 0;
-
-//        if (isBOTI) {
-//            this.tardis.render(matrices, vertices, light, overlay, red, green, blue, pAlpha);
-//        }
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PlinthExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PlinthExteriorModel.java
@@ -45,17 +45,14 @@ public class PlinthExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -83,15 +80,12 @@ public class PlinthExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS)
-            plinth.getChild("door").yaw = exterior.tardis().get().door().isOpen() ? -1.75f : 0f;
+            plinth.getChild("door").yaw = tardis.door().isOpen() ? -1.75f : 0f;
         else {
             float maxRot = 90f;
-            plinth.getChild("door").yaw = -(float) Math.toRadians(maxRot*exterior.tardis().get().door().getLeftRot());
+            plinth.getChild("door").yaw = -(float) Math.toRadians(maxRot*tardis.door().getLeftRot());
         }
 
         if (isBOTI) {

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PoliceBoxCoralModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PoliceBoxCoralModel.java
@@ -134,18 +134,15 @@ public class PoliceBoxCoralModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.scale(0.63F, 0.63F, 0.63F);
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -183,11 +180,8 @@ public class PoliceBoxCoralModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
-        DoorHandler door = exterior.tardis().get().door();
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+        DoorHandler door = tardis.door();
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PoliceBoxModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PoliceBoxModel.java
@@ -173,18 +173,15 @@ public class PoliceBoxModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.scale(0.63F, 0.63F, 0.63F);
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -221,11 +218,8 @@ public class PoliceBoxModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
-        DoorHandler door = exterior.tardis().get().door();
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+        DoorHandler door = tardis.door();
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
             this.TARDIS.getChild("Doors").getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? -5F : 0.0F;

--- a/src/main/java/dev/amble/ait/client/models/exteriors/PresentExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/PresentExteriorModel.java
@@ -37,17 +37,14 @@ public class PresentExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -88,12 +85,9 @@ public class PresentExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler door = exterior.tardis().get().door();
+            DoorHandler door = tardis.door();
 
             this.present.getChild("left_door").yaw = (door.isLeftOpen() || door.isOpen()) ? 8F : 0.0F;
             this.present.getChild("right_door").yaw = (door.isRightOpen() || door.areBothOpen())
@@ -101,8 +95,8 @@ public class PresentExteriorModel extends ExteriorModel {
                     : 0.0F;
         } else {
             float maxRot = 90f;
-            this.present.getChild("left_door").yaw = (float) Math.toRadians(exterior.tardis().get().door().getLeftRot() * maxRot);
-            this.present.getChild("right_door").yaw = -(float) Math.toRadians(exterior.tardis().get().door().getRightRot() * maxRot);
+            this.present.getChild("left_door").yaw = (float) Math.toRadians(tardis.door().getLeftRot() * maxRot);
+            this.present.getChild("right_door").yaw = -(float) Math.toRadians(tardis.door().getRightRot() * maxRot);
         }
 
         if (isBOTI) {

--- a/src/main/java/dev/amble/ait/client/models/exteriors/RenegadeExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/RenegadeExteriorModel.java
@@ -85,17 +85,14 @@ public class RenegadeExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -121,16 +118,11 @@ public class RenegadeExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty()) return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS)
-            renegade.getChild("door").yaw = exterior.tardis().get().door().isOpen() ? 1.75f : 0f;
+            renegade.getChild("door").yaw = tardis.door().isOpen() ? 1.75f : 0f;
         else {
-            float maxRot = 90f;
-
-            DoorHandler door = exterior.tardis().get().door();
-            renegade.getChild("door").yaw = (float) Math.toRadians(maxRot * door.getLeftRot());
+            renegade.getChild("door").yaw = (float) Math.toRadians(90f * tardis.door().getLeftRot());
         }
 
         if (isBOTI) {

--- a/src/main/java/dev/amble/ait/client/models/exteriors/SiegeModeModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/SiegeModeModel.java
@@ -38,14 +38,12 @@ public class SiegeModeModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
         matrices.push();
         matrices.translate(0, -1.5, 0);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
 
@@ -70,7 +68,7 @@ public class SiegeModeModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
 
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/exteriors/StallionExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/StallionExteriorModel.java
@@ -108,17 +108,13 @@ public class StallionExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty()) return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            body.getChild("door").yaw = exterior.tardis().get().door().isOpen() ? -1.35f : 0f;
-            body.getChild("door").getChild("door_two").yaw = exterior.tardis().get().door().isOpen() ? 2.65f : 0f;
+            body.getChild("door").yaw = tardis.door().isOpen() ? -1.35f : 0f;
+            body.getChild("door").getChild("door_two").yaw = tardis.door().isOpen() ? 2.65f : 0f;
         } else {
-            float maxLeftRot = 87f;
-            float maxRightRot = 150f;
-            body.getChild("door").yaw = -(float) Math.toRadians(maxLeftRot * exterior.tardis().get().door().getLeftRot());
-            body.getChild("door").getChild("door_two").yaw = (float) Math.toRadians(maxRightRot * exterior.tardis().get().door().getLeftRot());
+            body.getChild("door").yaw = -(float) Math.toRadians(87f * tardis.door().getLeftRot());
+            body.getChild("door").getChild("door_two").yaw = (float) Math.toRadians(150f * tardis.door().getLeftRot());
         }
 
         if (isBOTI) {
@@ -132,14 +128,14 @@ public class StallionExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float alpha) {
         matrices.push();
         matrices.scale(0.95f, 0.95f, 0.95f);
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, alpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, alpha);
         matrices.pop();
     }
 

--- a/src/main/java/dev/amble/ait/client/models/exteriors/TardimExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/TardimExteriorModel.java
@@ -64,17 +64,14 @@ public class TardimExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 
         matrices.pop();
     }
@@ -85,19 +82,16 @@ public class TardimExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
-            DoorHandler handler = exterior.tardis().get().door();
+            DoorHandler handler = tardis.door();
 
             this.tardis.getChild("left_door").yaw = (handler.isLeftOpen() || handler.isOpen()) ? -1.575f : 0.0F;
             this.tardis.getChild("right_door").yaw = (handler.isRightOpen() || handler.areBothOpen()) ? 1.575f : 0.0F;
         } else {
             float maxRot = 90f;
-            this.tardis.getChild("left_door").yaw = -(float) Math.toRadians(maxRot * exterior.tardis().get().door().getLeftRot());
-            this.tardis.getChild("right_door").yaw = (float) Math.toRadians(maxRot * exterior.tardis().get().door().getRightRot());
+            this.tardis.getChild("left_door").yaw = -(float) Math.toRadians(maxRot * tardis.door().getLeftRot());
+            this.tardis.getChild("right_door").yaw = (float) Math.toRadians(maxRot * tardis.door().getRightRot());
         }
 
         if (isBOTI) {

--- a/src/main/java/dev/amble/ait/client/models/exteriors/advent/DalekModExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/advent/DalekModExteriorModel.java
@@ -80,11 +80,8 @@ public class DalekModExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderDoors(ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
-        if (exterior.tardis().isEmpty())
-            return;
-
-        DoorHandler door = exterior.tardis().get().door();
+    public void renderDoors(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha, boolean isBOTI) {
+        DoorHandler door = tardis.door();
 
         if (!AITMod.CONFIG.CLIENT.ANIMATE_DOORS) {
 
@@ -93,9 +90,8 @@ public class DalekModExteriorModel extends ExteriorModel {
                     ? 5F
                     : 0.0F;
         } else {
-            float maxRot = 80;
-            this.dalekmod.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(maxRot*door.getLeftRot());
-            this.dalekmod.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(maxRot*door.getRightRot());
+            this.dalekmod.getChild("Doors").getChild("left_door").yaw = (float) Math.toRadians(80f*door.getLeftRot());
+            this.dalekmod.getChild("Doors").getChild("right_door").yaw = (float) -Math.toRadians(80f*door.getRightRot());
         }
 
         if (isBOTI) {
@@ -141,20 +137,15 @@ public class DalekModExteriorModel extends ExteriorModel {
     }
 
     @Override
-    public void renderWithAnimations(ExteriorBlockEntity exterior, ClientTardis tardis, ModelPart root, MatrixStack matrices,
+    public void renderWithAnimations(ClientTardis tardis, ExteriorBlockEntity exterior, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        if (exterior.tardis().isEmpty())
-            return;
-
         matrices.push();
         matrices.scale(0.945F, 0.945F, 0.945F);
         matrices.translate(0, -1.5f, 0);
 
-        this.renderDoors(exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
+        this.renderDoors(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha, false);
 
-        super.renderWithAnimations(exterior, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
+        super.renderWithAnimations(tardis, exterior, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
-
-
 }

--- a/src/main/java/dev/amble/ait/client/renderers/exteriors/ExteriorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/exteriors/ExteriorRenderer.java
@@ -105,7 +105,7 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
 
             matrices.push();
             matrices.translate(0.5f, 0.5f, 0.5f);
-            SIEGE_MODEL.renderWithAnimations(entity, tardis, SIEGE_MODEL.getPart(),
+            SIEGE_MODEL.renderWithAnimations(tardis, entity, SIEGE_MODEL.getPart(),
                     matrices,
                     vertexConsumers.getBuffer(AITRenderLayers.getEntityTranslucentCull(tardis.siege().texture().get())), light, overlay, 1, 1, 1, 1);
 
@@ -169,7 +169,7 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
         if (tardis.selfDestruct().isQueued())
             matrices.scale(0.7f, 0.7f, 0.7f);
 
-        model.renderWithAnimations(entity, tardis, this.model.getPart(),
+        model.renderWithAnimations(tardis, entity, this.model.getPart(),
                 matrices, vertexConsumers.getBuffer(AITRenderLayers.getEntityTranslucentCull(texture)), light, overlay, 1, 1,
                 1, alpha);
 
@@ -223,7 +223,7 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
             float blue = alarms ? !power ? 0.01f : 0.3f : u - colorAlpha;
 
             ClientLightUtil.renderEmissive((v, l) -> model.renderWithAnimations(
-                    entity, tardis, this.model.getPart(), matrices, v, l, overlay, red, green, blue, alpha
+                    tardis, entity, this.model.getPart(), matrices, v, l, overlay, red, green, blue, alpha
             ), emission, vertexConsumers);
         }
 
@@ -235,7 +235,7 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
                 Identifier biomeTexture = handler.getBiomeKey().get(this.variant.overrides());
 
                 if (alpha > 0.105f && (biomeTexture != null && !texture.equals(biomeTexture))) {
-                    model.renderWithAnimations(entity, tardis, this.model.getPart(),
+                    model.renderWithAnimations(tardis, entity, this.model.getPart(),
                             matrices,
                             vertexConsumers.getBuffer(AITRenderLayers.tardisEmissiveCullZOffset(biomeTexture, false)), light, overlay, 1, 1, 1, alpha);
                 }


### PR DESCRIPTION
## About the PR
This PR refactors the exterior models to use the passed client tardis ref instead of fetching it.

## Why / Balance
Increased stability against the race condition.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
