### PR TITLE
fix: position of sonic overlay

### DIFF
--- a/src/main/java/dev/amble/ait/client/overlays/SonicOverlay.java
+++ b/src/main/java/dev/amble/ait/client/overlays/SonicOverlay.java
@@ -83,7 +83,7 @@ public class SonicOverlay implements HudRenderCallback {
                 GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR, GlStateManager.SrcFactor.ONE,
                 GlStateManager.DstFactor.ZERO);
         context.drawTexture(texture, (context.getScaledWindowWidth() / 2) - 8,
-                (context.getScaledWindowHeight() / 2) - 8, 0, 0.0F, 0.0F, 16, 16, 16, 16);
+                (context.getScaledWindowHeight() / 2) - 24, 0, 0.0F, 0.0F, 16, 16, 16, 16);
         RenderSystem.defaultBlendFunc();
         RenderSystem.depthMask(true);
         RenderSystem.enableDepthTest();


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Moved sonic overlay upward
closes #1210

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Before it was overlapping with crosshair

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->