### PR TITLE
fix: linked item spam on unknown tardis

### DIFF
--- a/src/main/java/dev/amble/ait/api/tardis/link/LinkableItem.java
+++ b/src/main/java/dev/amble/ait/api/tardis/link/LinkableItem.java
@@ -87,6 +87,10 @@ public abstract class LinkableItem extends Item {
         return tardis.getUuid().equals(this.getTardisId(stack));
     }
 
+    public void unlink(ItemStack stack) {
+        stack.getOrCreateNbt().remove(this.path);
+    }
+
     public UUID getTardisId(ItemStack stack) {
         NbtCompound nbt = stack.getOrCreateNbt();
         NbtElement element = nbt.get(path);
@@ -110,9 +114,15 @@ public abstract class LinkableItem extends Item {
         if (world == null)
             return null;
 
-        return TardisManager.with(world, (o, manager) ->
-                manager.demandTardis(o, this.getTardisId(stack)));
+        Tardis tardis = TardisManager.with(world, (o, manager) -> manager.demandTardis(o, this.getTardisId(stack)));
+
+        if (tardis == null) {
+            this.unlink(stack);
+        }
+
+        return tardis;
     }
+
 
     public static <T> T apply(ItemStack stack, BiFunction<LinkableItem, ItemStack, T> f) {
         if (!(stack.getItem() instanceof LinkableItem linkable))


### PR DESCRIPTION
## About the PR
fixed spam console of a linked item to a exterior that doesn't exist

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed spam in the console of a linked item spamming in console that theres an unloaded tardis even though the tardis is deleted!
-->