### PR TITLE
fix: handles can no longer bypass security protocols

### DIFF
--- a/src/main/java/dev/amble/ait/core/handles/HandlesResponse.java
+++ b/src/main/java/dev/amble/ait/core/handles/HandlesResponse.java
@@ -46,6 +46,7 @@ public interface HandlesResponse extends Identifiable {
         source.playSound(successSound(), SoundCategory.PLAYERS, 1.0f, 1.0f);
         return true;
     }
+
     default boolean failure(HandlesSound source) {
         source.playSound(failureSound(), SoundCategory.PLAYERS, 1.0f, 1.0f);
         return false;
@@ -66,6 +67,13 @@ public interface HandlesResponse extends Identifiable {
      */
     default boolean isCommand(String command) {
         return getCommandWords().contains(command.toLowerCase());
+    }
+
+    /**
+     * @return Whether a non-secure person can run the command when P19 is on.
+     */
+    default boolean requiresSudo() {
+        return true;
     }
 
     /**


### PR DESCRIPTION
## About the PR
This PR fixes #1270.

## Why / Balance
Previously, handles allowed to bypass the P19 protocol.

## Technical details
The PR adds a "requiresSudo" method, which, when overriden, can define whether a certain command requires a security check when P19 is on.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: handles can no longer bypass P19