### PR TITLE
fix: oxygenator now has pickaxeminable tag so will drop

### DIFF
--- a/src/main/java/dev/amble/ait/module/planet/core/PlanetBlocks.java
+++ b/src/main/java/dev/amble/ait/module/planet/core/PlanetBlocks.java
@@ -22,6 +22,7 @@ public class PlanetBlocks extends BlockContainer {
 
     // Tech
 
+    @PickaxeMineable(tool = PickaxeMineable.Tool.IRON)
     public static final Block OXYGENATOR_BLOCK = new OxygenatorBlock(
             FabricBlockSettings.copy(Blocks.IRON_BLOCK));
 


### PR DESCRIPTION
## About the PR
added @pickaxeminable tag to the oxygenator block

## Why / Balance
it was missing it, there for wouldnt drop on being broken, and took ages to drop

## Technical details
added `@PickaxeMineable(tool = PickaxeMineable.Tool.IRON)` to `PlanetBlocks` class

## Media
NA

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NA

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: oxygenator not droping on being mined