### PR TITLE
Armor Stand Rendering For Our Custom Render Features

### DIFF
--- a/src/main/java/dev/amble/ait/client/renderers/wearables/RespiratorFeatureRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/wearables/RespiratorFeatureRenderer.java
@@ -10,8 +10,7 @@ import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.feature.FeatureRenderer;
 import net.minecraft.client.render.entity.feature.FeatureRendererContext;
-import net.minecraft.client.render.entity.model.EntityModelLoader;
-import net.minecraft.client.render.entity.model.PlayerEntityModel;
+import net.minecraft.client.render.entity.model.*;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
@@ -24,7 +23,7 @@ import dev.amble.ait.client.models.wearables.RespiratorModel;
 import dev.amble.ait.core.AITItems;
 
 @Environment(value = EnvType.CLIENT)
-public class RespiratorFeatureRenderer<T extends LivingEntity, M extends PlayerEntityModel<T>>
+public class RespiratorFeatureRenderer<T extends LivingEntity, M extends EntityModel<T> & ModelWithArms>
         extends
             FeatureRenderer<T, M> {
 
@@ -47,18 +46,18 @@ public class RespiratorFeatureRenderer<T extends LivingEntity, M extends PlayerE
         if (!(stack.isOf(AITItems.RESPIRATOR) || stack.isOf(AITItems.FACELESS_RESPIRATOR)))
             return;
 
-        if (!(livingEntity instanceof AbstractClientPlayerEntity && livingEntity instanceof ArmorStandEntity))
-            return;
+        if (livingEntity instanceof AbstractClientPlayerEntity || livingEntity instanceof ArmorStandEntity) {
 
-        matrixStack.push();
+            matrixStack.push();
 
-        this.model.mask.copyTransform(this.getContextModel().head);
-        this.model.setAngles(livingEntity, f, g, j, k, l);
+            this.model.mask.copyTransform(((BipedEntityModel)this.getContextModel()).head);
+            this.model.setAngles(livingEntity, f, g, j, k, l);
 
-        VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(RenderLayer.getEntitySmoothCutout(
-                stack.getItem() == AITItems.RESPIRATOR ? RESPIRATOR : FACELESS_RESPIRATOR));
-        this.model.render(matrixStack, vertexConsumer, i, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1f);
+            VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(RenderLayer.getEntitySmoothCutout(
+                    stack.getItem() == AITItems.RESPIRATOR ? RESPIRATOR : FACELESS_RESPIRATOR));
+            this.model.render(matrixStack, vertexConsumer, i, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1f);
 
-        matrixStack.pop();
+            matrixStack.pop();
+        }
     }
 }

--- a/src/main/java/dev/amble/ait/mixin/client/rendering/ArmorStandEntityRendererMixin.java
+++ b/src/main/java/dev/amble/ait/mixin/client/rendering/ArmorStandEntityRendererMixin.java
@@ -1,0 +1,36 @@
+package dev.amble.ait.mixin.client.rendering;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.render.entity.ArmorStandEntityRenderer;
+import net.minecraft.client.render.entity.EntityRendererFactory;
+import net.minecraft.client.render.entity.LivingEntityRenderer;
+import net.minecraft.client.render.entity.model.ArmorStandArmorEntityModel;
+import net.minecraft.client.render.entity.model.ArmorStandEntityModel;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+
+import dev.amble.ait.client.renderers.wearables.RespiratorFeatureRenderer;
+import dev.amble.ait.module.planet.client.renderers.wearables.SpacesuitFeatureRenderer;
+
+
+@Mixin(ArmorStandEntityRenderer.class)
+public abstract class ArmorStandEntityRendererMixin
+        extends
+            LivingEntityRenderer<ArmorStandEntity, ArmorStandArmorEntityModel> {
+
+    public ArmorStandEntityRendererMixin(EntityRendererFactory.Context ctx, ArmorStandEntityModel model,
+                                         float shadowRadius) {
+        super(ctx, model, shadowRadius);
+    }
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void ait$armorStandEntityRenderer(EntityRendererFactory.Context ctx, CallbackInfo ci) {
+        ArmorStandEntityRenderer renderer = (ArmorStandEntityRenderer) (Object) this;
+
+        this.addFeature(new RespiratorFeatureRenderer<>(renderer, ctx.getModelLoader()));
+        this.addFeature(new SpacesuitFeatureRenderer<>(renderer, ctx.getModelLoader()));
+    }
+}

