### PR TITLE
fix: don't load the tardis when the file manager is locked

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -148,6 +148,9 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
     }
 
     private Either<ServerTardis, Exception> loadTardis(MinecraftServer server, UUID uuid) {
+        if (this.fileManager.isLocked())
+            return null;
+
         Either<ServerTardis, Exception> result = this.fileManager.loadTardis(server, this, uuid, this::readTardis);
 
         this.lookup.put(uuid, result);


### PR DESCRIPTION
## About the PR
This PR fixes a crash that happens because of attempting to load a tardis when the file manager is locked.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: no more random crashes when trying to load a tardis during lock