### PR TITLE
fix: PlanetBlocks loottables / swords are less OP

### DIFF
--- a/src/main/java/dev/amble/ait/module/planet/core/PlanetBlocks.java
+++ b/src/main/java/dev/amble/ait/module/planet/core/PlanetBlocks.java
@@ -27,45 +27,46 @@ public class PlanetBlocks extends BlockContainer {
 
     // Mars
 
-    // Stone
+        // Stone
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_STONE = new Block(
             AbstractBlock.Settings.copy(Blocks.STONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_STONE_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.STONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_STONE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.STONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_STONE_STAIRS = new StairsBlock(
             MARTIAN_STONE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.STONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_STONE_BUTTON = new ButtonBlock(
             AbstractBlock.Settings.copy(Blocks.STONE_BUTTON), BlockSetType.STONE, 10, false);
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_STONE_PRESSURE_PLATE  = new PressurePlateBlock(
             PressurePlateBlock.ActivationRule.EVERYTHING, AbstractBlock.Settings.copy(Blocks.STONE_PRESSURE_PLATE),BlockSetType.STONE);
 
-    // Ores
+        // Ores
+
     @AutomaticModel
     @PickaxeMineable(tool = PickaxeMineable.Tool.NONE)
     public static final Block MARTIAN_COAL_ORE = new Block(
             AbstractBlock.Settings.copy(Blocks.COAL_ORE));
 
     @AutomaticModel
-    @PickaxeMineable(tool = PickaxeMineable.Tool.STONE)
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_COPPER_ORE = new Block(
             AbstractBlock.Settings.copy(Blocks.COPPER_ORE));
 
     @AutomaticModel
-    @PickaxeMineable(tool = PickaxeMineable.Tool.STONE)
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_IRON_ORE = new Block(
             AbstractBlock.Settings.copy(Blocks.IRON_ORE));
 
@@ -94,162 +95,168 @@ public class PlanetBlocks extends BlockContainer {
     public static final Block MARTIAN_EMERALD_ORE = new Block(
             AbstractBlock.Settings.copy(Blocks.EMERALD_ORE));
 
-    // Cobblestone
-    @PickaxeMineable
+        // Cobblestone
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_COBBLESTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.COBBLESTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_COBBLESTONE_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.COBBLESTONE_WALL));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     @NoBlockDrop
     public static final Block MARTIAN_COBBLESTONE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.COBBLESTONE_SLAB));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_COBBLESTONE_STAIRS = new StairsBlock(
             MARTIAN_COBBLESTONE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.COBBLESTONE_STAIRS));
 
-    // Mossy Cobblestone
-    @PickaxeMineable
+        // Mossy Cobblestone
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOSSY_MARTIAN_COBBLESTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.MOSSY_COBBLESTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOSSY_MARTIAN_COBBLESTONE_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.MOSSY_COBBLESTONE_WALL));
 
-    @PickaxeMineable
-    @NoBlockDrop
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOSSY_MARTIAN_COBBLESTONE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.MOSSY_COBBLESTONE_SLAB));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOSSY_MARTIAN_COBBLESTONE_STAIRS = new StairsBlock(
             MOSSY_MARTIAN_COBBLESTONE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.MOSSY_COBBLESTONE_STAIRS));
 
-    // Polished Stone
-    @PickaxeMineable
+        // Polished Stone
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block POLISHED_MARTIAN_STONE = new Block(
             AbstractBlock.Settings.copy(Blocks.POLISHED_ANDESITE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block POLISHED_MARTIAN_STONE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.POLISHED_ANDESITE_SLAB));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block POLISHED_MARTIAN_STONE_STAIRS = new StairsBlock(
             POLISHED_MARTIAN_STONE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.POLISHED_ANDESITE_STAIRS));
 
 
-    // Smooth Stone
-    @PickaxeMineable
+        // Smooth Stone
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block SMOOTH_MARTIAN_STONE = new Block(
             AbstractBlock.Settings.copy(Blocks.SMOOTH_STONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     @NoBlockDrop
     public static final Block SMOOTH_MARTIAN_STONE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.SMOOTH_STONE_SLAB));
 
-    // Sand
+        // Sand
 
     public static final Block MARTIAN_SAND = new FallingBlock(
             AbstractBlock.Settings.copy(Blocks.SAND));
 