--- a/src/main/java/dev/amble/ait/module/planet/client/renderers/wearables/SpacesuitFeatureRenderer.java
+++ b/src/main/java/dev/amble/ait/module/planet/client/renderers/wearables/SpacesuitFeatureRenderer.java
@@ -10,8 +10,7 @@ import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.feature.FeatureRenderer;
 import net.minecraft.client.render.entity.feature.FeatureRendererContext;
-import net.minecraft.client.render.entity.model.EntityModelLoader;
-import net.minecraft.client.render.entity.model.PlayerEntityModel;
+import net.minecraft.client.render.entity.model.*;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
@@ -24,7 +23,7 @@ import dev.amble.ait.module.planet.client.models.wearables.SpacesuitModel;
 import dev.amble.ait.module.planet.core.item.SpacesuitItem;
 
 @Environment(value = EnvType.CLIENT)
-public class SpacesuitFeatureRenderer<T extends LivingEntity, M extends PlayerEntityModel<T>>
+public class SpacesuitFeatureRenderer<T extends LivingEntity, M extends EntityModel<T> & ModelWithArms>
         extends
             FeatureRenderer<T, M> {
 
@@ -41,7 +40,7 @@ public class SpacesuitFeatureRenderer<T extends LivingEntity, M extends PlayerEn
     public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i, T livingEntity,
                        float f, float g, float h, float j, float k, float l) {
 
-        if (!(livingEntity instanceof AbstractClientPlayerEntity && livingEntity instanceof ArmorStandEntity))
+        if (!(livingEntity instanceof AbstractClientPlayerEntity || livingEntity instanceof ArmorStandEntity))
             return;
 
         matrixStack.push();
@@ -57,12 +56,12 @@ public class SpacesuitFeatureRenderer<T extends LivingEntity, M extends PlayerEn
             }
         }
 
-        this.model.Head.copyTransform(getContextModel().head);
-        this.model.Body.copyTransform(getContextModel().body);
-        this.model.LeftArm.copyTransform(getContextModel().leftArm);
-        this.model.RightArm.copyTransform(getContextModel().rightArm);
-        this.model.LeftLeg.copyTransform(getContextModel().leftLeg);
-        this.model.RightLeg.copyTransform(getContextModel().rightLeg);
+        this.model.Head.copyTransform(((BipedEntityModel) getContextModel()).head);
+        this.model.Body.copyTransform(((BipedEntityModel) getContextModel()).body);
+        this.model.LeftArm.copyTransform(((BipedEntityModel) getContextModel()).leftArm);
+        this.model.RightArm.copyTransform(((BipedEntityModel) getContextModel()).rightArm);
+        this.model.LeftLeg.copyTransform(((BipedEntityModel) getContextModel()).leftLeg);
+        this.model.RightLeg.copyTransform(((BipedEntityModel) getContextModel()).rightLeg);
         this.model.setAngles(livingEntity, f, g, j, k, l);
 
         VertexConsumer vertexConsumer = vertexConsumerProvider.getBuffer(RenderLayer.getEntityCutoutNoCullZOffset(BLANK_SPACESUIT));

--- a/src/main/resources/ait.mixins.json
+++ b/src/main/resources/ait.mixins.json
@@ -39,6 +39,7 @@
     "client.experimental_screen.CreateWorldScreenMixin",
     "client.experimental_screen.WorldOpenFlowsMixin",
     "client.rendering.ArmorFeatureRendererMixin",
+    "client.rendering.ArmorStandEntityRendererMixin",
     "client.rendering.BakedModelManagerMixin",
     "client.rendering.BGRendererMixin",
     "client.rendering.DebugRendererMixin",


### PR DESCRIPTION
## About the PR
I added a mixin to the ArmorStandEntityRenderer to add our features so they render on the model properly, and I modified the RenderFeatures we have to allow for the armor stand's BipedModel versus just using the player's model.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).

## Changelog
:cl:
- fix: armor stand renders respirators and other stuff correctly now