### PR TITLE
fix: disable autopilot after growth land

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -95,6 +95,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
             if (!tardis.isGrowth())
                 return TardisEvents.Interaction.PASS;
 
+            tardis.travel().autopilot(false);
             tardis.getExterior().setType(CategoryRegistry.CAPSULE);
             tardis.getExterior().setVariant(ExteriorVariantRegistry.CAPSULE_DEFAULT);
             return TardisEvents.Interaction.SUCCESS; // force mat even if checks fail


### PR DESCRIPTION
## About the PR
This PR automatically disables autopilot after growth tardis lands.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: disable autopilot after growth land