### PR TITLE
fix handlers being null sometimes due to multithreading

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/TardisHandlersManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisHandlersManager.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import com.google.gson.*;
+import dev.amble.ait.data.enummap.ConcurrentEnumMap;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import org.jetbrains.annotations.ApiStatus;
@@ -21,7 +22,7 @@ import dev.amble.ait.registry.impl.TardisComponentRegistry;
 public class TardisHandlersManager extends TardisComponent implements TardisTickable {
 
     @Exclude
-    private final EnumMap<IdLike, TardisComponent> handlers = new EnumMap<>(TardisComponentRegistry::values,
+    private final EnumMap<IdLike, TardisComponent> handlers = new ConcurrentEnumMap<>(TardisComponentRegistry::values,
             TardisComponent[]::new);
 
     public TardisHandlersManager() {

--- a/src/main/java/dev/amble/ait/data/enummap/ConcurrentEnumMap.java
+++ b/src/main/java/dev/amble/ait/data/enummap/ConcurrentEnumMap.java
@@ -1,0 +1,39 @@
+package dev.amble.ait.data.enummap;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * A thread-safe implementation of the {@link EnumMap}.
+ *
+ * @author Theo
+ */
+public class ConcurrentEnumMap<K extends Ordered, V> extends EnumMap<K, V> {
+
+    private final Object lock = new Object();
+
+    public ConcurrentEnumMap(Supplier<K[]> values, Function<Integer, V[]> supplier) {
+        super(values, supplier);
+    }
+
+    @Override
+    public V put(K k, V v) {
+        synchronized (lock) {
+            return super.put(k, v);
+        }
+    }
+
+    @Override
+    public void clear() {
+        synchronized (lock) {
+            super.clear();
+        }
+    }
+
+    @Override
+    public V get(int index) {
+        synchronized (lock) {
+            return super.get(index);
+        }
+    }
+}

--- a/src/main/java/dev/amble/ait/data/enummap/EnumMap.java
+++ b/src/main/java/dev/amble/ait/data/enummap/EnumMap.java
@@ -7,8 +7,10 @@ import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Custom and lightweight map implementation for enums. I know
- * {@link java.util.EnumMap} exists, but it's different.
+ * Custom and lightweight map implementation for enums.
+ * Faster than {@link java.util.EnumMap}.
+ *
+ * @author Theo.
  */
 public class EnumMap<K extends Ordered, V> {
 
@@ -41,10 +43,7 @@ public class EnumMap<K extends Ordered, V> {
     }
 
     public V remove(K k) {
-        V prev = values[k.index()];
-        values[k.index()] = null;
-
-        return prev;
+        return put(k, null);
     }
 
     public V get(K k) {
@@ -58,7 +57,7 @@ public class EnumMap<K extends Ordered, V> {
     public boolean containsKey(K k) {
         if ((this.size() - 1) < k.index()) return false;
 
-        return this.values[k.index()] != null;
+        return this.get(k) != null;
     }
 
     public void clear() {


### PR DESCRIPTION
## About the PR
This PR fixes a long standing bug in AIT (since, like, 1.0.4?). The bug that was randomly making handlers go null for no reason is now fixed!


## Technical details
The enum map used to store the handlers is using an array to store the handlers. Rarely, when the networking thread set the object but before it would put the new value in, the rendering thread would intervene and try to get the value, resulting in a null. This PR fixes it by using `synchronized` on a lock for array access.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a 🆑 symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
🆑
- fix: no more random crashes due to multithreading