### PR TITLE
fix: /ait data command accepts any json element now

### DIFF
--- a/src/main/java/dev/amble/ait/core/commands/DataCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/DataCommand.java
@@ -96,7 +96,7 @@ public class DataCommand {
         Value<T> value = keyed.getPropertyData().getExact(valueName);
         Class<?> classOfT = value.getProperty().getType().getClazz();
 
-        T obj = (T) ServerTardisManager.getInstance().getFileGson().fromJson(data.toString(), classOfT);
+        T obj = (T) ServerTardisManager.getInstance().getFileGson().fromJson(data, classOfT);
 
         value.set(obj);
         source.sendMessage(Text.translatable("command.ait.data.set", valueName, obj.toString()));


### PR DESCRIPTION
## About the PR
This PR changes the data command to parse the json element itself instead of turning it into a string.

## Why / Balance
This allows players (admins) to set doubles, integers and more.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: allow to use any json values in /ait data