### PR TITLE
fix: requeue the interior change on restart

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/ServerTardis.java
+++ b/src/main/java/dev/amble/ait/core/tardis/ServerTardis.java
@@ -51,12 +51,6 @@ public class ServerTardis extends Tardis {
 
     public void tick(MinecraftServer server) {
         this.getHandlers().tick(server);
-
-        // tell interior players how to fix growth every 10 seconds
-        if (this.isGrowth() && server.getTicks() % 200 == 0 && !this.interiorChangingHandler().queued().get()) {
-            if (this.interiorChangingHandler().hasEnoughPlasmicMaterial())
-                this.getInteriorWorld().getPlayers().forEach(player -> player.sendMessage(Text.translatable("tardis.message.growth.hint").formatted(Formatting.DARK_GRAY,Formatting.ITALIC), true));
-        }
     }
 
     public void markDirty(TardisComponent component) {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -68,9 +68,6 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
     private final BoolValue regenerating = REGENERATING.create(this);
 
     @Exclude
-    private Task<?> desktopTask;
-
-    @Exclude
     private List<ItemStack> restorationChestContents;
 
     public InteriorChangingHandler() {
@@ -328,7 +325,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
 
         if (!this.regenerating.get()) {
             tardis.getDesktop().startQueue(true);
-            this.desktopTask = Scheduler.get().runTaskLater(this::changeInterior, TimeUnit.SECONDS, 5);
+            Scheduler.get().runTaskLater(this::changeInterior, TimeUnit.SECONDS, 5);
 
             this.regenerating.set(true);
         }

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -82,8 +82,16 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         queued.of(this, QUEUED);
         regenerating.of(this, REGENERATING);
 
-        if (this.regenerating.get())
+        if (this.regenerating.get()) {
             this.regenerating.set(false);
+
+            TardisDesktopSchema queued = this.getQueuedInterior();
+
+            if (queued == null)
+                return;
+
+            tardis.interiorChangingHandler().queueInteriorChange(queued);
+        }
     }
 
     static {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -58,7 +58,10 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
     private static final Property<Identifier> QUEUED_INTERIOR_PROPERTY = new Property<>(Property.Type.IDENTIFIER, "queued_interior", new Identifier(""));
     private static final BoolProperty QUEUED = new BoolProperty("queued");
     private static final BoolProperty REGENERATING = new BoolProperty("regenerating");
+
     public static final int MAX_PLASMIC_MATERIAL_AMOUNT = 8;
+    private static final Text HINT_TEXT = Text.translatable("tardis.message.growth.hint").formatted(Formatting.DARK_GRAY, Formatting.ITALIC);
+
     private final Value<Identifier> queuedInterior = QUEUED_INTERIOR_PROPERTY.create(this);
     private static final IntProperty PLASMIC_MATERIAL_AMOUNT = new IntProperty("plasmic_material_amount");
     private final IntValue plasmicMaterialAmount = PLASMIC_MATERIAL_AMOUNT.create(this);
@@ -298,6 +301,10 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
             this.generateInteriorWithItem();
 
             if (!isQueued) {
+                if (server.getTicks() % 200 == 0 && this.hasEnoughPlasmicMaterial())
+                    this.tardis.asServer().getInteriorWorld().getPlayers().forEach(player ->
+                            player.sendMessage(HINT_TEXT, true));
+
                 if (this.tardis.door().isClosed()) {
                     this.tardis.door().openDoors();
                 } else {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -85,7 +85,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         queued.of(this, QUEUED);
         regenerating.of(this, REGENERATING);
 
-        if (this.regenerating.get()) {
+        if (this.isServer() && this.regenerating.get()) {
             this.regenerating.set(false);
 
             TardisDesktopSchema queued = this.getQueuedInterior();

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -82,14 +82,8 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         queued.of(this, QUEUED);
         regenerating.of(this, REGENERATING);
 
-        if (this.regenerating.get()) {
-            TardisDesktopSchema desktop = this.getQueuedInterior();
-
-            if (desktop == null)
-                return;
-
-            this.queueInteriorChange(desktop);
-        }
+        if (this.regenerating.get())
+            this.regenerating.set(false);
     }
 
     static {

--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -176,8 +176,6 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
                 }
 
                 tardis.door().closeDoors();
-                tardis.interiorChangingHandler().queued().set(false);
-                tardis.interiorChangingHandler().regenerating().set(false);
             }
 
             this.fileManager.saveTardis(server, this, tardis);


### PR DESCRIPTION
## About the PR
This PR fixes the interior not re-queuing after a restart.

## Why / Balance
This PR fixes a long standing issue in AIT: when a player queues an interior change and restarts the server (rejoins the world) - the interior change doesn't queue, the doors stay locked and etc.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: re-queue the interior change on restart