### PR TITLE
feat: you can now reference tardises around in commands (^ and ~)

### DIFF
--- a/src/main/java/dev/amble/ait/AITMod.java
+++ b/src/main/java/dev/amble/ait/AITMod.java
@@ -224,7 +224,7 @@ public class AITMod implements ModInitializer {
             TeleportInteriorCommand.register(dispatcher);
             SummonTardisCommand.register(dispatcher);
             SetLockedCommand.register(dispatcher);
-            GetInsideTardisCommand.register(dispatcher);
+            ThisTardisCommand.register(dispatcher);
             FuelCommand.register(dispatcher);
             SetRepairTicksCommand.register(dispatcher);
             RiftChunkCommand.register(dispatcher);

--- a/src/main/java/dev/amble/ait/core/commands/DataCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/DataCommand.java
@@ -8,8 +8,10 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.suggestion.SuggestionProvider;
 
+import dev.amble.ait.core.tardis.Tardis;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
@@ -55,52 +57,57 @@ public class DataCommand {
                                 .then(literal("get").executes(DataCommand::runGet)))))));
     }
 
-    private static <T> int runGet(CommandContext<ServerCommandSource> context) {
+    private static <T> int runGet(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
+        Value<T> value = getValue(context, tardis);
 
-        String rawComponent = StringArgumentType.getString(context, "component");
-        String valueName = StringArgumentType.getString(context, "value");
+        if (value == null)
+            return 0;
 
-        TardisComponent.IdLike id = TardisComponentRegistry.getInstance().get(rawComponent);
-
-        if (!(tardis.handler(id) instanceof KeyedTardisComponent keyed)) {
-            source.sendMessage(Text.translatable("command.ait.data.fail", valueName, rawComponent));
-            return 0; // womp womp
-        }
-
-        Value<T> value = keyed.getPropertyData().getExact(valueName);
         T obj = value.get();
 
         String json = ServerTardisManager.getInstance().getFileGson().toJson(obj);
 
-        source.sendMessage(Text.translatable("command.ait.data.get", valueName, json));
+        source.sendMessage(Text.translatable("command.ait.data.get",
+                value.getProperty().getName(), json));
+
         return Command.SINGLE_SUCCESS;
     }
 
-    private static <T> int runSet(CommandContext<ServerCommandSource> context) {
+    @SuppressWarnings("unchecked")
+    private static <T> int runSet(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 
-        String rawComponent = StringArgumentType.getString(context, "component");
-        String valueName = StringArgumentType.getString(context, "value");
+        Value<T> value = getValue(context, tardis);
+
+        if (value == null)
+            return 0;
 
         JsonElement data = JsonElementArgumentType.getJsonElement(context, "data");
-        TardisComponent.IdLike id = TardisComponentRegistry.getInstance().get(rawComponent);
 
-        if (!(tardis.handler(id) instanceof KeyedTardisComponent keyed)) {
-            source.sendMessage(Text.translatable("command.ait.data.fail", valueName, rawComponent));
-            return 0; // womp womp
-        }
-
-        Value<T> value = keyed.getPropertyData().getExact(valueName);
         Class<?> classOfT = value.getProperty().getType().getClazz();
-
         T obj = (T) ServerTardisManager.getInstance().getFileGson().fromJson(data, classOfT);
 
         value.set(obj);
-        source.sendMessage(Text.translatable("command.ait.data.set", valueName, obj.toString()));
+        source.sendMessage(Text.translatable("command.ait.data.set",
+                value.getProperty().getName(), obj.toString()));
 
         return Command.SINGLE_SUCCESS;
+    }
+
+    private static <T> Value<T> getValue(CommandContext<ServerCommandSource> context, Tardis tardis) {
+        String valueName = StringArgumentType.getString(context, "value");
+        String rawComponent = StringArgumentType.getString(context, "component");
+
+        TardisComponent.IdLike id = TardisComponentRegistry.getInstance().get(rawComponent);
+
+        if (!(tardis.handler(id) instanceof KeyedTardisComponent keyed)) {
+            context.getSource().sendMessage(Text.translatable("command.ait.data.fail", valueName, rawComponent));
+            return null; // womp womp
+        }
+
+        return keyed.getPropertyData().getExact(valueName);
     }
 }

--- a/src/main/java/dev/amble/ait/core/commands/DebugCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/DebugCommand.java
@@ -54,11 +54,11 @@ public class DebugCommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private static int executeTardis(CommandContext<ServerCommandSource> context) {
+    private static int executeTardis(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
 
         if (!source.isExecutedByPlayer())
-            return Command.SINGLE_SUCCESS;
+            return 0;
 
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 

--- a/src/main/java/dev/amble/ait/core/commands/FlightCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/FlightCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
@@ -24,11 +25,13 @@ public class FlightCommand {
 
     }
 
-    private static int execute(CommandContext<ServerCommandSource> context) {
+    private static int execute(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerPlayerEntity player = context.getSource().getPlayer();
-        ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 
-        if (player == null) return 0;
+        if (player == null)
+            return 0;
+
+        ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 
         if (!AITMod.CONFIG.SERVER.RWF_ENABLED) {
             player.sendMessage(Text.translatable("tardis.message.control.rwf_disabled"), true);

--- a/src/main/java/dev/amble/ait/core/commands/FuelCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/FuelCommand.java
@@ -8,6 +8,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
@@ -37,7 +38,7 @@ public class FuelCommand {
                                 .then(argument("tardis", TardisArgumentType.tardis()).executes(FuelCommand::get)))));
     }
 
-    private static int add(CommandContext<ServerCommandSource> context) {
+    private static int add(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 
@@ -50,7 +51,7 @@ public class FuelCommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private static int remove(CommandContext<ServerCommandSource> context) {
+    private static int remove(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 
@@ -63,7 +64,7 @@ public class FuelCommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private static int set(CommandContext<ServerCommandSource> context) {
+    private static int set(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 
@@ -80,7 +81,7 @@ public class FuelCommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private static int get(CommandContext<ServerCommandSource> context) {
+    private static int get(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 

--- a/src/main/java/dev/amble/ait/core/commands/GetCreatorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/GetCreatorCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
@@ -22,7 +23,7 @@ public class GetCreatorCommand {
                         argument("tardis", TardisArgumentType.tardis()).executes(GetCreatorCommand::runCommand)))));
     }
 
-    private static int runCommand(CommandContext<ServerCommandSource> context) {
+    private static int runCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 

--- a/src/main/java/dev/amble/ait/core/commands/GetNameCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/GetNameCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
@@ -21,12 +22,11 @@ public class GetNameCommand {
                         .then(argument("tardis", TardisArgumentType.tardis()).executes(GetNameCommand::runCommand)))));
     }
 
-    private static int runCommand(CommandContext<ServerCommandSource> context) {
+    private static int runCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 
-        source.sendMessage(Text.translatableWithFallback("tardis.name", "TARDIS name: %s", tardis.stats().getName()));
-
+        source.sendMessage(Text.translatableWithFallback("command.tardis.ait.name", "TARDIS name: %s", tardis.stats().getName()));
         return Command.SINGLE_SUCCESS;
     }
 }

--- a/src/main/java/dev/amble/ait/core/commands/LinkCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/LinkCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -24,7 +25,7 @@ public class LinkCommand {
                 .then(argument("tardis", TardisArgumentType.tardis()).executes(LinkCommand::runCommand))));
     }
 
-    private static int runCommand(CommandContext<ServerCommandSource> context) {
+    private static int runCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerPlayerEntity source = context.getSource().getPlayer();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 

--- a/src/main/java/dev/amble/ait/core/commands/ListCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/ListCommand.java
@@ -40,8 +40,15 @@ public class ListCommand {
         ServerCommandSource source = context.getSource();
         source.sendMessage(Text.literal("TARDIS':"));
 
-        ServerTardisManager.getInstance().forEach(tardis -> sendTardis(source, tardis));
+        ServerTardisManager.getInstance().forEach(tardis -> filterTardis(source, tardis, args));
         return Command.SINGLE_SUCCESS;
+    }
+
+    private static void filterTardis(ServerCommandSource source, ServerTardis tardis, String args) {
+        if (!tardis.getUuid().toString().contains(args))
+            return;
+
+        sendTardis(source, tardis);
     }
 
     private static void sendTardis(ServerCommandSource source, ServerTardis tardis) {

--- a/src/main/java/dev/amble/ait/core/commands/LoadCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/LoadCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
@@ -32,7 +33,7 @@ public class LoadCommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    public static int search(CommandContext<ServerCommandSource> context) {
+    public static int search(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerTardis loaded = TardisArgumentType.getTardis(context, "target");
         ServerCommandSource source = context.getSource();
         sendTardis(source, loaded);

--- a/src/main/java/dev/amble/ait/core/commands/RemoveCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/RemoveCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
@@ -18,12 +19,11 @@ import dev.amble.ait.core.tardis.manager.ServerTardisManager;
 public class RemoveCommand {
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        dispatcher
-                .register(literal(AITMod.MOD_ID).then(literal("remove").requires(source -> source.hasPermissionLevel(2))
-                        .then(argument("tardis", TardisArgumentType.tardis()).executes(RemoveCommand::removeCommand))));
+        dispatcher.register(literal(AITMod.MOD_ID).then(literal("remove").requires(source -> source.hasPermissionLevel(2))
+                .then(argument("tardis", TardisArgumentType.tardis()).executes(RemoveCommand::removeCommand))));
     }
 
-    private static int removeCommand(CommandContext<ServerCommandSource> context) {
+    private static int removeCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 

--- a/src/main/java/dev/amble/ait/core/commands/SetLockedCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetLockedCommand.java
@@ -8,6 +8,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -23,7 +24,7 @@ public class SetLockedCommand {
                         .then(argument("locked", BoolArgumentType.bool()).executes(SetLockedCommand::runCommand)))));
     }
 
-    private static int runCommand(CommandContext<ServerCommandSource> context) {
+    private static int runCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerPlayerEntity source = context.getSource().getPlayer();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
         boolean locked = BoolArgumentType.getBool(context, "locked");

--- a/src/main/java/dev/amble/ait/core/commands/SetMaxSpeedCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetMaxSpeedCommand.java
@@ -8,6 +8,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 
 import dev.amble.ait.AITMod;
@@ -26,7 +27,7 @@ public class SetMaxSpeedCommand {
                         argument("speed", IntegerArgumentType.integer(0)).executes(SetMaxSpeedCommand::runCommand)))));
     }
 
-    private static int runCommand(CommandContext<ServerCommandSource> context) {
+    private static int runCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
         int speed = IntegerArgumentType.getInteger(context, "speed");
 

--- a/src/main/java/dev/amble/ait/core/commands/SetNameCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetNameCommand.java
@@ -8,6 +8,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 
 import dev.amble.ait.AITMod;
@@ -22,7 +23,7 @@ public class SetNameCommand {
                         .then(argument("value", StringArgumentType.string()).executes(SetNameCommand::runCommand))))));
     }
 
