### PR TITLE
feat: cooler engine phasing

### DIFF
--- a/src/main/java/dev/amble/ait/core/engine/impl/EngineSystem.java
+++ b/src/main/java/dev/amble/ait/core/engine/impl/EngineSystem.java
@@ -142,7 +142,7 @@ public class EngineSystem extends DurableSubSystem {
             }
         }
         public void start() {
-            this.initial = AITMod.RANDOM.nextInt(140, 200); // 7-10 seconds
+            this.initial = AITMod.RANDOM.nextInt(1200, 2400); // evry 30-60 seconds if i dont suck at math
             this.countdown = this.initial;
             this.start.accept(this);
         }
@@ -166,33 +166,37 @@ public class EngineSystem extends DurableSubSystem {
                         tdis.getDesktop().playSoundAtEveryConsole(AITSounds.HOP_DEMAT);
                         tdis.getExterior().playSound(AITSounds.HOP_DEMAT);
 
-                        system.tardis().subsystems().demat().removeDurability(2);
+                        system.tardis().subsystems().demat().removeDurability(5);
                     },
                     (phaser) -> {
                         Tardis tardis1 = system.tardis();
                         TravelHandler travel = tardis1.travel();
-                        TravelUtil.randomPos(tardis1, 1, 250, cached -> {
+                        TravelUtil.randomPos(tardis1, 1, 300, cached -> {
                             travel.forceDestination(cached);
                             if (travel.isLanded()) {
-                                system.tardis().subsystems().demat().removeDurability(300);
+                                system.tardis().subsystems().demat().removeDurability(15);
+                                system.tardis().travel().speed(500);
+                                system.tardis().travel().autopilot(false);
 
                                 system.tardis().getDesktop().playSoundAtEveryConsole(AITSounds.UNSTABLE_FLIGHT_LOOP);
                                 system.tardis().getExterior().playSound(AITSounds.UNSTABLE_FLIGHT_LOOP);
+                                system.tardis().getExterior().playSound(AITSounds.CLOISTER);
                                 tardis1.travel().forceDemat(TravelSoundRegistry.PHASING_DEMAT);
+                                system.tardis().travel().autopilot(false);
                             }
 
                             TardisEvents.ENGINES_PHASE.invoker().onPhase(system);
                         });
                     },
                     (phaser) -> {
-                        SoundEvent sound = (phaser.countdown < (phaser.initial - (250))) ? AITSounds.HOP_MAT : AITSounds.LAND_THUD;
+                        SoundEvent sound = (phaser.countdown < (phaser.initial - (300))) ? AITSounds.HOP_MAT : AITSounds.LAND_THUD;
 
                         system.tardis().getDesktop().playSoundAtEveryConsole(sound);
                         system.tardis().getExterior().playSound(sound);
 
                         system.tardis().alarm().enabled().set(false);
                     },
-                    (phaser) -> system.tardis().travel().isLanded() && system.tardis().subsystems().demat().durability() < 250 && !system.tardis().subsystems().demat().isBroken() && !system.tardis().travel().handbrake() && !system.tardis().isGrowth() && AITMod.RANDOM.nextInt(0, 1024) == 1
+                    (phaser) -> system.tardis().travel().isLanded() && system.tardis().subsystems().demat().durability() < 300 && !system.tardis().subsystems().demat().isBroken() && !system.tardis().travel().handbrake() && !system.tardis().isGrowth() && AITMod.RANDOM.nextInt(0, 1024) == 1
             );
         }
     }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Engine phasing can now trigger between 1-300 durability
If triggerd will immidetly travel to the random position and begin ghost monumenting
The demat circuit only loses 15 durability when fail so it can ghost monument properly.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
 This adds to the ghost monument mechanic as its rarely acctualy seen gameplay wise unless triggerd manualy.

## Technical details
<!-- Summary of code changes for easier review. -->
i changed some stuff lol

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- Engine phasing can trigger between 1-300 durability
- Engine phasing will now cause ghost monument 