-    // Martian Sandstone
+        // Martian Sandstone
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_SANDSTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_SANDSTONE_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_SANDSTONE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_SANDSTONE_BRICK_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_SANDSTONE_BRICK_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_SANDSTONE_BRICK_STAIRS = new StairsBlock(
             POLISHED_MARTIAN_STONE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_SANDSTONE_STAIRS = new StairsBlock(
             POLISHED_MARTIAN_STONE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CRACKED_MARTIAN_SANDSTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block POLISHED_MARTIAN_SANDSTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_SANDSTONE_PILLAR = new PillarBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_SANDSTONE_BRICKS = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CRACKED_MARTIAN_SANDSTONE_BRICKS = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CHISELED_MARTIAN_SANDSTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
 
-    // Bricks
-    @PickaxeMineable
+        // Bricks
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_BRICKS = new Block(
             AbstractBlock.Settings.copy(Blocks.STONE_BRICKS));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_BRICK_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.STONE_BRICK_SLAB));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_BRICK_STAIRS = new StairsBlock(
             MARTIAN_BRICKS.getDefaultState(), AbstractBlock.Settings.copy(Blocks.STONE_BRICK_STAIRS));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_BRICK_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.STONE_BRICK_WALL));
 
-    // Other
-    @PickaxeMineable
+        // Other
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MARTIAN_PILLAR = new PillarBlock(
             AbstractBlock.Settings.copy(Blocks.QUARTZ_PILLAR));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CHISELED_MARTIAN_STONE = new Block(
             AbstractBlock.Settings.copy(Blocks.CHISELED_STONE_BRICKS));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CRACKED_MARTIAN_BRICKS = new Block(
             AbstractBlock.Settings.copy(Blocks.CRACKED_STONE_BRICKS));
 
-    // Infested Blocks
-    @PickaxeMineable
+        // Infested Blocks
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block INFESTED_MARTIAN_STONE = new InfestedBlock(
             Blocks.INFESTED_STONE, AbstractBlock.Settings.copy(Blocks.INFESTED_STONE));
 
-    @PickaxeMineable
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block INFESTED_MARTIAN_COBBLESTONE = new InfestedBlock(
             Blocks.INFESTED_COBBLESTONE, AbstractBlock.Settings.copy(Blocks.INFESTED_COBBLESTONE));
 
@@ -257,20 +264,25 @@ public class PlanetBlocks extends BlockContainer {
 
     // Moon
 
-    // Anorthosite
+        // Anorthosite
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE = new Block(
             AbstractBlock.Settings.copy(Blocks.STONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.STONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.STONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_STAIRS = new StairsBlock(
             ANORTHOSITE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.STONE));
 
-    // Ores
+        // Ores
 
     @AutomaticModel
     @PickaxeMineable(tool = PickaxeMineable.Tool.NONE)
@@ -278,12 +290,12 @@ public class PlanetBlocks extends BlockContainer {
             AbstractBlock.Settings.copy(Blocks.COAL_ORE));
 
     @AutomaticModel
-    @PickaxeMineable(tool = PickaxeMineable.Tool.STONE)
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_COPPER_ORE = new Block(
             AbstractBlock.Settings.copy(Blocks.COPPER_ORE));
 
     @AutomaticModel
-    @PickaxeMineable(tool = PickaxeMineable.Tool.STONE)
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_IRON_ORE = new Block(
             AbstractBlock.Settings.copy(Blocks.IRON_ORE));
 
@@ -312,94 +324,119 @@ public class PlanetBlocks extends BlockContainer {
     public static final Block ANORTHOSITE_EMERALD_ORE = new Block(
             AbstractBlock.Settings.copy(Blocks.EMERALD_ORE));
 
-    // Polished Stone
+        // Polished Stone
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block POLISHED_ANORTHOSITE = new Block(
             AbstractBlock.Settings.copy(Blocks.POLISHED_ANDESITE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block POLISHED_ANORTHOSITE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.POLISHED_ANDESITE_SLAB));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block POLISHED_ANORTHOSITE_STAIRS = new StairsBlock(
             POLISHED_ANORTHOSITE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.POLISHED_ANDESITE_STAIRS));
 
-    // Smooth Stone
+        // Smooth Stone
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block SMOOTH_ANORTHOSITE = new Block(
             AbstractBlock.Settings.copy(Blocks.SMOOTH_STONE));
 
-    @NoBlockDrop
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block SMOOTH_ANORTHOSITE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.SMOOTH_STONE_SLAB));
 
-    // Sand (Regolith)
+        // Sand (Regolith)
+
     public static final Block REGOLITH = new FallingBlock(
             AbstractBlock.Settings.copy(Blocks.SAND));
 