-    private static int runCommand(CommandContext<ServerCommandSource> context) {
+    private static int runCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
         String name = StringArgumentType.getString(context, "value");
 

--- a/src/main/java/dev/amble/ait/core/commands/SetRepairTicksCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetRepairTicksCommand.java
@@ -8,6 +8,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
 
@@ -26,7 +27,7 @@ public class SetRepairTicksCommand {
                                         .executes(SetRepairTicksCommand::runCommand))))));
     }
 
-    private static int runCommand(CommandContext<ServerCommandSource> context) {
+    private static int runCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 

--- a/src/main/java/dev/amble/ait/core/commands/SetSiegeCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetSiegeCommand.java
@@ -8,6 +8,7 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 
 import dev.amble.ait.AITMod;
@@ -23,7 +24,7 @@ public class SetSiegeCommand {
     }
 
     // TODO: improve feedback
-    private static int runCommand(CommandContext<ServerCommandSource> context) {
+    private static int runCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
         boolean sieged = BoolArgumentType.getBool(context, "siege");
 

--- a/src/main/java/dev/amble/ait/core/commands/SummonTardisCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SummonTardisCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,22 +37,22 @@ public class SummonTardisCommand {
                                         .executes(SummonTardisCommand::runCommandWithPosAndMessage)))));
     }
 
