### PR TITLE
Interior Commands (no need to use the TARDIS ID)

### DIFF
--- a/src/main/java/dev/amble/ait/AITMod.java
+++ b/src/main/java/dev/amble/ait/AITMod.java
@@ -221,6 +221,7 @@ public class AITMod implements ModInitializer {
         Registry.register(net.minecraft.registry.Registries.FEATURE, CRATER_ID, CRATER);
 
         CommandRegistrationCallback.EVENT.register(((dispatcher, registryAccess, environment) -> {
+            // Normal commands that require a TARDIS ID
             TeleportInteriorCommand.register(dispatcher);
             SummonTardisCommand.register(dispatcher);
             SetLockedCommand.register(dispatcher);
@@ -248,6 +249,21 @@ public class AITMod implements ModInitializer {
             DebugCommand.register(dispatcher);
             EraseChunksCommand.register(dispatcher);
             FlightCommand.register(dispatcher);
+
+            // Commands that can only be executed from the interior
+            DataInteriorCommand.register(dispatcher);
+            FlightInteriorCommand.register(dispatcher);
+            FuelInteriorCommand.register(dispatcher);
+            GetCreatorInteriorCommand.register(dispatcher);
+            GetNameInteriorCommand.register(dispatcher);
+            LinkInteriorCommand.register(dispatcher);
+            SetLockedInteriorCommand.register(dispatcher);
+            SetMaxSpeedInteriorCommand.register(dispatcher);
+            SetNameInteriorCommand.register(dispatcher);
+            SetRepairTicksInteriorCommand.register(dispatcher);
+            SetSiegeInteriorCommand.register(dispatcher);
+            TriggerMoodRollInteriorCommand.register(dispatcher);
+            UnlockInteriorCommand.register(dispatcher);
         }));
 
         ServerPlayNetworking.registerGlobalReceiver(TardisUtil.REGION_LANDING_CODE,

--- a/src/main/java/dev/amble/ait/core/commands/DataInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/DataInteriorCommand.java
@@ -1,0 +1,99 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.google.gson.JsonElement;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+
+import net.minecraft.command.CommandSource;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.api.tardis.KeyedTardisComponent;
+import dev.amble.ait.api.tardis.TardisComponent;
+import dev.amble.ait.core.commands.argument.JsonElementArgumentType;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.tardis.manager.ServerTardisManager;
+import dev.amble.ait.core.world.TardisServerWorld;
+import dev.amble.ait.data.properties.Value;
+import dev.amble.ait.registry.impl.TardisComponentRegistry;
+
+public class DataInteriorCommand {
+
+    public static final SuggestionProvider<ServerCommandSource> VALUE_SUGGESTION = (context, builder) -> {
+        ServerTardis tardis = ((TardisServerWorld) context.getSource().getWorld()).getTardis();
+        String rawComponent = StringArgumentType.getString(context, "component");
+
+        TardisComponent.IdLike id = TardisComponentRegistry.getInstance().get(rawComponent);
+
+        if (!(tardis.handler(id) instanceof KeyedTardisComponent keyed))
+            return builder.buildFuture(); // womp womp
+
+        return CommandSource.suggestMatching(
+                keyed.getPropertyData().values().stream().map(value -> value.getProperty().getName()), builder);
+    };
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("data").requires(source -> source.hasPermissionLevel(2))
+                        .then(argument("value", StringArgumentType.word()).suggests(VALUE_SUGGESTION)
+                                .then(literal("set").then(argument("data", JsonElementArgumentType.jsonElement())
+                                        .executes(DataInteriorCommand::runSet)))
+                                .then(literal("get").executes(DataInteriorCommand::runGet)))));
+    }
+
+    private static <T> int runGet(CommandContext<ServerCommandSource> context) {
+        ServerCommandSource source = context.getSource();
+
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
+
+        String rawComponent = StringArgumentType.getString(context, "component");
+        String valueName = StringArgumentType.getString(context, "value");
+
+        TardisComponent.IdLike id = TardisComponentRegistry.getInstance().get(rawComponent);
+
+        if (!(tardis.handler(id) instanceof KeyedTardisComponent keyed)) {
+            source.sendMessage(Text.translatable("command.ait.data.fail", valueName, rawComponent));
+            return 0; // womp womp
+        }
+
+        Value<T> value = keyed.getPropertyData().getExact(valueName);
+        T obj = value.get();
+
+        String json = ServerTardisManager.getInstance().getFileGson().toJson(obj);
+
+        source.sendMessage(Text.translatable("command.ait.data.get", valueName, json));
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static <T> int runSet(CommandContext<ServerCommandSource> context) {
+        ServerCommandSource source = context.getSource();
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
+
+        String rawComponent = StringArgumentType.getString(context, "component");
+        String valueName = StringArgumentType.getString(context, "value");
+
+        JsonElement data = JsonElementArgumentType.getJsonElement(context, "data");
+        TardisComponent.IdLike id = TardisComponentRegistry.getInstance().get(rawComponent);
+
+        if (!(tardis.handler(id) instanceof KeyedTardisComponent keyed)) {
+            source.sendMessage(Text.translatable("command.ait.data.fail", valueName, rawComponent));
+            return 0; // womp womp
+        }
+
+        Value<T> value = keyed.getPropertyData().getExact(valueName);
+        Class<?> classOfT = value.getProperty().getType().getClazz();
+
+        T obj = (T) ServerTardisManager.getInstance().getFileGson().fromJson(data, classOfT);
+
+        value.set(obj);
+        source.sendMessage(Text.translatable("command.ait.data.set", valueName, obj.toString()));
+
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/FlightInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/FlightInteriorCommand.java
@@ -1,0 +1,45 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.world.TardisServerWorld;
+
+public class FlightInteriorCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("flight").requires(source -> source.hasPermissionLevel(2))
+                                .executes(FlightInteriorCommand::execute)));
+
+    }
+
+    private static int execute(CommandContext<ServerCommandSource> context) {
+        ServerPlayerEntity player = context.getSource().getPlayer();
+        if (player == null) return 0;
+        ServerTardis tardis = ((TardisServerWorld) player.getServerWorld()).getTardis();
+
+        if (!AITMod.CONFIG.SERVER.RWF_ENABLED) {
+            player.sendMessage(Text.translatable("tardis.message.control.rwf_disabled"), true);
+            return Command.SINGLE_SUCCESS;
+        }
+
+        if (!player.isCreative()) {
+            player.sendMessage(Text.translatable("tardis.message.control.rwf_creative_only"), true);
+            return Command.SINGLE_SUCCESS;
+        }
+
+        context.getSource().getServer().executeSync(()
+                -> tardis.flight().enterFlight(player));
+
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/FuelInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/FuelInteriorCommand.java
@@ -1,0 +1,89 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.DoubleArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.tardis.handler.FuelHandler;
+import dev.amble.ait.core.util.TextUtil;
+import dev.amble.ait.core.world.TardisServerWorld;
+
+public class FuelInteriorCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher
+                .register(literal(AITMod.MOD_ID).then(literal("fuel").requires(source -> source.hasPermissionLevel(2))
+                        .then(literal("add").then(argument("amount", DoubleArgumentType.doubleArg(0, FuelHandler.TARDIS_MAX_FUEL))
+                                        .executes(FuelInteriorCommand::add))))
+                        .then(literal("remove").requires(source -> source.hasPermissionLevel(2))
+                                .then(argument("amount", DoubleArgumentType.doubleArg(0, FuelHandler.TARDIS_MAX_FUEL))
+                                                .executes(FuelInteriorCommand::remove)))
+                        .then(literal("set").requires(source -> source.hasPermissionLevel(2))
+                                .then(argument("amount", DoubleArgumentType.doubleArg(0, FuelHandler.TARDIS_MAX_FUEL))
+                                                .executes(FuelInteriorCommand::set)))
+                        .then(literal("get").requires(source -> source.hasPermissionLevel(2))
+                                        .executes(FuelInteriorCommand::get)));
+    }
+
+    private static int add(CommandContext<ServerCommandSource> context) {
+        ServerCommandSource source = context.getSource();
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
+
+        double fuel = DoubleArgumentType.getDouble(context, "amount");
+        tardis.addFuel(fuel);
+
+        source.sendMessage(
+                Text.translatable("message.ait.fuel.add", fuel, TextUtil.forTardis(tardis), tardis.getFuel()));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int remove(CommandContext<ServerCommandSource> context) {
+        ServerCommandSource source = context.getSource();
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
+
+        double fuel = DoubleArgumentType.getDouble(context, "amount");
+        tardis.removeFuel(fuel);
+
+        source.sendMessage(
+                Text.translatable("message.ait.fuel.remove", fuel, TextUtil.forTardis(tardis), tardis.getFuel()));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int set(CommandContext<ServerCommandSource> context) {
+        ServerCommandSource source = context.getSource();
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
+
+        double fuel = DoubleArgumentType.getDouble(context, "amount");
+
+        if (fuel > FuelHandler.TARDIS_MAX_FUEL) {
+            source.sendMessage(Text.translatable("message.ait.fuel.max"));
+            return 0;
+        }
+
+        tardis.setFuelCount(fuel);
+        source.sendMessage(Text.translatable("message.ait.fuel.set", TextUtil.forTardis(tardis), fuel));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int get(CommandContext<ServerCommandSource> context) {
+        ServerCommandSource source = context.getSource();
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
+
+        double fuel = tardis.fuel().getCurrentFuel();
+        source.sendMessage(Text.translatable("message.ait.fuel.get", TextUtil.forTardis(tardis), fuel));
+
+        return (int) fuel;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/GetCreatorInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/GetCreatorInteriorCommand.java
@@ -6,29 +6,26 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
 import dev.amble.ait.AITMod;
-import dev.amble.ait.core.util.TextUtil;
+import dev.amble.ait.core.tardis.ServerTardis;
 import dev.amble.ait.core.world.TardisServerWorld;
 
-public class GetInsideTardisCommand {
+public class GetCreatorInteriorCommand {
 
-    // TODO: add BlockPosition argument type
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        dispatcher.register(literal(AITMod.MOD_ID).then(literal("this")
-                .executes(GetInsideTardisCommand::runCommand)));
+        dispatcher.register(literal(AITMod.MOD_ID)
+                .then(literal("creator-name").requires(source -> source.hasPermissionLevel(2))
+                        .then(literal("get").executes(GetCreatorInteriorCommand::runCommand))));
     }
 
     private static int runCommand(CommandContext<ServerCommandSource> context) {
-        Entity source = context.getSource().getEntity();
+        ServerCommandSource source = context.getSource();
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
 
-        if (source.getWorld() instanceof TardisServerWorld tardisWorld)
-            source.sendMessage(Text.translatable("message.ait.id")
-                    .append(TextUtil.forTardis(tardisWorld.getTardis())));
-
+        source.sendMessage(Text.literal(tardis.stats().getPlayerCreatorName()));
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/dev/amble/ait/core/commands/GetNameInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/GetNameInteriorCommand.java
@@ -6,28 +6,25 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
 import dev.amble.ait.AITMod;
-import dev.amble.ait.core.util.TextUtil;
+import dev.amble.ait.core.tardis.ServerTardis;
 import dev.amble.ait.core.world.TardisServerWorld;
 
-public class GetInsideTardisCommand {
-
-    // TODO: add BlockPosition argument type
+public class GetNameInteriorCommand {
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        dispatcher.register(literal(AITMod.MOD_ID).then(literal("this")
-                .executes(GetInsideTardisCommand::runCommand)));
+        dispatcher.register(literal(AITMod.MOD_ID)
+                .then(literal("name").requires(source -> source.hasPermissionLevel(2)).then(literal("get")
+                        .executes(GetNameInteriorCommand::runCommand))));
     }
 
     private static int runCommand(CommandContext<ServerCommandSource> context) {
-        Entity source = context.getSource().getEntity();
+        ServerCommandSource source = context.getSource();
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
 
-        if (source.getWorld() instanceof TardisServerWorld tardisWorld)
-            source.sendMessage(Text.translatable("message.ait.id")
-                    .append(TextUtil.forTardis(tardisWorld.getTardis())));
+        source.sendMessage(Text.translatableWithFallback("tardis.name", "TARDIS name: %s", tardis.stats().getName()));
 
         return Command.SINGLE_SUCCESS;
     }

--- a/src/main/java/dev/amble/ait/core/commands/LinkInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/LinkInteriorCommand.java
@@ -1,0 +1,39 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.api.tardis.link.LinkableItem;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.world.TardisServerWorld;
+
+public class LinkInteriorCommand {
+
+    // TODO: add slot argument, like in "/item replace" command
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("link").requires(source -> source.hasPermissionLevel(2))
+                .executes(LinkInteriorCommand::runCommand)));
+    }
+
+    private static int runCommand(CommandContext<ServerCommandSource> context) {
+        ServerPlayerEntity source = context.getSource().getPlayer();
+        if (source == null) return 0;
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
+
+        ItemStack stack = source.getMainHandStack();
+
+        if (!(stack.getItem() instanceof LinkableItem linker))
+            return 0;
+
+        linker.link(stack, tardis);
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/SetLockedInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetLockedInteriorCommand.java
@@ -1,0 +1,35 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.world.TardisServerWorld;
+
+public class SetLockedInteriorCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("lock").requires(source -> source.hasPermissionLevel(2))
+                        .then(argument("locked",
+                                BoolArgumentType.bool()).executes(SetLockedInteriorCommand::runCommand))));
+    }
+
+    private static int runCommand(CommandContext<ServerCommandSource> context) {
+        ServerPlayerEntity source = context.getSource().getPlayer();
+        if (source == null) return 0;
+        ServerTardis tardis = ((TardisServerWorld) source.getServerWorld()).getTardis();
+        boolean locked = BoolArgumentType.getBool(context, "locked");
+
+        tardis.door().interactLock(locked, source, true);
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/SetMaxSpeedInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetMaxSpeedInteriorCommand.java
@@ -1,0 +1,36 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.minecraft.server.command.ServerCommandSource;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.world.TardisServerWorld;
+
+/**
+ * temporary command to set max speed until we find a proper way
+ */
+public class SetMaxSpeedInteriorCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("set-max-speed")
+                .requires(source -> source.hasPermissionLevel(2)).then(
+                        argument("speed", IntegerArgumentType.integer(0))
+                                .executes(SetMaxSpeedInteriorCommand::runCommand))));
+    }
+
+    private static int runCommand(CommandContext<ServerCommandSource> context) {
+        ServerTardis tardis = ((TardisServerWorld) context.getSource().getWorld()).getTardis();
+        int speed = IntegerArgumentType.getInteger(context, "speed");
+
+        tardis.travel().maxSpeed().set(speed);
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/SetNameInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetNameInteriorCommand.java
@@ -1,0 +1,33 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.minecraft.server.command.ServerCommandSource;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.world.TardisServerWorld;
+
+public class SetNameInteriorCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("name").requires(source -> source.hasPermissionLevel(2))
+                .then(literal("set")
+                        .then(argument("value",
+                                StringArgumentType.string()).executes(SetNameInteriorCommand::runCommand)))));
+    }
+
+    private static int runCommand(CommandContext<ServerCommandSource> context) {
+        ServerTardis tardis = ((TardisServerWorld) context.getSource().getWorld()).getTardis();
+        String name = StringArgumentType.getString(context, "value");
+
+        tardis.stats().setName(name);
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/SetRepairTicksInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetRepairTicksInteriorCommand.java
@@ -1,0 +1,46 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.tardis.handler.TardisCrashHandler;
+import dev.amble.ait.core.world.TardisServerWorld;
+
+public class SetRepairTicksInteriorCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID)
+                .then(literal("repair").requires(source -> source.hasPermissionLevel(2))
+                        .then(literal("set").then(
+                                argument("ticks", IntegerArgumentType.integer(0, TardisCrashHandler.MAX_REPAIR_TICKS))
+                                        .executes(SetRepairTicksInteriorCommand::runCommand)))));
+    }
+
+    private static int runCommand(CommandContext<ServerCommandSource> context) {
+        ServerCommandSource source = context.getSource();
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
+
+        if (tardis.crash().getRepairTicks() >= TardisCrashHandler.MAX_REPAIR_TICKS) {
+            source.sendMessage(Text.translatableWithFallback("tardis.repair.max", "TARDIS repair ticks are at max!"));
+            return 0;
+        }
+
+        int repairTicksAmount = IntegerArgumentType.getInteger(context, "ticks");
+        tardis.crash().setRepairTicks(repairTicksAmount);
+
+        source.sendMessage(Text.translatableWithFallback("tardis.repair.set", "Set repair ticks for [%s] to: [%s]",
+                tardis.getUuid(), tardis.crash().getRepairTicks()));
+
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/SetSiegeInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetSiegeInteriorCommand.java
@@ -1,0 +1,33 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.minecraft.server.command.ServerCommandSource;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.world.TardisServerWorld;
+
+public class SetSiegeInteriorCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("siege")
+                .requires(source -> source.hasPermissionLevel(2))
+                        .then(argument("siege", BoolArgumentType.bool()).executes(SetSiegeInteriorCommand::runCommand))));
+    }
+
+    // TODO: improve feedback
+    private static int runCommand(CommandContext<ServerCommandSource> context) {
+        ServerTardis tardis = ((TardisServerWorld) context.getSource().getWorld()).getTardis();
+        boolean sieged = BoolArgumentType.getBool(context, "siege");
+
+        tardis.siege().setActive(sieged);
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/TriggerMoodRollInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/TriggerMoodRollInteriorCommand.java
@@ -1,0 +1,33 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+
+import net.minecraft.server.command.ServerCommandSource;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.api.tardis.TardisComponent;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.tardis.handler.mood.MoodHandler;
+import dev.amble.ait.core.world.TardisServerWorld;
+
+public class TriggerMoodRollInteriorCommand {
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("trigger-mood-roll")
+                .requires(source -> source.hasPermissionLevel(2))
+                        .executes(TriggerMoodRollInteriorCommand::triggerMoodRollCommand)));
+    }
+
+    private static int triggerMoodRollCommand(CommandContext<ServerCommandSource> context) {
+
+        ServerTardis tardis = ((TardisServerWorld) context.getSource().getWorld()).getTardis();
+
+        tardis.<MoodHandler>handler(TardisComponent.Id.MOOD).rollForMoodDictatedEvent();
+
+        return Command.SINGLE_SUCCESS;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/commands/UnlockInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/UnlockInteriorCommand.java
@@ -1,0 +1,88 @@
+package dev.amble.ait.core.commands;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import dev.amble.lib.api.Identifiable;
+import dev.amble.lib.register.unlockable.Unlockable;
+import dev.amble.lib.register.unlockable.UnlockableRegistry;
+
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.api.Nameable;
+import dev.amble.ait.core.commands.argument.IdentifierWildcardArgumentType;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.world.TardisServerWorld;
+import dev.amble.ait.data.Wildcard;
+import dev.amble.ait.registry.impl.DesktopRegistry;
+import dev.amble.ait.registry.impl.console.variant.ConsoleVariantRegistry;
+import dev.amble.ait.registry.impl.exterior.ExteriorVariantRegistry;
+
+public class UnlockInteriorCommand {
+
+    public static final SuggestionProvider<ServerCommandSource> CONSOLE_SUGGESTION = (context,
+            builder) -> IdentifierWildcardArgumentType.suggestWildcardIds(builder,
+                    ConsoleVariantRegistry.getInstance());
+    public static final SuggestionProvider<ServerCommandSource> DESKTOP_SUGGESTION = (context,
+            builder) -> IdentifierWildcardArgumentType.suggestWildcardIds(builder, DesktopRegistry.getInstance());
+    public static final SuggestionProvider<ServerCommandSource> EXTERIOR_SUGGESTION = (context,
+            builder) -> IdentifierWildcardArgumentType.suggestWildcardIds(builder,
+                    ExteriorVariantRegistry.getInstance());
+
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("unlock")
+                .requires(source -> source.hasPermissionLevel(2))
+                        .then(literal("console").then(argument("console", IdentifierWildcardArgumentType.wildcard())
+                                .suggests(CONSOLE_SUGGESTION).executes(UnlockInteriorCommand::unlockConsole)))
+                        .then(literal("desktop").then(argument("desktop", IdentifierWildcardArgumentType.wildcard())
+                                .suggests(DESKTOP_SUGGESTION).executes(UnlockInteriorCommand::unlockDesktop)))
+                        .then(literal("exterior").then(argument("exterior", IdentifierWildcardArgumentType.wildcard())
+                                .suggests(EXTERIOR_SUGGESTION).executes(UnlockInteriorCommand::unlockExterior)))));
+    }
+
+    private static <T extends Identifiable & Unlockable & Nameable> int unlock(
+            CommandContext<ServerCommandSource> context, String type, Wildcard<T> wildcard,
+            UnlockableRegistry<T> registry) {
+        ServerCommandSource source = context.getSource();
+        ServerTardis tardis = ((TardisServerWorld) source.getWorld()).getTardis();
+
+        if (wildcard.isPresent()) {
+            T t = wildcard.get();
+            source.getServer().execute(() -> tardis.stats().unlock(t));
+
+            source.sendMessage(Text.translatableWithFallback("command.ait.unlock.some", "Granted [%s] %s %s",
+                    tardis.getUuid(), t.name(), type));
+
+            return Command.SINGLE_SUCCESS;
+        }
+
+        source.getServer().execute(() -> registry.unlockAll(tardis));
+        source.sendMessage(Text.translatableWithFallback("command.ait.unlock.all", "Granted [%s] every %s",
+                tardis.getUuid(), type));
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int unlockConsole(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        return unlock(context, "console", IdentifierWildcardArgumentType.getConsoleVariantArgument(context, "console"),
+                ConsoleVariantRegistry.getInstance());
+    }
+
+    private static int unlockDesktop(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        return unlock(context, "desktop", IdentifierWildcardArgumentType.getDesktopArgument(context, "desktop"),
+                DesktopRegistry.getInstance());
+    }
+
+    private static int unlockExterior(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        return unlock(context, "exterior variant",
+                IdentifierWildcardArgumentType.getExteriorVariantArgument(context, "exterior"),
+                ExteriorVariantRegistry.getInstance());
+    }
+}


### PR DESCRIPTION
## About the PR
I added interior-only commands that can be run from the interior without having to use the tardis id of the tardis you're targeting.

## Why / Balance
Having to constantly remember a tardis' id is super annoying, and most of the time that im using the tardis id specific commands, I'm inside of that tardis anyway.

## Technical details
Just made it so it gets the tardis from the serverWorld, looks like "ServerTardis tardis = ((TardisServerWorld) source.getWorld).getTardis();" inside of new command classes called <TardisCommand>InteriorCommand.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NEEDS TO HAVE WARNINGS AND FAIL CASES SO IT DOESN'T CRASH PEOPLE THAT ARE OUTSIDE OF A TARDIS.

:cl:
- Added interior-executable commands.