### PR TITLE
fix: lock STM on server start, add nullability check

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -47,7 +47,9 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
     protected final TardisFileManager<ServerTardis> fileManager = new TardisFileManager<>();
 
     public DeprecatedServerTardisManager() {
-        ServerLifecycleEvents.SERVER_STARTING.register(server -> this.fileManager.setLocked(false));
+        this.fileManager.setLocked(true);
+
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> this.fileManager.setLocked(false));
         ServerLifecycleEvents.SERVER_STOPPING.register(this::saveAndReset);
 
         ServerCrashEvent.EVENT.register(((server, report) -> this.reset())); // just panic and reset
@@ -113,6 +115,9 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
         if (either == null)
             either = this.loadTardis(server, uuid);
 
+        if (either == null)
+            return null;
+
         return either.map(tardis -> tardis, o -> null);
     }
 
@@ -147,6 +152,7 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
         this.lookup.forEach((uuid, either) -> either.ifLeft(consumer));
     }
 
+    @Nullable
     private Either<ServerTardis, Exception> loadTardis(MinecraftServer server, UUID uuid) {
         if (this.fileManager.isLocked())
             return null;


### PR DESCRIPTION
## About the PR
This PR fixes an inconsistency in `ServerTardisManager` code that was there since beta of 1.1.0.

## Why / Balance
This fixes #1389 (or at least it should).

## Technical details
STM has a locking feature which prevents the STM from doing loading/saving/networking under certain circumstances. Previously, the STM wasn't being locked before server fully started.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: no more seemingly random server crashes in multiplayer