-    private static int runCommand(CommandContext<ServerCommandSource> context) {
+    private static int runCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         return summonTardis(context, null, true);  // Default to showing the message
     }
 
-    private static int runCommandWithPos(CommandContext<ServerCommandSource> context) {
+    private static int runCommandWithPos(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         BlockPos pos = BlockPosArgumentType.getBlockPos(context, "pos");
         return summonTardis(context, pos, true);
     }
 
-    private static int runCommandWithPosAndMessage(CommandContext<ServerCommandSource> context) {
+    private static int runCommandWithPosAndMessage(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         BlockPos pos = BlockPosArgumentType.getBlockPos(context, "pos");
         boolean showMessage = BoolArgumentType.getBool(context, "showMessage");
         return summonTardis(context, pos, showMessage);
     }
 
-    private static int summonTardis(CommandContext<ServerCommandSource> context, @Nullable BlockPos pos, boolean showMessage) {
+    private static int summonTardis(CommandContext<ServerCommandSource> context, @Nullable BlockPos pos, boolean showMessage) throws CommandSyntaxException {
         Entity source = context.getSource().getEntity();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 

--- a/src/main/java/dev/amble/ait/core/commands/TeleportInteriorCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/TeleportInteriorCommand.java
@@ -35,14 +35,14 @@ public final class TeleportInteriorCommand {
                 )));
     }
 
-    private static int tpSelfInterior(CommandContext<ServerCommandSource> context) {
+    private static int tpSelfInterior(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         Entity source = context.getSource().getEntity();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 
         return tpToInterior(tardis, Collections.singleton(source));
     }
 
-    private static int tpSelfExterior(CommandContext<ServerCommandSource> context) {
+    private static int tpSelfExterior(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         Entity source = context.getSource().getEntity();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 

--- a/src/main/java/dev/amble/ait/core/commands/ThisTardisCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/ThisTardisCommand.java
@@ -14,19 +14,17 @@ import dev.amble.ait.AITMod;
 import dev.amble.ait.core.util.TextUtil;
 import dev.amble.ait.core.world.TardisServerWorld;
 
-public class GetInsideTardisCommand {
+public class ThisTardisCommand {
 
     // TODO: add BlockPosition argument type
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
         dispatcher.register(literal(AITMod.MOD_ID).then(literal("this")
-                .executes(GetInsideTardisCommand::runCommand)));
+                .executes(ThisTardisCommand::runCommand)));
     }
 
     private static int runCommand(CommandContext<ServerCommandSource> context) {
-        Entity source = context.getSource().getEntity();
-
-        if (source.getWorld() instanceof TardisServerWorld tardisWorld)
-            source.sendMessage(Text.translatable("message.ait.id").append(TextUtil.forTardis(tardisWorld.getTardis())));
+        if (context.getSource().getWorld() instanceof TardisServerWorld tardisWorld)
+            context.getSource().sendMessage(Text.translatable("message.ait.id").append(TextUtil.forTardis(tardisWorld.getTardis())));
 
         return Command.SINGLE_SUCCESS;
     }

--- a/src/main/java/dev/amble/ait/core/commands/TravelDebugCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/TravelDebugCommand.java
@@ -30,7 +30,7 @@ public class TravelDebugCommand {
                         .then(literal("remat").executes(TravelDebugCommand::remat)))));
     }
 
