### PR TITLE
ci: open PR to merge main into ver on push

### DIFF
--- a/.github/workflows/version_sync.yml
+++ b/.github/workflows/version_sync.yml
@@ -13,24 +13,26 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Create Pull Request from main into ver/1.3.0
-        id: create_pr
+        id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BYPASS_TOKEN }}
           base: ver/1.3.0      # Target branch for the PR
           branch: main         # Source branch
           title: "Sync main to ver/1.3.0"
           body: "Auto-generated PR to merge changes from main into ver/1.3.0."
           commit-message: "Merge main into ver/1.3.0"
 
-#  auto-merge:
-#    needs: create-pr
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Attempt to auto-merge PR (force merge bypassing approvals)
-#        uses: peter-evans/merge-pull-request@v2
-#        with:
-#          token: ${{ secrets.MERGE_TOKEN }}  # Must be a PAT with admin rights to bypass branch protection
-#          pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}
-#          merge-method: merge
-#          bypass: true
+      - name: Auto approve
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: gh pr review --approve "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable Pull Request Automerge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.BYPASS_TOKEN }}
+          pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
+          merge-method: squash

--- a/.github/workflows/version_sync.yml
+++ b/.github/workflows/version_sync.yml
@@ -16,7 +16,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.BYPASS_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN }}
           base: ver/1.3.0      # Target branch for the PR
           branch: main         # Source branch
           title: "Sync main to ver/1.3.0"
@@ -33,6 +33,6 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.BYPASS_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           merge-method: squash

--- a/.github/workflows/version_sync.yml
+++ b/.github/workflows/version_sync.yml
@@ -1,0 +1,36 @@
+name: Sync main to ver/1.3.0
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create Pull Request from main into ver/1.3.0
+        id: create_pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ver/1.3.0      # Target branch for the PR
+          branch: main         # Source branch
+          title: "Sync main to ver/1.3.0"
+          body: "Auto-generated PR to merge changes from main into ver/1.3.0."
+          commit-message: "Merge main into ver/1.3.0"
+
+#  auto-merge:
+#    needs: create-pr
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Attempt to auto-merge PR (force merge bypassing approvals)
+#        uses: peter-evans/merge-pull-request@v2
+#        with:
+#          token: ${{ secrets.MERGE_TOKEN }}  # Must be a PAT with admin rights to bypass branch protection
+#          pull-request-number: ${{ steps.create_pr.outputs.pull-request-number }}
+#          merge-method: merge
+#          bypass: true


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Added a workflow which opens a PR main -> 1.3.0 on push to main

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ensures that the version branch is always up to date with the latest release.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->