### PR TITLE
perf: improve siege tardis ticking

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
@@ -182,16 +182,8 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
         if (!tardis.travel().isLanded())
             return;
 
-
-        /*if (tardis.stats().getTargetWorld() != null &&
-                !tardis.stats().getTargetWorld().equals
-                        (tardis.asServer().getInteriorWorld().getRegistryKey()))
-            tardis.stats().setTargetWorld(this,
-                tardis.asServer().getInteriorWorld().getRegistryKey(), tardis.getDesktop().getDoorPos().getPos(), true);*/
-
         tardis.door().interact((ServerWorld) this.getWorld(), this.getPos(), (ServerPlayerEntity) player);
     }
-
 
     /**
      * Validates the exterior position of the TARDIS

--- a/src/main/java/dev/amble/ait/core/blocks/ExteriorBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/ExteriorBlock.java
@@ -289,26 +289,17 @@ public class ExteriorBlock extends Block implements BlockEntityProvider, ICantBr
     @Override
     public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand,
                               BlockHitResult hit) {
+        if (world.isClient())
+            return ActionResult.SUCCESS;
 
+        if (!(world.getBlockEntity(pos) instanceof ExteriorBlockEntity exterior))
+            return ActionResult.CONSUME;
 
-        BlockEntity blockEntity = world.getBlockEntity(pos);
+        if (exterior.tardis().isEmpty())
+            return ActionResult.FAIL;
 
-
-        if (blockEntity instanceof ExteriorBlockEntity exterior) {
-
-            //exterior.sitOn(state, world, pos, player, hand, hit);
-
-            if (world.isClient()) {
-                return ActionResult.SUCCESS;
-            }
-
-            if (exterior.tardis().isEmpty()) {
-                return ActionResult.FAIL;
-            }
-            if (hit.getSide() != Direction.UP) {
-                exterior.useOn((ServerWorld) world, player.isSneaking(), player);
-            }
-        }
+        if (hit.getSide() != Direction.UP)
+            exterior.useOn((ServerWorld) world, player.isSneaking(), player);
 
         return ActionResult.CONSUME; // Consume the event regardless of the outcome
     }

--- a/src/main/java/dev/amble/ait/core/tardis/handler/SiegeHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/SiegeHandler.java
@@ -47,13 +47,13 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
     private static final Property<UUID> HELD_KEY = new Property<>(Property.Type.UUID, "siege_held_uuid", new UUID(0, 0));
     private static final Property<Identifier> TEXTURE = new Property<>(Property.Type.IDENTIFIER, "texture", DEFAULT_TEXTURRE);
 
-    private static final IntProperty SIEGE_TIME = new IntProperty("siege_time", 0);
     private static final BoolProperty ACTIVE = new BoolProperty("siege_mode", false);
 
     private final Value<UUID> heldKey = HELD_KEY.create(this);
-    private final IntValue siegeTime = SIEGE_TIME.create(this);
     private final BoolValue active = ACTIVE.create(this);
     private final Value<Identifier> texture = TEXTURE.create(this);
+
+    private int siegeTime;
 
     public SiegeHandler() {
         super(Id.SIEGE);
@@ -87,7 +87,6 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
     @Override
     public void onLoaded() {
         active.of(this, ACTIVE);
-        siegeTime.of(this, SIEGE_TIME);
         heldKey.of(this, HELD_KEY);
         texture.of(this, TEXTURE);
     }
@@ -108,16 +107,13 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
     }
 
     public void setSiegeBeingHeld(UUID playerId) {
-        if (playerId != null)
+        if (playerId != null) {
             this.tardis.door().closeDoors();
             this.tardis.door().setLocked(true);
             this.tardis.alarm().enabled().set(true);
+        }
 
         this.heldKey.set(playerId);
-    }
-
-    public int getTimeInSiegeMode() {
-        return this.siegeTime.get();
     }
 
     public void setActive(boolean siege) {
@@ -130,6 +126,8 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
             sound = AITSounds.SIEGE_ENABLE;
             this.tardis.door().closeDoors();
             this.tardis.door().setLocked(true);
+            this.tardis.door().setDeadlocked(true);
+
             this.tardis.fuel().disablePower();
 
             TardisUtil.giveEffectToInteriorPlayers(this.tardis.asServer(),
@@ -138,10 +136,13 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
             sound = AITSounds.SIEGE_DISABLE;
             this.tardis.door().setDeadlocked(false);
             this.tardis.door().setLocked(false);
+
             this.tardis.alarm().enabled().set(false);
 
             if (this.tardis.getExterior().findExteriorBlock().isEmpty())
                 this.tardis.travel().placeExterior(false);
+
+            this.siegeTime = 0;
         }
 
         for (BlockPos console : this.tardis.getDesktop().getConsolePos()) {
@@ -149,10 +150,7 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
         }
 
         this.tardis.removeFuel(0.01 * FuelHandler.TARDIS_MAX_FUEL * this.tardis.travel().instability());
-        this.tardis().door().closeDoors();
-        this.tardis.door().setLocked(true);
         this.active.set(siege);
-
     }
 
     @Override
@@ -160,30 +158,23 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
         if (!this.active.get())
             return;
 
-        this.siegeTime.flatMap(i -> this.active.get() ? i + 1 : 0);
+        this.siegeTime += 1;
 
-        if (server.getTicks() % 20 != 0)
+        if (server.getTicks() % 10 == 0)
             return;
 
-        boolean isHeld = this.isSiegeBeingHeld();
-        this.tardis.door().setDeadlocked(true);
-
-        if (isHeld && this.tardis.getExterior().findExteriorBlock().isPresent())
-            this.setSiegeBeingHeld(null);
-        this.tardis.door().closeDoors();
-        this.tardis.door().locked();
-        boolean freeze = !isHeld && this.getTimeInSiegeMode() > 60 * 20 && !this.tardis.subsystems().lifeSupport().isEnabled();
+        boolean freeze = this.siegeTime > 60 * 20 && !this.isSiegeBeingHeld()
+                && !this.tardis.subsystems().lifeSupport().isEnabled();
 
         for (ServerPlayerEntity player : TardisUtil.getPlayersInsideInterior(this.tardis.asServer())) {
-            if (!player.isAlive())
+            if (!player.isAlive() || !player.canFreeze())
                 continue;
 
-            if (!freeze || player.canFreeze()) {
+            if (freeze) {
+                this.freeze(player);
+            } else {
                 this.unfreeze(player);
-                continue;
             }
-
-            this.freeze(player);
         }
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
@@ -315,7 +315,7 @@ public class TardisUtil {
     }
 
     public static List<ServerPlayerEntity> getPlayersInsideInterior(ServerTardis tardis) {
-        return new ArrayList<>(tardis.getInteriorWorld().getPlayers());
+        return tardis.getInteriorWorld().getPlayers();
     }
 
     public static List<LivingEntity> getLivingInInterior(Tardis tardis, Predicate<LivingEntity> predicate) {


### PR DESCRIPTION
## About the PR
This PR improves siege mode performance.

## Technical details
Instead of ticking every non 20th tick (1, 2, 3, ..., 18, 19, 21) it will tick every 10th tick now. 
Also removed useless exterior block checks.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- perf: siege mode is no longer as performance heavy as it was