### PR TITLE
Enqueue runnables to TARDIS states

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/ThrottleControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/ThrottleControl.java
@@ -31,40 +31,8 @@ public class ThrottleControl extends Control {
         TravelHandler travel = tardis.travel();
         TravelHandlerBase.State state = travel.getState();
 
-        if (player.getMainHandStack().isOf(AITItems.MUG)) {
-            /*
-            This is an example of how to use the travel queue.
-            This code enqueues a crash to be performed after dematerialization.
-             */
-
-            ActionQueue drinkAction = new ActionQueue();
-
-            drinkAction.thenRun(() -> {
-                travel.speed(travel.maxSpeed().get());
-                travel.crash();
-                TardisCriterions.BRAND_NEW.trigger(player);
-            });
-
-            if (state == TravelHandlerBase.State.LANDED) {
-                boolean hadAutopilot = travel.autopilot();
-
-                travel.autopilot(true);
-
-                travel.dematerialize().ifPresent(tr -> {
-                    tr.thenRun(drinkAction);
-                    tardis.alarm().enable();
-                });
-
-                travel.autopilot(hadAutopilot);
-
-                return Result.SUCCESS;
-            }
-
-            if (state == TravelHandlerBase.State.FLIGHT) {
-                drinkAction.execute();
-
-                return Result.SUCCESS;
-            }
+        if (TelepathicControl.isLiquid(player.getMainHandStack())) {
+            return TelepathicControl.spillLiquid(tardis, world, console, player);
         }
 
         if (!leftClick) {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/CrashableTardisTravel.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/CrashableTardisTravel.java
@@ -2,11 +2,13 @@ package dev.amble.ait.core.tardis.handler.travel;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
 
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.util.ServerLifecycleHooks;
 
+import dev.drtheo.queue.api.ActionQueue;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.server.MinecraftServer;
@@ -45,7 +47,7 @@ public sealed interface CrashableTardisTravel permits TravelHandler {
 
     BoolValue antigravs();
 
-    void forceRemat();
+    Optional<ActionQueue> forceRemat();
 
     CachedDirectedGlobalPos position();
 

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -1,6 +1,7 @@
 package dev.amble.ait.core.tardis.handler.travel;
 
 import dev.amble.lib.data.CachedDirectedGlobalPos;
+import dev.drtheo.queue.api.ActionQueue;
 import dev.drtheo.scheduler.api.Scheduler;
 import dev.drtheo.scheduler.api.TimeUnit;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
@@ -36,6 +37,9 @@ import dev.amble.ait.core.util.WorldUtil;
 import dev.amble.ait.core.world.RiftChunkManager;
 import dev.amble.ait.data.Exclude;
 
+import java.util.EnumMap;
+import java.util.Optional;
+
 public final class TravelHandler extends AnimatedTravelHandler implements CrashableTardisTravel {
 
     @Exclude
@@ -43,6 +47,9 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
     @Exclude
     private boolean waiting;
+
+    @Exclude
+    private EnumMap<State, ActionQueue> travelQueue;
 
     public static final Identifier CANCEL_DEMAT_SOUND = AITMod.id("cancel_demat_sound");
 
@@ -149,6 +156,8 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
     public void postInit(InitContext context) {
         if (this.isServer() && context.created())
             this.placeExterior(true);
+
+        this.state.addListener((this::executeQueue));
     }
 
     public void deleteExterior() {
@@ -234,12 +243,12 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
         Scheduler.get().runTaskLater(() -> this.travelCooldown = false, TimeUnit.SECONDS, 5);
     }
 
-    public void dematerialize(TravelSound sound) {
+    public Optional<ActionQueue> dematerialize(TravelSound sound) {
         if (this.getState() != State.LANDED)
-            return;
+            return Optional.empty();
 
         if (!this.tardis.fuel().hasPower())
-            return;
+            return Optional.empty();
 
         if (this.autopilot()) {
             // fulfill all the prerequisites
@@ -252,14 +261,14 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
         if (TardisEvents.DEMAT.invoker().onDemat(this.tardis) == TardisEvents.Interaction.FAIL || this.travelCooldown) {
             this.failDemat();
-            return;
+            return Optional.empty();
         }
 
-        this.forceDemat(sound);
+        return Optional.of(this.forceDemat(sound));
     }
 
-    public void dematerialize() {
-        this.dematerialize(null);
+    public Optional<ActionQueue> dematerialize() {
+        return this.dematerialize(null);
     }
 
     private void failDemat() {
@@ -284,7 +293,7 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
         this.createCooldown();
     }
 
-    public void forceDemat(TravelSound replacementSound) {
+    public ActionQueue forceDemat(TravelSound replacementSound) {
         this.state.set(State.DEMAT);
 
         SoundEvent sound = tardis.stats().getTravelEffects().get(this.getState()).sound();
@@ -297,6 +306,8 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
         this.runAnimations();
 
         this.startFlight();
+
+        return this.queueFor(State.FLIGHT);
     }
 
     public void forceDemat() {
@@ -328,19 +339,19 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
         NetworkUtil.sendToInterior(this.tardis.asServer(), CANCEL_DEMAT_SOUND, PacketByteBufs.empty());
     }
 
-    public void rematerialize() {
+    public Optional<ActionQueue> rematerialize() {
         if (TardisEvents.MAT.invoker().onMat(tardis.asServer()) == TardisEvents.Interaction.FAIL
                 || this.travelCooldown) {
             this.failRemat();
-            return;
+            return Optional.empty();
         }
 
-        this.forceRemat();
+        return this.forceRemat();
     }
 
-    public void forceRemat() {
+    public Optional<ActionQueue> forceRemat() {
         if (this.getState() != State.FLIGHT)
-            return;
+            return Optional.empty();
 
         if (this.tardis.sequence().hasActiveSequence())
             this.tardis.sequence().setActiveSequence(null, true);
@@ -351,7 +362,7 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
         if (result.type() == TardisEvents.Interaction.FAIL) {
             this.crash();
-            return;
+            return Optional.of(this.queueFor(State.LANDED));
         }
 
         final CachedDirectedGlobalPos finalPos = result.value().orElse(initialPos);
@@ -361,6 +372,8 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
         SafePosSearch.wrapSafe(finalPos, this.vGroundSearch.get(),
                 this.hGroundSearch.get(), this::finishForceRemat);
+
+        return Optional.of(this.queueFor(State.LANDED));
     }
 
     private void finishForceRemat(CachedDirectedGlobalPos pos) {
@@ -392,6 +405,28 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
         tardis.door().interactLock(tardis.door().previouslyLocked().get(), null, false);
         TardisEvents.LANDED.invoker().onLanded(this.tardis);
+    }
+
+    private void executeQueue(State state) {
+        if (this.travelQueue == null)
+            this.travelQueue = new EnumMap<>(State.class);
+
+	    ActionQueue queue = this.travelQueue.computeIfAbsent(state, k -> new ActionQueue());
+
+	    queue.execute();
+    }
+
+    /**
+     * Returns the queue of actions to be ran when the TARDIS next reaches a specific state
+     * Please dont call "execute" or "finish" lol
+     * @param state the state to enqueue the action for
+     * @return the action queue for the state
+     */
+    public ActionQueue queueFor(State state) {
+        if (this.travelQueue == null)
+            this.travelQueue = new EnumMap<>(State.class);
+
+        return this.travelQueue.computeIfAbsent(state, k -> new ActionQueue());
     }
 
     public void initPos(CachedDirectedGlobalPos cached) {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -156,8 +156,6 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
     public void postInit(InitContext context) {
         if (this.isServer() && context.created())
             this.placeExterior(true);
-
-        this.state.addListener((this::executeQueue));
     }
 
     public void deleteExterior() {
@@ -294,7 +292,7 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
     }
 
     public ActionQueue forceDemat(TravelSound replacementSound) {
-        this.state.set(State.DEMAT);
+        this.setState(State.DEMAT);
 
         SoundEvent sound = tardis.stats().getTravelEffects().get(this.getState()).sound();
 
@@ -317,7 +315,7 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
     public void finishDemat() {
         this.crashing.set(false);
         this.previousPosition.set(this.position);
-        this.state.set(State.FLIGHT);
+        this.setState(State.FLIGHT);
 
         TardisEvents.ENTER_FLIGHT.invoker().onFlight(this.tardis);
         this.deleteExterior();
@@ -367,7 +365,7 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
         final CachedDirectedGlobalPos finalPos = result.value().orElse(initialPos);
 
-        this.state.set(State.MAT);
+        this.setState(State.MAT);
         this.waiting = true;
 
         SafePosSearch.wrapSafe(finalPos, this.vGroundSearch.get(),
@@ -400,7 +398,7 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
         if (this.autopilot() && this.speed.get() > 0)
             this.speed.set(0);
 
-        this.state.set(State.LANDED);
+        this.setState(State.LANDED);
         this.resetFlight();
 
         tardis.door().interactLock(tardis.door().previouslyLocked().get(), null, false);
@@ -427,6 +425,13 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
             this.travelQueue = new EnumMap<>(State.class);
 
         return this.travelQueue.computeIfAbsent(state, k -> new ActionQueue());
+    }
+
+    @Override
+    protected void setState(State state) {
+        super.setState(state);
+
+        this.executeQueue(state);
     }
 
     public void initPos(CachedDirectedGlobalPos cached) {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
@@ -146,6 +146,10 @@ public abstract class TravelHandlerBase extends KeyedTardisComponent implements 
         return state.get();
     }
 
+    protected void setState(State state) {
+        this.state.set(state);
+    }
+
     public CachedDirectedGlobalPos position() {
         return this.position.get();
     }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
You can now enqueue runnables to a tardis state
When the state changes, it runs all enqueued actions of the new state
eg - if you wanted to run something after the TARDIS next demats, youd enqueue to the FLIGHT state

I also fixed #1326 & #1325 as an example of how this system can be used.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Improvement of workflow, instead of adding things to `finishDemat` or similar you can simply enqueue to the returned `ActionQueue`
Hopefully this will also improve some peoples understanding of the codebase, as I've seen some people call things like
```
travel.demat
travel.crash
```
which wont work, as the TARDIS is still dematerialising and cannot crash in that state

## Technical details
<!-- Summary of code changes for easier review. -->
`TravelHandler` now stores an `EnumMap` of `State`s and `ActionQueue`s 
`dematerialize` and related methods now return `Optional<ActionQueue>` for convenience
`rematerialize` and related methods /\
`queueFor` to get the queue for a state

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->
N/A 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
fix: coffee not crashing 