### PR TITLE
fix: use tardis getter in tardis server world to prevent a crash

### DIFF
--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -45,7 +45,7 @@ public class TardisServerWorld extends MultiDimServerWorld {
 
     @Override
     public boolean spawnEntity(Entity entity) {
-        if (entity instanceof ItemEntity && tardis.interiorChangingHandler().regenerating().get())
+        if (entity instanceof ItemEntity && this.getTardis().interiorChangingHandler().regenerating().get())
             return false;
 
         return super.spawnEntity(entity);


### PR DESCRIPTION
## About the PR
This PR fixes a crash in `TardisServerWorld`.

## Technical details
The crash is caused by the lazily loaded tardis value not being null checked. The PR updates the code to use a getter.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: no more random reconfig crashes