### PR TITLE
feat: spawning particles at door after reconfig

### DIFF
--- a/src/main/java/dev/amble/ait/AITMod.java
+++ b/src/main/java/dev/amble/ait/AITMod.java
@@ -248,6 +248,7 @@ public class AITMod implements ModInitializer {
             DebugCommand.register(dispatcher);
             EraseChunksCommand.register(dispatcher);
             FlightCommand.register(dispatcher);
+            SetDoorParticleCommand.register(dispatcher, registryAccess);
         }));
 
         ServerPlayNetworking.registerGlobalReceiver(TardisUtil.REGION_LANDING_CODE,

--- a/src/main/java/dev/amble/ait/core/commands/SetDoorParticleCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/SetDoorParticleCommand.java
@@ -1,0 +1,39 @@
+package dev.amble.ait.core.commands;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.commands.argument.TardisArgumentType;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.tardis.manager.ServerTardisManager;
+import net.minecraft.command.CommandRegistryAccess;
+import net.minecraft.command.argument.ParticleEffectArgumentType;
+import net.minecraft.particle.ParticleEffect;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+public class SetDoorParticleCommand {
+	public static void register(CommandDispatcher<ServerCommandSource> dispatcher, CommandRegistryAccess access) {
+		dispatcher.register(literal(AITMod.MOD_ID).then(literal("door_particle").requires(source -> source.hasPermissionLevel(2))
+				.then(argument("tardis", TardisArgumentType.tardis()).then(argument("particle_type", ParticleEffectArgumentType.particleEffect(access)).executes(SetDoorParticleCommand::execute)))));
+	}
+
+	private static int execute(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		ServerCommandSource source = context.getSource();
+		ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
+		ParticleEffect particle = ParticleEffectArgumentType.getParticle(context, "particle_type");
+
+		tardis.door().setDoorParticles(particle);
+
+		source.sendFeedback(
+				() -> Text.translatableWithFallback("command.ait.door_particle.done", "Particle of [%s] set to [%s]", tardis.getUuid(), particle.asString()),
+				true);
+
+		return Command.SINGLE_SUCCESS;
+	}
+}

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -18,6 +18,9 @@ import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.particle.ParticleEffect;
+import net.minecraft.particle.ParticleType;
+import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
@@ -228,6 +231,12 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
 
                     TardisUtil.sendMessageToLinked(tardis.asServer(), Text.translatable("tardis.message.interiorchange.success", tardis.stats().getName(), tardis.getDesktop().getSchema().name()));
                     createChestAtInteriorDoor(restorationChestContents);
+
+                    ParticleEffect particle = ParticleTypes.CLOUD;
+                    tardis.door().setDoorParticles(particle);
+                    Scheduler.get().runTaskLater(() -> {
+                        tardis.door().tryReplaceDoorParticle(particle, null);
+                    }, TimeUnit.SECONDS, 3);
                 }).execute();
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/handler/TardisCrashHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/TardisCrashHandler.java
@@ -82,10 +82,11 @@ public class TardisCrashHandler extends KeyedTardisComponent implements TardisTi
         CachedDirectedGlobalPos exteriorPosition = tardis.travel().position();
         ServerWorld exteriorWorld = exteriorPosition.getWorld();
 
-        if (tardis.door().isOpen() && state != State.NORMAL) {
-            exteriorWorld.spawnParticles(ParticleTypes.CAMPFIRE_COSY_SMOKE, exteriorPosition.getPos().toCenterPos().x,
-                    exteriorPosition.getPos().getY() + 2f, exteriorPosition.getPos().toCenterPos().z, 1, 0.05D, 0.05D,
-                    0.05D, 0.01D);
+        DoorHandler door = tardis.door();
+        if (state != State.NORMAL) {
+            door.setDoorParticles(ParticleTypes.CAMPFIRE_COSY_SMOKE);
+        } else {
+            door.tryReplaceDoorParticle(ParticleTypes.CAMPFIRE_COSY_SMOKE, null);
         }
 
         if (state != State.TOXIC)

--- a/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
@@ -173,10 +173,8 @@ public class TardisUtil {
         return TardisUtil.offsetInteriorDoorPos(desktop.getDoorPos());
     }
 
-    public static Vec3d offsetDoorPosition(DirectedBlockPos directed) {
-        BlockPos pos = directed.getPos();
-
-        return switch (directed.getRotation()) {
+    public static Vec3d offsetDoorPosition(Vec3d pos, byte rotation) {
+        return switch (rotation) {
             case 1, 2, 3 -> new Vec3d(pos.getX() + 1.1f, pos.getY(), pos.getZ() - 0.5f);
             case 4 -> new Vec3d(pos.getX() + 1.5f, pos.getY(), pos.getZ() + 0.5f);
             case 5, 6, 7 -> new Vec3d(pos.getX() + 1.5f, pos.getY(), pos.getZ() + 1.1f);
@@ -188,6 +186,10 @@ public class TardisUtil {
         };
     }
 
+    public static Vec3d offsetDoorPosition(DirectedBlockPos directed) {
+        return offsetDoorPosition(new Vec3d(directed.getPos().getX(), directed.getPos().getY(), directed.getPos().getZ()), directed.getRotation());
+    }
+
     public static Vec3d offsetInteriorDoorPos(DirectedBlockPos directed) {
         BlockPos pos = directed.getPos();
 
@@ -197,6 +199,15 @@ public class TardisUtil {
             case 12 -> new Vec3d(pos.getX() + 0.6f, pos.getY(), pos.getZ() + 0.5f);
             default -> new Vec3d(pos.getX() + 0.5f, pos.getY(), pos.getZ() + 0.6f);
         };
+    }
+
+    // TODO - move to amblekit
+    public static Vec3d offsetPos(DirectedBlockPos directed, float value) {
+        BlockPos pos = directed.getPos();
+
+        return new Vec3d(pos.getX() + value * (double) directed.getVector().getX(),
+                pos.getY() + value * (double) directed.getVector().getY(),
+                pos.getZ() + value * (double) directed.getVector().getZ());
     }
 
     public static void teleportOutside(Tardis tardis, Entity entity) {


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Particles spawn at the door after reconfig
Command to spawn them
closes #1458

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Looks cool

## Technical details
<!-- Summary of code changes for easier review. -->
`DoorHandler` holds `doorOpenParticle`
Every 5 ticks, if it isnt null and is open, it spawns these particles at the door
`InteriorChangingHandler` sets it to cloud

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
feat: after reconfig, steam particles spawn
feat: /ait door_particle command to spawn your own