### PR TITLE
Fixed Spacesuit Breathing

### DIFF
--- a/src/main/java/dev/amble/ait/client/screens/AstralMapScreen.java
+++ b/src/main/java/dev/amble/ait/client/screens/AstralMapScreen.java
@@ -3,7 +3,6 @@ package dev.amble.ait.client.screens;
 import java.util.List;
 import java.util.function.Consumer;
 
-import dev.amble.ait.core.util.WorldUtil;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 
@@ -18,6 +17,7 @@ import dev.amble.ait.AITMod;
 import dev.amble.ait.api.Nameable;
 import dev.amble.ait.client.screens.widget.SwitcherManager;
 import dev.amble.ait.core.blocks.AstralMapBlock;
+import dev.amble.ait.core.util.WorldUtil;
 
 public class AstralMapScreen extends Screen {
 

--- a/src/main/java/dev/amble/ait/module/planet/mixin/gravity/LivingEntityMixin.java
+++ b/src/main/java/dev/amble/ait/module/planet/mixin/gravity/LivingEntityMixin.java
@@ -102,7 +102,7 @@ public abstract class LivingEntityMixin extends Entity {
                 entity.setFrozenTicks(entity.getMinFreezeDamageTicks() + 20);
         }
 
-        if (!planet.hasOxygen() && !Planet.hasOxygenInTank(entity)) {
+        if (!planet.hasOxygen() && !Planet.hasFullSuit(entity) && !Planet.hasOxygenInTank(entity)) {
             entity.addStatusEffect(new StatusEffectInstance(StatusEffects.NAUSEA,
                     200, 1, false, false));
             entity.addStatusEffect(new StatusEffectInstance(StatusEffects.WITHER, 1,


### PR DESCRIPTION
## About the PR
Planets/Space without oxygen requires a full spacesuit to breathe now

## Why / Balance
You could take every piece off but the chestplate and be fine

## Technical details
just added hasFullSpacesuit() boolean to the mixin.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- Fixed being able to breathe where you shouldn't be with your helmet off.