### PR TITLE
fix(manager): crash when loading & file manager locked

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -123,8 +123,13 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
 
     @Override
     public void loadTardis(MinecraftServer server, UUID uuid, @Nullable Consumer<ServerTardis> consumer) {
-        if (consumer != null)
-            this.loadTardis(server, uuid).ifLeft(consumer);
+        if (consumer == null) return;
+
+        Either<ServerTardis,Exception> either = this.loadTardis(server, uuid);
+
+        if (either == null) return;
+
+        either.ifLeft(consumer);
     }
 
     @Override


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Return an exception if file manager is locked while trying to load tardis
closes #1443

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Causes an edge-case crash + makes more sense / continuity

## Technical details
<!-- Summary of code changes for easier review. -->
In `loadTardis` 
```
        if (this.fileManager.isLocked())
            return Either.right(new Exception("TardisFileManager is locked!"));
```

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->