### PR TITLE
fix: exterior not rendering behind the shields

### DIFF
--- a/src/main/java/dev/amble/ait/client/renderers/exteriors/ExteriorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/exteriors/ExteriorRenderer.java
@@ -81,23 +81,8 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
         final float alpha = entity.getAlpha();
         RenderSystem.enableCull();
         RenderSystem.enableBlend();
+        RenderSystem.enableDepthTest();
         RenderSystem.defaultBlendFunc();
-        if (tardis.areVisualShieldsActive()) {
-            profiler.push("shields");
-
-            float delta = (tickDelta + MinecraftClient.getInstance().player.age) * 0.03f;
-            VertexConsumer vertexConsumer = vertexConsumers
-                    .getBuffer(RenderLayer.getEnergySwirl(SHIELDS, delta % 1.0F, (delta * 0.1F) % 1.0F));
-
-            matrices.push();
-            matrices.translate(0.5F, 0.0F, 0.5F);
-
-            SHIELDS_MODEL.render(matrices, vertexConsumer, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, 0f,
-                    0.25f, 0.5f, alpha);
-
-            matrices.pop();
-            profiler.pop();
-        }
         RenderSystem.disableBlend();
         RenderSystem.enableCull();
 
@@ -236,6 +221,23 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
         profiler.pop();
         matrices.pop();
 
+        if (tardis.areVisualShieldsActive()) {
+            profiler.push("shields");
+
+            float delta = (tickDelta + MinecraftClient.getInstance().player.age) * 0.03f;
+            VertexConsumer vertexConsumer = vertexConsumers
+                    .getBuffer(RenderLayer.getEnergySwirl(SHIELDS, delta % 1.0F, (delta * 0.1F) % 1.0F));
+
+            matrices.push();
+            matrices.translate(0.5F, 0.0F, 0.5F);
+
+            SHIELDS_MODEL.render(matrices, vertexConsumer, LightmapTextureManager.MAX_LIGHT_COORDINATE, OverlayTexture.DEFAULT_UV, 0f,
+                    0.25f, 0.5f, alpha);
+
+            matrices.pop();
+            profiler.pop();
+        }
+
         profiler.push("sonic");
         ItemStack stack = tardis.sonic().getExteriorSonic();
 
@@ -260,6 +262,8 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
 
         matrices.pop();
         profiler.pop();
+
+
     }
 
     private void updateModel(Tardis tardis) {


### PR DESCRIPTION
## About the PR
Moved shield rendering to the end, so it can be rendered over the exterior

## Why / Balance
fixes the exterior going invisible when shield is on


## Media
![image](https://github.com/user-attachments/assets/b6b8cc5d-02ea-4ab2-99f8-0242c18272d6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Exterior not rendering correctly behind the shields!
-->