### PR TITLE
ci: use bot token instead of ci token

### DIFF
--- a/.github/workflows/pr-labeler-approve.yml
+++ b/.github/workflows/pr-labeler-approve.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           username: ${{ github.actor }}
           team: "development"
-          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' && github.event.review.state == 'APPROVED' }}
         uses: actions-ecosystem/action-add-labels@v1
         with:


### PR DESCRIPTION
## About the PR
This PR updates the workflows to use `BOT_TOKEN` from our bot account instead of `CI_TOKEN` (which was my personal token).

## Why / Balance
It's better to do automization on a bot account.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
