### PR TITLE
fix the hammer crash

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/ExtraHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/ExtraHandler.java
@@ -2,8 +2,6 @@ package dev.amble.ait.core.tardis.handler;
 
 import java.util.function.Consumer;
 
-import dev.amble.lib.data.CachedDirectedGlobalPos;
-
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -38,6 +36,12 @@ public class ExtraHandler extends KeyedTardisComponent {
         Drink drink = DrinkRegistry.getInstance().get(AITMod.id("coffee"));
         ItemStack stack = new ItemStack(AITItems.MUG);
         DrinkUtil.setDrink(stack, drink);
+    }
+
+    @Override
+    public void onLoaded() {
+        setRefreshmentItemValue.of(this, SET_REFRESHMENT_ITEM);
+        setInsertedDiscValue.of(this, INSERTED_DISC);
         consoleHammer.of(this, CONSOLE_HAMMER);
     }
 
@@ -78,16 +82,6 @@ public class ExtraHandler extends KeyedTardisComponent {
         world.spawnEntity(entity);
     }
 
-    public static void spawnItem(CachedDirectedGlobalPos cached, ItemStack sonic) {
-        spawnItem(cached.getWorld(), cached.getPos(), sonic);
-    }
-
-    @Override
-    public void onLoaded() {
-        setRefreshmentItemValue.of(this, SET_REFRESHMENT_ITEM);
-        setInsertedDiscValue.of(this, INSERTED_DISC);
-    }
-
     public ItemStack getRefreshmentItem() {
         ItemStack itemStack = setRefreshmentItemValue.get();
         return itemStack != null ? itemStack : ItemStack.EMPTY;
@@ -105,5 +99,4 @@ public class ExtraHandler extends KeyedTardisComponent {
     public void setInsertedDisc(ItemStack item) {
         setInsertedDiscValue.set(item);
     }
-
 }

--- a/src/main/java/dev/amble/ait/data/properties/Value.java
+++ b/src/main/java/dev/amble/ait/data/properties/Value.java
@@ -95,7 +95,7 @@ public class Value<T> implements Disposable {
 
     protected void sync() {
         if (this.holder == null)
-            return
+            return;
 
         if (!(this.holder.tardis() instanceof ServerTardis tardis)) {
             this.syncToServer();
@@ -104,6 +104,7 @@ public class Value<T> implements Disposable {
 
         ServerTardisManager.getInstance().markPropertyDirty(tardis, this);
     }
+    
     @Environment(EnvType.CLIENT)
     protected void syncToServer() { // todo - flags
         ClientPlayNetworking.send(new SyncPropertyC2SPacket(this.holder.tardis().getUuid(), this));

--- a/src/main/java/dev/amble/ait/data/properties/Value.java
+++ b/src/main/java/dev/amble/ait/data/properties/Value.java
@@ -94,7 +94,10 @@ public class Value<T> implements Disposable {
     }
 
     protected void sync() {
-        if (this.holder == null || !(this.holder.tardis() instanceof ServerTardis tardis)) {
+        if (this.holder == null)
+            return
+
+        if (!(this.holder.tardis() instanceof ServerTardis tardis)) {
             this.syncToServer();
             return;
         }


### PR DESCRIPTION
## About the PR
This PR fixes the hammer crash. Previously, if you put the hammer in the slot it would crash dedicated servers.

## Technical details
Apparently, some silly goober didnt put the value load in the `#onLoaded` method. And some other silly guy made it so if the value isnt bound to any tardis then it's seen as if it was a client tardis. Obviously, the `syncToServer` doesn't exist on servers.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a 🆑 symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

🆑
- fix: the hammer no longer crashes dedicated servers