### PR TITLE
fix red warning in main menu for releases

### DIFF
--- a/versioning.gradle
+++ b/versioning.gradle
@@ -12,7 +12,7 @@ ext.getCurrentVersion = {
             qualifier = null
         }
 
-        if (branch == "main" || branch == "release") {
+        if (branch == "main") {
             branch = null
         }
     }


### PR DESCRIPTION
## About the PR
This will remove the red warning banner in the main menu for release versions.

## Why / Balance
The red warning banner should not be shown for release versions, as it is meant for experimental versions.
Otherwise this will confuse the player, as to whether they have a release version installed or not.

## Technical details
Currently `versioning.gradle` sets the branch string to null in cases where it should be "release".
Which leads to this check to always return false:
https://github.com/amblelabs/ait/blob/72ae989a453174b14c5fe14e62962ce83294f69f/src/main/java/dev/amble/ait/AITMod.java#L126
Which in turn means that the red warning banner in the main menu will always be shown, even in releases.
This RP ensures that the version string will have "-release" at its end (for release versions).

I left the branch string still at null in cases where the branch is "main", as I assumed that no releases will be deployed from that branch, but from the release branch only.

## Media
![image](https://github.com/user-attachments/assets/3016c49c-b5ae-4f1e-bd3c-f124c333d5f1)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: red warning for experimental versions was shown for release versions