### PR TITLE
fix: kill interior drops on interior change end

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
@@ -205,15 +205,6 @@ public class TardisDesktop extends TardisComponent {
         this.tardis.door().setLocked(false);
         this.tardis.door().setDeadlocked(false);
         this.tardis.alarm().disable();
-
-        AITMod.LOGGER.info("Removing entities in {}", CORNERS.getBox().expand(0, 300, 0));
-
-        this.tardis.asServer().getInteriorWorld().getEntitiesByClass(
-                ItemEntity.class, CORNERS.getBox().expand(0, 300, 0), i -> true
-        ).forEach(itemEntity -> {
-            AITMod.LOGGER.info("removing {}", itemEntity);
-            itemEntity.discard();;
-        });
     }
 
     public ActionQueue changeInterior(TardisDesktopSchema schema, boolean clear, boolean sendEvent) {

--- a/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
@@ -206,9 +206,14 @@ public class TardisDesktop extends TardisComponent {
         this.tardis.door().setDeadlocked(false);
         this.tardis.alarm().disable();
 
+        AITMod.LOGGER.info("Removing entities in {}", CORNERS.getBox().expand(0, 300, 0));
+
         this.tardis.asServer().getInteriorWorld().getEntitiesByClass(
                 ItemEntity.class, CORNERS.getBox().expand(0, 300, 0), i -> true
-        ).forEach(Entity::discard);
+        ).forEach(itemEntity -> {
+            AITMod.LOGGER.info("removing {}", itemEntity);
+            itemEntity.discard();;
+        });
     }
 
     public ActionQueue changeInterior(TardisDesktopSchema schema, boolean clear, boolean sendEvent) {

--- a/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
@@ -11,6 +11,8 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.decoration.AbstractDecorationEntity;
+import net.minecraft.entity.decoration.painting.PaintingEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
@@ -184,6 +186,9 @@ public class TardisDesktop extends TardisComponent {
         ServerTardis tardis = this.tardis.asServer();
         ServerWorld world = tardis.getInteriorWorld();
         int chunkRadius = ChunkSectionPos.getSectionCoord(RADIUS);
+
+        TardisUtil.getEntitiesInBox(AbstractDecorationEntity.class, world, corners.getBox(), frame -> true)
+                .forEach(frame -> frame.remove(Entity.RemovalReason.DISCARDED));
 
         return new ChunkEraser.Builder().withFlags(Block.FORCE_STATE).build(
                 world, -chunkRadius, -chunkRadius, chunkRadius, chunkRadius

--- a/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
@@ -2,6 +2,7 @@ package dev.amble.ait.core.tardis;
 
 import java.util.*;
 
+import dev.amble.ait.core.tardis.util.TardisUtil;
 import dev.amble.lib.data.DirectedBlockPos;
 import dev.drtheo.queue.api.ActionQueue;
 import dev.drtheo.queue.api.util.block.ChunkEraser;

--- a/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
@@ -206,9 +206,9 @@ public class TardisDesktop extends TardisComponent {
         this.tardis.door().setDeadlocked(false);
         this.tardis.alarm().disable();
 
-        this.tardis.asServer().getInteriorWorld().getEntitiesByType(
-                TypeFilter.instanceOf(ItemEntity.class), i -> true
-        ).forEach(item -> item.remove(Entity.RemovalReason.DISCARDED));
+        this.tardis.asServer().getInteriorWorld().getEntitiesByClass(
+                ItemEntity.class, CORNERS.getBox().expand(0, 300, 0), i -> true
+        ).forEach(Entity::discard);
     }
 
     public ActionQueue changeInterior(TardisDesktopSchema schema, boolean clear, boolean sendEvent) {

--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -10,6 +10,8 @@ import dev.drtheo.multidim.api.MultiDimServerWorld;
 import dev.drtheo.multidim.api.WorldBlueprint;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.ItemEntity;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.world.ClientWorld;
@@ -39,6 +41,14 @@ public class TardisServerWorld extends MultiDimServerWorld {
 
     public TardisServerWorld(WorldBlueprint blueprint, MinecraftServer server, Executor workerExecutor, LevelStorage.Session session, ServerWorldProperties properties, RegistryKey<World> worldKey, DimensionOptions dimensionOptions, WorldGenerationProgressListener worldGenerationProgressListener, List<Spawner> spawners, @Nullable RandomSequencesState randomSequencesState, boolean created) {
         super(blueprint, server, workerExecutor, session, properties, worldKey, dimensionOptions, worldGenerationProgressListener, spawners, randomSequencesState, created);
+    }
+
+    @Override
+    public boolean spawnEntity(Entity entity) {
+        if (entity instanceof ItemEntity && tardis.interiorChangingHandler().regenerating().get())
+            return false;
+        
+        return super.spawnEntity(entity);
     }
 
     public void setTardis(ServerTardis tardis) {

--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -47,7 +47,7 @@ public class TardisServerWorld extends MultiDimServerWorld {
     public boolean spawnEntity(Entity entity) {
         if (entity instanceof ItemEntity && tardis.interiorChangingHandler().regenerating().get())
             return false;
-        
+
         return super.spawnEntity(entity);
     }
 


### PR DESCRIPTION
## About the PR
This PR makes it so the interior drops get removed after interior change sequence.
Closes #1296.

## Why / Balance
Previously, all the stuff like flower pots, signs, paintings, item frames, and etc would drop in the interior as entities after the interior reconfig. Now - they dont.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: kill interior drops after interior change