### PR TITLE
fix/scale_invisibility

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/StatsHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/StatsHandler.java
@@ -60,9 +60,9 @@ public class StatsHandler extends KeyedTardisComponent {
     private static final BoolProperty SECURITY = new BoolProperty("security", false);
     private static final BoolProperty HAIL_MARY = new BoolProperty("hail_mary", false);
     private static final BoolProperty RECEIVE_CALLS = new BoolProperty("receive_calls", true);
-    private static final DoubleProperty TARDIS_X_SCALE = new DoubleProperty("tardis_x_scale");
-    private static final DoubleProperty TARDIS_Y_SCALE = new DoubleProperty("tardis_y_scale");
-    private static final DoubleProperty TARDIS_Z_SCALE = new DoubleProperty("tardis_z_scale");
+    private static final DoubleProperty TARDIS_X_SCALE = new DoubleProperty("tardis_x_scale", 1);
+    private static final DoubleProperty TARDIS_Y_SCALE = new DoubleProperty("tardis_y_scale", 1);
+    private static final DoubleProperty TARDIS_Z_SCALE = new DoubleProperty("tardis_z_scale", 1);
 
 
     private final Value<String> tardisName = NAME.create(this);


### PR DESCRIPTION
## About the PR
The scale of the TARDIS in the StatsHandler was defaulting to 0 for TARDIS' that didn't have the scale values already. I changed it so that the default value is "1".

## Why / Balance
Fixes old TARDIS' going invisible.

## Technical details
I just added a ", 1" to each DoubleProperty for scale in the StatsHandler.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- Fixed old, invisible TARDIS'.