### PR TITLE
chore: delete invalid exteriors on use and on collision

### DIFF
--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -8,14 +8,12 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.UUID;
 
-import dev.amble.ait.api.ClientWorldEvents;
 import dev.amble.lib.register.AmbleRegistries;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.particle.v1.ParticleFactoryRegistry;

--- a/src/main/java/dev/amble/ait/client/boti/BOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/BOTI.java
@@ -7,17 +7,17 @@ import java.util.Queue;
 import com.mojang.blaze3d.platform.GlConst;
 import com.mojang.blaze3d.platform.GlStateManager;
 
-import dev.amble.ait.AITMod;
-import dev.amble.ait.compat.DependencyChecker;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.Framebuffer;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
 
+import dev.amble.ait.AITMod;
+import dev.amble.ait.compat.DependencyChecker;
 import dev.amble.ait.core.blockentities.DoorBlockEntity;
 import dev.amble.ait.core.blockentities.ExteriorBlockEntity;
 import dev.amble.ait.core.entities.GallifreyFallsPaintingEntity;
 import dev.amble.ait.core.entities.RiftEntity;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 
 
 public class BOTI {
@@ -69,7 +69,7 @@ public class BOTI {
 
         return invalid;
     }
-    
+
     private static boolean isInvalidSetup() {
         return !DependencyChecker.hasNvidiaCard() && !DependencyChecker.hasIndium();
     }

--- a/src/main/java/dev/amble/ait/client/renderers/SonicRendering.java
+++ b/src/main/java/dev/amble/ait/client/renderers/SonicRendering.java
@@ -29,7 +29,6 @@ import dev.amble.ait.core.engine.block.SubSystemBlockEntity;
 import dev.amble.ait.core.engine.impl.EngineSystem;
 import dev.amble.ait.core.item.SonicItem;
 import dev.amble.ait.core.item.sonic.SonicMode;
-import dev.amble.ait.core.util.WorldUtil;
 import dev.amble.ait.core.world.TardisServerWorld;
 
 public class SonicRendering {

--- a/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
@@ -2,22 +2,22 @@ package dev.amble.ait.core.blockentities;
 
 
 
-import dev.amble.ait.core.AITBlocks;
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.math.Direction;
-import org.jetbrains.annotations.Nullable;
-
-import net.minecraft.block.BlockState;
-import net.minecraft.entity.LivingEntity;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
 import dev.amble.ait.core.AITBlockEntityTypes;
+import dev.amble.ait.core.AITBlocks;
 import dev.amble.ait.core.engine.SubSystem;
 import dev.amble.ait.core.engine.block.SubSystemBlockEntity;
 import dev.amble.ait.core.engine.link.IFluidLink;

--- a/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
@@ -4,12 +4,14 @@ import static dev.amble.ait.core.tardis.handler.InteriorChangingHandler.MAX_PLAS
 
 import java.util.UUID;
 
+import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.drtheo.scheduler.api.Scheduler;
 import dev.drtheo.scheduler.api.TimeUnit;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
@@ -19,6 +21,7 @@ import net.minecraft.item.BrushItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.BlockStateParticleEffect;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
@@ -73,6 +76,8 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
     public void useOn(ServerWorld world, boolean sneaking, PlayerEntity player) {
         if (this.tardis().isEmpty() || player == null)
             return;
+
+        if (!this.validateExteriorPosition()) return;
 
         ServerTardis tardis = (ServerTardis) this.tardis().get();
         ItemStack hand = player.getMainHandStack();
@@ -187,6 +192,36 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
         tardis.door().interact((ServerWorld) this.getWorld(), this.getPos(), (ServerPlayerEntity) player);
     }
 
+
+    /**
+     * Validates the exterior position of the TARDIS
+     * Will delete this block if the exterior is not valid
+     * @return true if the exterior is valid
+     */
+    public boolean validateExteriorPosition() {
+        if (!this.isLinked()) return true;
+
+        ServerTardis tardis = this.tardis().get().asServer();
+
+        CachedDirectedGlobalPos expectedPos = tardis.travel().position();
+        RegistryKey<World> expectedDim = expectedPos.getDimension();
+        BlockPos expectedBlockPos = expectedPos.getPos();
+
+        ServerWorld extWorld = (ServerWorld) this.getWorld();
+        BlockPos extPos = this.getPos();
+
+        boolean invalid = !extWorld.getRegistryKey().equals(expectedDim) || !extPos.equals(expectedBlockPos);
+
+        if (!invalid) return true;
+
+        AITMod.LOGGER.warn("Invalid exterior at {} {}, expected {} {} for TARDIS {}. Removing..",
+                extWorld.getRegistryKey(), extPos, expectedDim, expectedBlockPos, tardis.getUuid());
+
+        extWorld.setBlockState(extPos, Blocks.AIR.getDefaultState());
+
+        return true;
+    }
+
     public void sitOn(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
         if (world.isClient()) return;
 
@@ -246,6 +281,8 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
     }
 
     public void onEntityCollision(Entity entity) {
+        if (!this.validateExteriorPosition()) return;
+
         TardisRef ref = this.tardis();
 
         if (ref == null)

--- a/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
@@ -198,6 +198,7 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
      * Will delete this block if the exterior is not valid
      * @return true if the exterior is valid
      */
+    @Deprecated(since = "1.3.0")
     public boolean validateExteriorPosition() {
         if (!this.isLinked()) return true;
 

--- a/src/main/java/dev/amble/ait/core/blocks/ExteriorBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/ExteriorBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.block.entity.BlockEntityType;
 import net.minecraft.client.util.ParticleUtil;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
@@ -394,6 +395,28 @@ public class ExteriorBlock extends Block implements BlockEntityProvider, ICantBr
             return false;
 
         return canFallThrough(state);
+    }
+
+    @Override
+    public void onPlaced(World world, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack itemStack) {
+        super.onPlaced(world, pos, state, placer, itemStack);
+
+        if (world.isClient())
+            return;
+
+        if (world.getBlockEntity(pos) instanceof ExteriorBlockEntity exterior)
+            exterior.validateExteriorPosition();
+    }
+
+    @Override
+    public void onStateReplaced(BlockState state, World world, BlockPos pos, BlockState newState, boolean moved) {
+        super.onStateReplaced(state, world, pos, newState, moved);
+
+        if (world.isClient())
+            return;
+
+        if (world.getBlockEntity(pos) instanceof ExteriorBlockEntity exterior)
+            exterior.validateExteriorPosition();
     }
 
     private static boolean canFallThrough(BlockState state) {

--- a/src/main/java/dev/amble/ait/core/engine/SubSystem.java
+++ b/src/main/java/dev/amble/ait/core/engine/SubSystem.java
@@ -6,13 +6,13 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import com.google.gson.*;
-import dev.amble.ait.AITMod;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
-import net.minecraft.text.Text;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.text.Text;
 
+import dev.amble.ait.AITMod;
 import dev.amble.ait.api.tardis.Disposable;
 import dev.amble.ait.api.tardis.Initializable;
 import dev.amble.ait.api.tardis.TardisComponent;

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -6,7 +6,6 @@ import static net.minecraft.data.server.recipe.RecipeProvider.*;
 import java.util.Calendar;
 import java.util.concurrent.CompletableFuture;
 
-import dev.amble.ait.core.engine.SubSystem;
 import dev.amble.lib.datagen.lang.AmbleLanguageProvider;
 import dev.amble.lib.datagen.lang.LanguageType;
 import dev.amble.lib.datagen.sound.AmbleSoundProvider;
@@ -31,6 +30,7 @@ import dev.amble.ait.core.AITBlocks;
 import dev.amble.ait.core.AITEntityTypes;
 import dev.amble.ait.core.AITItemGroups;
 import dev.amble.ait.core.AITItems;
+import dev.amble.ait.core.engine.SubSystem;
 import dev.amble.ait.datagen.datagen_providers.*;
 import dev.amble.ait.datagen.datagen_providers.loot.AITBlockLootTables;
 import dev.amble.ait.module.ModuleRegistry;


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Invalid exteriors get deleted

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
patch for #477
RWF causes dupe exteriors, temp patch until 1.3.0

## Technical details
<!-- Summary of code changes for easier review. -->
Added a method which checks the expected dimension and position & deletes the exterior if they dont match.
Is ran on use and on collision

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->