### PR TITLE
feat: sonic scan mode is hand-dependent

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -73,12 +73,16 @@ public class ScanningSonicMode extends SonicMode {
     public boolean process(ItemStack stack, World world, PlayerEntity user) {
         HitResult hitResult = SonicMode.getHitResult(user);
 
-        if (hitResult instanceof BlockHitResult blockHit && !world.getBlockState(blockHit.getBlockPos()).isAir()) {
-            return this.scanBlocks(stack, world, user, blockHit.getBlockPos());
-        }
+        boolean isMainHand = user.getMainHandStack().getItem() == stack.getItem();
 
-        if (hitResult instanceof EntityHitResult entityHit && !(entityHit.getEntity() instanceof RiftEntity)) {
-            return this.scanEntities(stack, world, user, entityHit.getEntity());
+        if (isMainHand) {
+            if (hitResult instanceof BlockHitResult blockHit && !world.getBlockState(blockHit.getBlockPos()).isAir()) {
+                return this.scanBlocks(stack, world, user, blockHit.getBlockPos());
+            }
+
+            if (hitResult instanceof EntityHitResult entityHit && !(entityHit.getEntity() instanceof RiftEntity)) {
+                return this.scanEntities(stack, world, user, entityHit.getEntity());
+            }
         }
 
         return this.scanRegion(stack, world, user, BlockPos.ofFloored(hitResult.getPos()));


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
main hand to scan blocks/entities
off hand to scan region

closes #1106

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As the range of block scan is quite large, you have to look in air to scan a region
This is changed by disabling the block scan in off hand mode, allowing region scans to become easier.

## Technical details
<!-- Summary of code changes for easier review. -->
add "isMainHand" check to `ScanningSonicMode#process`

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- feat: sonic scan mode is now hand-dependent (main = blocks/entities, off = region)