### PR TITLE
fix: blueprint tooltip flickering between amounts

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/blueprint/BlueprintItem.java
+++ b/src/main/java/dev/amble/ait/core/item/blueprint/BlueprintItem.java
@@ -51,11 +51,10 @@ public class BlueprintItem extends Item {
 
         tooltip.add(Text.translatable("ait.blueprint.tooltip").formatted(Formatting.BLUE)
                 .append(blueprint.text().copy().formatted(Formatting.GRAY)));
-        for (int i = blueprint.inputs().size() - 1; i >= 0; i--) {
-            ItemStack stack1 = blueprint.inputs().get(i).toStack();
-            tooltip.add(Texts.bracketed(Text.translatable(stack1.getTranslationKey())).append(" x").append(Text.of(String.valueOf(stack1.getCount()))).formatted(Formatting.DARK_GRAY));
-        }
 
+        for (int i = blueprint.inputs().size() - 1; i >= 0; i--) {
+            tooltip.add(blueprint.inputs().get(i).text().copy().formatted(Formatting.DARK_GRAY));
+        }
     }
 
     public static BlueprintSchema getSchema(ItemStack stack) {

--- a/src/main/java/dev/amble/ait/core/item/blueprint/BlueprintSchema.java
+++ b/src/main/java/dev/amble/ait/core/item/blueprint/BlueprintSchema.java
@@ -18,6 +18,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
 import net.minecraft.text.Text;
+import net.minecraft.text.Texts;
 import net.minecraft.util.Identifier;
 
 import dev.amble.ait.AITMod;
@@ -112,6 +113,14 @@ public record BlueprintSchema(Identifier id, Text text, InputList inputs, ItemSt
                     ", maxCount=" + maxCount +
                     ", minCount=" + minCount +
                     '}';
+        }
+
+        public Text text() {
+            Text countText = minCount == maxCount ? Text.of(String.valueOf(minCount)) : Text.of(minCount + "-" + maxCount);
+
+            return Texts.bracketed(Text.translatable(item.getTranslationKey()))
+                    .append(" x")
+                    .append(countText);
         }
     }
     public static class InputList extends ArrayList<Input> {


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Blueprint display now shows the range the item count could be in tooltip

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was difficult to see the amounts before, as it would flicker between them.

## Technical details
<!-- Summary of code changes for easier review. -->
Added `text` method to `Input` for representation.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->