### PR TITLE
fix: use min loyalty security setting properly

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/SecurityControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/SecurityControl.java
@@ -64,7 +64,7 @@ public class SecurityControl extends Control {
         if (player.hasPermissionLevel(2))
             return true;
 
-        if (!tardis.loyalty().get(player).isOf(Loyalty.Type.COMPANION))
+        if (!tardis.loyalty().get(player).isOf(tardis.permissions().p19Loyalty().get()))
             return false;
 
         if (!KeyItem.isKeyInInventory(player))

--- a/src/main/java/dev/amble/ait/core/tardis/handler/permissions/PermissionHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/permissions/PermissionHandler.java
@@ -40,8 +40,6 @@ public class PermissionHandler extends KeyedTardisComponent {
     }
 
     static {
-        // TODO: make properties have a built-in util to C->S
-        // YES PLEASE :)))
         ServerPlayNetworking.registerGlobalReceiver(P19_LOYALTY_SYNC,
                 ServerTardisManager.receiveTardis((tardis, server, player, handler, buf, responseSender) -> {
                     if (tardis == null)


### PR DESCRIPTION
## About the PR
This PR fixes min loyalty setting (#1263). Previously, this value was ignored.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: dont ignore isomophic level setting