### PR TITLE
Exterior BOTI doors not turning dark red during alarm when TARDIS unpowered

### DIFF
--- a/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
@@ -156,7 +156,7 @@ public class TardisExteriorBOTI extends BOTI {
             boolean power = tardis.fuel().hasPower();
             boolean alarms = tardis.alarm().enabled().get();
 
-            float red = power ? s : 0;
+            float red = power ? s : alarms ? 0.3f : 0;
             float green = power ? alarms ? 0.3f : t : 0;
             float blue = power ? alarms ? 0.3f : u : 0;
 


### PR DESCRIPTION
## About the PR
When an exterior door is open during an alarm *and* there is no power, then the windows will be black, whereas all other windows are dark red.

This commit fixes it so that an exterior open door will show with the correct (dark red) color in the BOTI when alarms are on while the TARDIS is not powered.

## Why / Balance
It makes the exterior doors in the BOTI behave consistently with all the other windows.

## Technical details
I simply added another check to the existing ternary for the red color.

## Media
**Before:**
![image](https://github.com/user-attachments/assets/6e0d1020-900f-45bd-92fc-3203f33e983f)

**After:**
![image](https://github.com/user-attachments/assets/86467a45-6c23-408a-a296-9c1189deadce)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- fix: exterior BOTI doors did not turn red during an alarm when power was off
