### PR TITLE
feat: engine comes with cables, requires 3x3 space

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
@@ -79,21 +79,21 @@ public class EngineBlockEntity extends SubSystemBlockEntity implements ITardisSo
             if (dir == Direction.UP || dir == Direction.DOWN) continue;
 
             BlockPos offset = centre.offset(dir);
-            success = tryPlace(world, offset, AITBlocks.CABLE_BLOCK.getDefaultState()) && success;
+            success = success && tryPlace(world, offset, AITBlocks.CABLE_BLOCK.getDefaultState());
         }
 
         // place barrier blocks in corners
         BlockPos corner = centre.add(1, 0, 1);
-        success = tryPlace(world, corner, Blocks.BARRIER.getDefaultState()) && success;
+        success = success && tryPlace(world, corner, Blocks.BARRIER.getDefaultState());
 
         corner = centre.add(-1, 0, 1);
-        success = tryPlace(world, corner, Blocks.BARRIER.getDefaultState()) && success;
+        success = success && tryPlace(world, corner, Blocks.BARRIER.getDefaultState());
 
         corner = centre.add(1, 0, -1);
-        success = tryPlace(world, corner, Blocks.BARRIER.getDefaultState()) && success;
+        success = success && tryPlace(world, corner, Blocks.BARRIER.getDefaultState());
 
         corner = centre.add(-1, 0, -1);
-        success = tryPlace(world, corner, Blocks.BARRIER.getDefaultState()) && success;
+        success = success && tryPlace(world, corner, Blocks.BARRIER.getDefaultState());
 
         return success;
     }
@@ -121,21 +121,21 @@ public class EngineBlockEntity extends SubSystemBlockEntity implements ITardisSo
         // place cable blocks adjacent
         for (Direction dir : Direction.values()) {
             BlockPos offset = centre.offset(dir);
-            success = tryRemoveIfMatches(world, offset, AITBlocks.CABLE_BLOCK) && success;
+            success = success && tryRemoveIfMatches(world, offset, AITBlocks.CABLE_BLOCK);
         }
 
         // place barrier blocks in corners
         BlockPos corner = centre.add(1, 0, 1);
-        success = tryRemoveIfMatches(world, corner, Blocks.BARRIER) && success;
+        success = success && tryRemoveIfMatches(world, corner, Blocks.BARRIER);
 
         corner = centre.add(-1, 0, 1);
-        success = tryRemoveIfMatches(world, corner, Blocks.BARRIER) && success;
+        success = success && tryRemoveIfMatches(world, corner, Blocks.BARRIER);
 
         corner = centre.add(1, 0, -1);
-        success = tryRemoveIfMatches(world, corner, Blocks.BARRIER) && success;
+        success = success && tryRemoveIfMatches(world, corner, Blocks.BARRIER);
 
         corner = centre.add(-1, 0, -1);
-        success = tryRemoveIfMatches(world, corner, Blocks.BARRIER) && success;
+        success = success && tryRemoveIfMatches(world, corner, Blocks.BARRIER);
 
         return success;
     }

--- a/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
@@ -40,20 +40,18 @@ public class EngineBlockEntity extends SubSystemBlockEntity implements ITardisSo
 
         this.tardis().ifPresent(tardis -> tardis.subsystems().engine().setEnabled(true));
 
-        if (!tryPlaceFillBlocks()) {
-            this.onBroken(world, pos);
-            world.setBlockState(pos, Blocks.AIR.getDefaultState());
+        if (tryPlaceFillBlocks()) return;
 
-            if (placer != null) {
-                Block.dropStack(world, pos, AITBlocks.ENGINE_BLOCK.asItem().getDefaultStack());
+        this.onBroken(world, pos);
+        world.setBlockState(pos, Blocks.AIR.getDefaultState());
 
-                if (placer instanceof ServerPlayerEntity player) {
-                    player.sendMessage(Text.translatable("tardis.message.engine.no_space").formatted(Formatting.RED), true);
-                }
-            }
+        if (placer == null) return;
 
-            return;
-        }
+        Block.dropStack(world, pos, AITBlocks.ENGINE_BLOCK.asItem().getDefaultStack());
+
+        if (!(placer instanceof ServerPlayerEntity player)) return;
+
+        player.sendMessage(Text.translatable("tardis.message.engine.no_space").formatted(Formatting.RED), true);
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
@@ -148,7 +148,7 @@ public class EngineBlockEntity extends SubSystemBlockEntity implements ITardisSo
      */
     private boolean tryRemoveIfMatches(ServerWorld world, BlockPos pos, Block expected) {
         BlockState state = world.getBlockState(pos);
-        if (state.getBlock() == expected) {
+        if (state.isOf(expected)) {
             world.removeBlock(pos, false);
             return true;
         }

--- a/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
@@ -51,6 +51,8 @@ public class EngineBlockEntity extends SubSystemBlockEntity implements ITardisSo
                     player.sendMessage(Text.translatable("tardis.message.engine.no_space").formatted(Formatting.RED), true);
                 }
             }
+
+            return;
         }
     }
 

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1063,6 +1063,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("message.ait.cage.void_hint", "(Throw this into the END void)");
         provider.addTranslation("message.ait.cage.empty", "(Place this in a rift chunk)");
         provider.addTranslation("tardis.message.engine.system_is_weakened", "This System Is Showing Signs Of Weakness, But Is Still Functional!");
+        provider.addTranslation("tardis.message.engine.no_space", "Engine requires a 3x3 space to function!");
 
         // Achievements
         provider.addTranslation("achievement.ait.title.root", "Adventures in Time");


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
The engine now spawns cables adjacent to it and barrier blocks in the corner
closes #1168

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is done as people were confused why they couldnt properly link up the engine
It also fixes the representation, as the engine was a large 3x3 structure but only had a small hitbox

## Technical details
<!-- Summary of code changes for easier review. -->
Created `tryPlaceFillBlocks` `tryRemoveFillBlocks` methods which attempt to place and remove these blocks on place/broken

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- feat: engine comes with cables, requires 3x3 space