### PR TITLE
BOTI Warning for AMD GPUs without Indium

### DIFF
--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -480,6 +480,9 @@ public class AITModClient implements ClientModInitializer {
     }
 
     public void exteriorBOTI(WorldRenderContext context) {
+        BOTI.tryWarn();
+
+
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
@@ -511,6 +514,8 @@ public class AITModClient implements ClientModInitializer {
     }
 
     public void doorBOTI(WorldRenderContext context) {
+        BOTI.tryWarn();
+
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
@@ -543,6 +548,8 @@ public class AITModClient implements ClientModInitializer {
     }
 
     public void paintingBOTI(WorldRenderContext context) {
+        BOTI.tryWarn();
+
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
@@ -566,6 +573,8 @@ public class AITModClient implements ClientModInitializer {
     }
 
     public void riftBOTI(WorldRenderContext context) {
+        BOTI.tryWarn();
+
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;

--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -8,12 +8,15 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.UUID;
 
+import dev.amble.ait.api.ClientWorldEvents;
 import dev.amble.lib.register.AmbleRegistries;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.*;
@@ -270,6 +273,10 @@ public class AITModClient implements ClientModInitializer {
         SonicModelLoader.init();
 
         AstralMapBlock.registerSyncListener();
+
+        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {;
+            BOTI.tryWarn();
+        });
     }
     public static Screen screenFromId(int id) {
         return screenFromId(id, null, null);
@@ -480,9 +487,6 @@ public class AITModClient implements ClientModInitializer {
     }
 
     public void exteriorBOTI(WorldRenderContext context) {
-        BOTI.tryWarn();
-
-
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
@@ -514,8 +518,6 @@ public class AITModClient implements ClientModInitializer {
     }
 
     public void doorBOTI(WorldRenderContext context) {
-        BOTI.tryWarn();
-
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
@@ -548,8 +550,6 @@ public class AITModClient implements ClientModInitializer {
     }
 
     public void paintingBOTI(WorldRenderContext context) {
-        BOTI.tryWarn();
-
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
@@ -573,8 +573,6 @@ public class AITModClient implements ClientModInitializer {
     }
 
     public void riftBOTI(WorldRenderContext context) {
-        BOTI.tryWarn();
-
         MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;

--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -274,9 +274,7 @@ public class AITModClient implements ClientModInitializer {
 
         AstralMapBlock.registerSyncListener();
 
-        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {;
-            BOTI.tryWarn();
-        });
+        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> BOTI.tryWarn());
     }
     public static Screen screenFromId(int id) {
         return screenFromId(id, null, null);

--- a/src/main/java/dev/amble/ait/client/boti/BOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/BOTI.java
@@ -1,18 +1,25 @@
 package dev.amble.ait.client.boti;
 
 
+import java.awt.*;
 import java.util.LinkedList;
 import java.util.Queue;
 
 import com.mojang.blaze3d.platform.GlConst;
 import com.mojang.blaze3d.platform.GlStateManager;
 
+import dev.amble.ait.AITMod;
+import dev.amble.ait.compat.DependencyChecker;
+import dev.amble.ait.config.AITConfig;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.Framebuffer;
 
 import dev.amble.ait.core.blockentities.DoorBlockEntity;
 import dev.amble.ait.core.blockentities.ExteriorBlockEntity;
 import dev.amble.ait.core.entities.GallifreyFallsPaintingEntity;
 import dev.amble.ait.core.entities.RiftEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 
 
 public class BOTI {
@@ -22,6 +29,7 @@ public class BOTI {
     public static Queue<DoorBlockEntity> DOOR_RENDER_QUEUE = new LinkedList<>();
     public static Queue<GallifreyFallsPaintingEntity> PAINTING_RENDER_QUEUE = new LinkedList<>();
     public static Queue<ExteriorBlockEntity> EXTERIOR_RENDER_QUEUE = new LinkedList<>();
+    private static boolean HAS_BEEN_WARNED = false;
 
     public static void copyFramebuffer(Framebuffer src, Framebuffer dest) {
         GlStateManager._glBindFramebuffer(GlConst.GL_READ_FRAMEBUFFER, src.fbo);
@@ -43,5 +51,27 @@ public class BOTI {
 
     public static void setFramebufferColor(Framebuffer src, float r, float g, float b, float a) {
         src.setClearColor(r, g, b, a);
+    }
+
+    /**
+     * Warns the user if they are missing Indium and have a non-Nvidia card.
+     * @return true if the user is missing Indium and have a non-Nvidia card.
+     */
+    public static boolean tryWarn() {
+        boolean invalid = isInvalidSetup();
+
+        if (!HAS_BEEN_WARNED) {
+            HAS_BEEN_WARNED = true;
+
+            if (invalid) {
+                MinecraftClient.getInstance().player.sendMessage(Text.literal("You appear to have an AMD GPU. Indium is required, but is not found. This may cause issues with the mod - BOTI has been disabled!").formatted(DependencyChecker.hasIndium() ? Formatting.GREEN : Formatting.RED), false);
+                AITMod.CONFIG.CLIENT.ENABLE_TARDIS_BOTI = false;
+            }
+        }
+
+        return invalid;
+    }
+    private static boolean isInvalidSetup() {
+        return !DependencyChecker.hasNvidiaCard() && !DependencyChecker.hasIndium();
     }
 }

--- a/src/main/java/dev/amble/ait/client/boti/BOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/BOTI.java
@@ -71,6 +71,7 @@ public class BOTI {
 
         return invalid;
     }
+    
     private static boolean isInvalidSetup() {
         return !DependencyChecker.hasNvidiaCard() && !DependencyChecker.hasIndium();
     }

--- a/src/main/java/dev/amble/ait/client/boti/BOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/BOTI.java
@@ -1,7 +1,6 @@
 package dev.amble.ait.client.boti;
 
 
-import java.awt.*;
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -10,7 +9,6 @@ import com.mojang.blaze3d.platform.GlStateManager;
 
 import dev.amble.ait.AITMod;
 import dev.amble.ait.compat.DependencyChecker;
-import dev.amble.ait.config.AITConfig;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.Framebuffer;
 

--- a/src/main/java/dev/amble/ait/compat/DependencyChecker.java
+++ b/src/main/java/dev/amble/ait/compat/DependencyChecker.java
@@ -11,6 +11,7 @@ public class DependencyChecker {
     private static final boolean HAS_IRIS = doesModExist("iris");
     private static final boolean HAS_SODIUM = doesModExist("sodium");
     private static final boolean HAS_GRAVITY = doesModExist("gravity_changer_q");
+    private static final boolean HAS_INDIUM = doesModExist("indium");
 
     private static Boolean NVIDIA_CARD;
 
@@ -32,6 +33,9 @@ public class DependencyChecker {
 
     public static boolean hasGravity() {
         return HAS_GRAVITY;
+    }
+    public static boolean hasIndium() {
+        return HAS_INDIUM;
     }
 
     @Environment(EnvType.CLIENT)

--- a/src/main/java/dev/amble/ait/compat/DependencyChecker.java
+++ b/src/main/java/dev/amble/ait/compat/DependencyChecker.java
@@ -34,6 +34,7 @@ public class DependencyChecker {
     public static boolean hasGravity() {
         return HAS_GRAVITY;
     }
+
     public static boolean hasIndium() {
         return HAS_INDIUM;
     }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Added a HUD warning which shows up if the client is missing indium and has a non-nvidia gpu

closes #1182 

Not tested as I dont have AMD GPU

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Indium is required for AMD GPUs as it causes rendering issues

## Technical details
<!-- Summary of code changes for easier review. -->
Added `tryWarn` and a check for `indium` existing

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: show a warning for AMD GPUs without Indium