### PR TITLE
fix: ait:staser_bolt_magazine not being in loottables

### DIFF
--- a/src/main/resources/data/ait/loot_tables/chests/cult_chest_one.json
+++ b/src/main/resources/data/ait/loot_tables/chests/cult_chest_one.json
@@ -148,6 +148,11 @@
           "type": "minecraft:item",
           "name": "ait:drifting_music_disc",
           "weight": 1
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ait:staser_bolt_magazine",
+          "weight": 1
         }
       ],
       "rolls": 15


### PR DESCRIPTION
## About the PR
added the ait:staser_bolt_magazine to the cult_chest_one lootable

## Why / Balance
it was not in any loottable and is not craftable

**Changelog**
:cl:
fix:  ait:staser_bolt_magazine not being in loottables