-    private static int demat(CommandContext<ServerCommandSource> context) {
+    private static int demat(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         Tardis tardis = TardisArgumentType.getTardis(context, "tardis");
         tardis.travel().dematerialize();
 
@@ -46,7 +46,7 @@ public class TravelDebugCommand {
         return Command.SINGLE_SUCCESS;
     }
 
-    private static int remat(CommandContext<ServerCommandSource> context) {
+    private static int remat(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         Tardis tardis = TardisArgumentType.getTardis(context, "tardis");
         tardis.travel().rematerialize();
 

--- a/src/main/java/dev/amble/ait/core/commands/TriggerMoodRollCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/TriggerMoodRollCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
 
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
 
 import dev.amble.ait.AITMod;
@@ -23,8 +24,7 @@ public class TriggerMoodRollCommand {
                         .executes(TriggerMoodRollCommand::triggerMoodRollCommand))));
     }
 
-    private static int triggerMoodRollCommand(CommandContext<ServerCommandSource> context) {
-
+    private static int triggerMoodRollCommand(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 
         tardis.<MoodHandler>handler(TardisComponent.Id.MOOD).rollForMoodDictatedEvent();

--- a/src/main/java/dev/amble/ait/core/commands/UnlockCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/UnlockCommand.java
@@ -50,7 +50,7 @@ public class UnlockCommand {
 
     private static <T extends Identifiable & Unlockable & Nameable> int unlock(
             CommandContext<ServerCommandSource> context, String type, Wildcard<T> wildcard,
-            UnlockableRegistry<T> registry) {
+            UnlockableRegistry<T> registry) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();
         ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
 

--- a/src/main/java/dev/amble/ait/core/commands/argument/TardisArgumentType.java
+++ b/src/main/java/dev/amble/ait/core/commands/argument/TardisArgumentType.java
@@ -15,6 +15,10 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 
+import dev.amble.ait.api.tardis.link.v2.block.AbstractLinkableBlockEntity;
+import dev.amble.ait.core.AITBlockEntityTypes;
+import dev.amble.ait.core.world.TardisServerWorld;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
@@ -22,16 +26,18 @@ import net.minecraft.text.Text;
 import dev.amble.ait.core.tardis.ServerTardis;
 import dev.amble.ait.core.tardis.TardisManager;
 import dev.amble.ait.core.tardis.manager.ServerTardisManager;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
 
 public class TardisArgumentType implements ArgumentType<TardisArgumentType.ServerTardisAccessor> {
 
     public static final SimpleCommandExceptionType INVALID_UUID = new SimpleCommandExceptionType(
             Text.translatable("argument.uuid.invalid"));
 
-    private static final Collection<String> EXAMPLES = List.of("dd12be42-52a9-4a91-a8a1-11c01849e498");
+    private static final Collection<String> EXAMPLES = List.of("~", "^", "dd12be42-52a9-4a91-a8a1-11c01849e498");
     private static final Pattern VALID_CHARACTERS = Pattern.compile("^([-A-Fa-f0-9]+)");
 
-    public static ServerTardis getTardis(CommandContext<ServerCommandSource> context, String name) {
+    public static ServerTardis getTardis(CommandContext<ServerCommandSource> context, String name) throws CommandSyntaxException {
         return context.getArgument(name, ServerTardisAccessor.class).get(context);
     }
 
@@ -41,7 +47,37 @@ public class TardisArgumentType implements ArgumentType<TardisArgumentType.Serve
 
     @Override
     public ServerTardisAccessor parse(StringReader reader) throws CommandSyntaxException {
+        if (reader.canRead() && reader.peek() == '~') {
+            reader.skip();
+
+            return context -> {
+                if (!(context.getSource().getWorld() instanceof TardisServerWorld tardisWorld))
+                    throw INVALID_UUID.create();
+
+                return tardisWorld.getTardis();
+            };
+        }
+
+        if (reader.canRead() && reader.peek() == '^') {
+            reader.skip();
+
+            return context -> {
+                HitResult hit = context.getSource().getEntity().raycast(16, 0, false);
+
+                if (!(hit instanceof BlockHitResult blockHit))
+                    throw INVALID_UUID.create();
+
+                BlockEntity blockEntity = context.getSource().getWorld().getBlockEntity(blockHit.getBlockPos());
+
+                if (!(blockEntity instanceof AbstractLinkableBlockEntity linkable))
+                    throw INVALID_UUID.create();
+
+                return linkable.tardis().get().asServer();
+            };
+        }
+
         String string = reader.getRemaining();
+
         Matcher matcher = VALID_CHARACTERS.matcher(string);
 
         if (!matcher.find())
@@ -60,7 +96,8 @@ public class TardisArgumentType implements ArgumentType<TardisArgumentType.Serve
         boolean isServer = context.getSource() instanceof ServerCommandSource;
         TardisManager<?, ?> manager = TardisManager.getInstance(isServer);
 
-        return CommandSource.suggestMatching(manager.ids().stream().map(UUID::toString), builder);
+        return CommandSource.suggestMatching(manager.ids().stream().map(UUID::toString),
+                builder.suggest("~").suggest("^"));
     }
 
     @Override
@@ -70,6 +107,6 @@ public class TardisArgumentType implements ArgumentType<TardisArgumentType.Serve
 
     @FunctionalInterface
     public interface ServerTardisAccessor {
-        ServerTardis get(CommandContext<ServerCommandSource> context);
+        ServerTardis get(CommandContext<ServerCommandSource> context) throws CommandSyntaxException;
     }
 }


### PR DESCRIPTION
## About the PR
This PR makes it so you can use `~` to point to the tardis you're currently in and `^` to point at a linked block entity instead of using a full tardis UUID.

This PR is a (better) alternative to #1251.

## Why / Balance
Previously, you had to find the tardis, then go inside it using a command, then copying its UUID, then doing something else. Now you can just look at it, or just be inside.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- `GetInsideCommand` -> `ThisCommand`

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: now you can use ~ and ^ to point at tardises inside of commands