-    // Sandstone
+        // Sandstone
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOON_SANDSTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOON_SANDSTONE_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOON_SANDSTONE_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOON_SANDSTONE_STAIRS = new StairsBlock(
             POLISHED_MARTIAN_STONE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CRACKED_MOON_SANDSTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block POLISHED_MOON_SANDSTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOON_SANDSTONE_PILLAR = new PillarBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOON_SANDSTONE_BRICKS = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOON_SANDSTONE_BRICK_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOON_SANDSTONE_BRICK_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block MOON_SANDSTONE_BRICK_STAIRS = new StairsBlock(
             POLISHED_MARTIAN_STONE.getDefaultState(), AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CRACKED_MOON_SANDSTONE_BRICKS = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CHISELED_MOON_SANDSTONE = new Block(
             AbstractBlock.Settings.copy(Blocks.SANDSTONE));
 
-    // Bricks
+        // Bricks
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_BRICKS = new Block(
             AbstractBlock.Settings.copy(Blocks.STONE_BRICKS));
 
 
-    @NoBlockDrop
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_BRICK_SLAB = new SlabBlock(
             AbstractBlock.Settings.copy(Blocks.STONE_BRICK_SLAB));
 
-
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_BRICK_STAIRS = new StairsBlock(
             ANORTHOSITE_BRICKS.getDefaultState(), AbstractBlock.Settings.copy(Blocks.STONE_BRICK_STAIRS));
 
-
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_BRICK_WALL = new WallBlock(
             AbstractBlock.Settings.copy(Blocks.STONE_BRICK_WALL));
 
-    // Other
+        // Other
+
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block ANORTHOSITE_PILLAR = new PillarBlock(
             AbstractBlock.Settings.copy(Blocks.QUARTZ_PILLAR));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CHISELED_ANORTHOSITE = new Block(
             AbstractBlock.Settings.copy(Blocks.CHISELED_STONE_BRICKS));
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block CRACKED_ANORTHOSITE_BRICKS = new Block(
             AbstractBlock.Settings.copy(Blocks.CRACKED_STONE_BRICKS));
 

--- a/src/main/java/dev/amble/ait/module/planet/core/PlanetItems.java
+++ b/src/main/java/dev/amble/ait/module/planet/core/PlanetItems.java
@@ -31,13 +31,13 @@ public class PlanetItems extends ItemContainer {
 
     // TOOLS
 
-    public static final Item MARTIAN_STONE_SWORD = new SwordItem(PlanetToolMaterial.MARTIAN_STONE, 5, 3f, new AItemSettings());
+    public static final Item MARTIAN_STONE_SWORD = new SwordItem(PlanetToolMaterial.MARTIAN_STONE, 3, -2.4f, new AItemSettings());
     public static final Item MARTIAN_STONE_SHOVEL = new ShovelItem(PlanetToolMaterial.MARTIAN_STONE, 0, 0f, new AItemSettings());
     public static final Item MARTIAN_STONE_PICKAXE = new PickaxeItem(PlanetToolMaterial.MARTIAN_STONE, 2, 2f, new AItemSettings());
     public static final Item MARTIAN_STONE_AXE = new AxeItem(PlanetToolMaterial.MARTIAN_STONE, 3, 1f, new AItemSettings());
     public static final Item MARTIAN_STONE_HOE = new HoeItem(PlanetToolMaterial.MARTIAN_STONE, 1, 2f, new AItemSettings());
 
-    public static final Item ANORTHOSITE_SWORD = new AnorthositeSwordItem(PlanetToolMaterial.ANORTHOSITE, 5, 3f, new AItemSettings());
+    public static final Item ANORTHOSITE_SWORD = new AnorthositeSwordItem(PlanetToolMaterial.ANORTHOSITE, 3, -2.4f, new AItemSettings());
     public static final Item ANORTHOSITE_SHOVEL = new ShovelItem(PlanetToolMaterial.ANORTHOSITE, 0, 0f, new AItemSettings());
     public static final Item ANORTHOSITE_PICKAXE = new PickaxeItem(PlanetToolMaterial.ANORTHOSITE, 2, 2f, new AItemSettings());
     public static final Item ANORTHOSITE_AXE = new AxeItem(PlanetToolMaterial.ANORTHOSITE, 3, 1f, new AItemSettings());


### PR DESCRIPTION
## About the PR
I made the planet themed swords less OP, i also fixed all the planet block loottables and pickaxe level being non existant

## Why / Balance
The swords had an attack speed of 7 (minecrafts default for most swords is 1.6). Most of the planet blocks did not drop their items.

## Technical details
- added `@PickaxeMineable(tool = PickaxeMineable.Tool.IRON)` to blocks that where missing it in the `PlanetBlocks` class
- changed `ANORTHOSITE_SWORD` and `MARTIAN_STONE_SWORD` `attackspeed` from `3` to `-2.4` in the `PlanetItems` class

## Media
No "in-game" changes where made (just code based)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nothing was broken in this branch, just fixed 

**Changelog**
- Fix: made planet swords have less attack speed (less OP)
- Fix: planet block loottables and pickaxeminable level