### PR TITLE
fix: two hartnell variants are missing emissions

### DIFF
--- a/src/main/resources/data/ait/console/exile.json
+++ b/src/main/resources/data/ait/console/exile.json
@@ -1,5 +1,6 @@
 {
   "id": "ait:exile",
   "parent": "ait:console/hartnell",
-  "texture": "ait:textures/blockentities/consoles/exile.png"
+  "texture": "ait:textures/blockentities/consoles/exile.png",
+  "emission": "ait:textures/blockentities/consoles/hartnell_console_emission.png"
 }

--- a/src/main/resources/data/ait/console/hartnell_mint_green_console.json
+++ b/src/main/resources/data/ait/console/hartnell_mint_green_console.json
@@ -1,5 +1,6 @@
 {
   "id": "ait:hartnell_mint_green_console",
   "parent": "ait:console/hartnell",
-  "texture": "ait:textures/blockentities/consoles/hartnell_mint_green_console.png"
+  "texture": "ait:textures/blockentities/consoles/hartnell_mint_green_console.png",
+  "emission": "ait:textures/blockentities/consoles/hartnell_console_emission.png"
 }


### PR DESCRIPTION
## About the PR
This PR adds the existing hartnell emissions-file to the two hartnell console variants "exile" and "mint green" (not to be confused with just the mint one).

## Why / Balance
All the hartnell variants have emissions except for the two that are loaded via JSON file (i.e. "exile" and "mint green"), which seems inconsistent, especially since the emissions light up the same elements for these two variants as for all the others.

## Technical details
I simply added the existing hartnell emissions file `hartnell_console_emission.png` to the two mentioned JSONs.

As a side-effect, this fix also prevents the exception `java.io.FileNotFoundException: ait:intentionally_empty` in the log when switching the console to one of these two JSON variants (due to the emissions-file now being referenced).

It also doesn't show the dark and purple texture overlays in the hologram-preview anymore (see screenshots below).

## Media
<details>
<summary><ins>Before:</ins></summary>

![image](https://github.com/user-attachments/assets/5d92d824-e612-4858-8923-6ff8f2f7ab94)
![image](https://github.com/user-attachments/assets/d97b20c2-d33a-43a9-8151-cabdfa3ad928)
</details>

<ins>After:</ins>
![image](https://github.com/user-attachments/assets/ec580a2e-82ae-4496-bed1-820d292cbdaa)
![image](https://github.com/user-attachments/assets/78cf379a-830a-497d-9106-ddc782e4cb51)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I would've read and followed the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines), if they existed. 😛
- [x] I have added media to this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- fix: The two Hartnell console variants "exile" and "mint green" are no longer missing emissions.