### PR TITLE
Sonic Overload Changes

### DIFF
--- a/src/main/java/dev/amble/ait/core/AITItems.java
+++ b/src/main/java/dev/amble/ait/core/AITItems.java
@@ -75,7 +75,7 @@ public class AITItems extends ItemContainer {
             ArmorItem.Type.HELMET, new AItemSettings().group(AITItemGroups.MAIN).maxCount(1).maxDamage(80),
             true);
 
-    public static final Item SONIC_SCREWDRIVER = new SonicItem(new AItemSettings().group(AITItemGroups.MAIN));
+    public static final Item SONIC_SCREWDRIVER = new SonicItem(new AItemSettings().maxCount(1).group(AITItemGroups.MAIN));
 
     public static final Item HYPERCUBE = new HypercubeItem(new AItemSettings().maxCount(1).group(AITItemGroups.MAIN));
     public static final Item PSYCHPAPER = new PsychpaperItem(new AItemSettings().maxCount(1).group(AITItemGroups.MAIN));

--- a/src/main/java/dev/amble/ait/core/item/SonicItem.java
+++ b/src/main/java/dev/amble/ait/core/item/SonicItem.java
@@ -96,7 +96,7 @@ public class SonicItem extends LinkableItem implements ArtronHolderItem {
         int ticks = mode.maxTime() - remainingUseTicks;
 
         if (ticks % 10 == 0) {
-            removeFuel(1, stack);
+            removeFuel(mode.fuelCost(), stack);
 
             if (!this.checkFuel(stack))
                 return;
@@ -205,3 +205,4 @@ public class SonicItem extends LinkableItem implements ArtronHolderItem {
         return MAX_FUEL;
     }
 }
+

--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -8,6 +8,7 @@ import net.minecraft.particle.BlockStateParticleEffect;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.state.property.Properties;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -106,14 +107,12 @@ public class OverloadSonicMode extends SonicMode {
         }
 
         if (state.isOf(Blocks.OBSIDIAN)) {
-            // try place fire above if replaceable
-            BlockPos firePos = pos.up();
-            BlockState fireState = Blocks.FIRE.getDefaultState();
-
-            if (world.getBlockState(firePos).isReplaceable()) {
-                world.setBlockState(firePos, fireState);
-                world.emitGameEvent(user, GameEvent.BLOCK_PLACE, firePos);
-                playFx(world, firePos);
+            BlockPos blockPos2 = pos.offset(blockHit.getSide());
+            if (AbstractFireBlock.canPlaceAt(world, blockPos2, user.getHorizontalFacing())) {
+                this.playFx(world, blockPos2);
+                BlockState blockState2 = AbstractFireBlock.getState(world, blockPos2);
+                world.setBlockState(blockPos2, blockState2, Block.NOTIFY_ALL | Block.REDRAW_ON_MAIN_THREAD);
+                world.emitGameEvent(user, GameEvent.BLOCK_PLACE, pos);
             }
         }
     }

--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -102,6 +102,19 @@ public class OverloadSonicMode extends SonicMode {
             TntBlock.primeTnt(world, pos);
             world.removeBlock(pos, false);
             world.emitGameEvent(user, GameEvent.BLOCK_DESTROY, pos);
+            return;
+        }
+
+        if (state.isOf(Blocks.OBSIDIAN)) {
+            // try place fire above if replaceable
+            BlockPos firePos = pos.up();
+            BlockState fireState = Blocks.FIRE.getDefaultState();
+
+            if (world.getBlockState(firePos).isReplaceable()) {
+                world.setBlockState(firePos, fireState);
+                world.emitGameEvent(user, GameEvent.BLOCK_PLACE, firePos);
+                playFx(world, firePos);
+            }
         }
     }
 
@@ -155,5 +168,10 @@ public class OverloadSonicMode extends SonicMode {
     @Override
     public Identifier model(SonicSchema.Models models) {
         return models.overload();
+    }
+
+    @Override
+    public int fuelCost() {
+        return 2;
     }
 }

--- a/src/main/java/dev/amble/ait/core/item/sonic/SonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/SonicMode.java
@@ -109,6 +109,10 @@ public abstract class SonicMode implements Ordered {
 
     public abstract Identifier model(SonicSchema.Models models);
 
+    public int fuelCost() {
+        return 1;
+    }
+
     public static HitResult getHitResult(LivingEntity user) {
         return getHitResult(user, 16);
     }

--- a/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
+++ b/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
@@ -55,7 +55,8 @@ public class AITBlockTagProvider extends AmbleBlockTagProvider {
                 .add(Blocks.BARREL)
                 .add(Blocks.REDSTONE_WIRE, Blocks.COMPARATOR, Blocks.REPEATER)
                 .add(Blocks.BELL, Blocks.JUKEBOX, Blocks.TRAPPED_CHEST)
-                .add(Blocks.DAYLIGHT_DETECTOR);
+                .add(Blocks.DAYLIGHT_DETECTOR)
+                .add(Blocks.OBSIDIAN);
 
         getOrCreateTagBuilder(BlockTags.COAL_ORES).add(PlanetBlocks.ANORTHOSITE_COAL_ORE, PlanetBlocks.MARTIAN_COAL_ORE);
         getOrCreateTagBuilder(BlockTags.COPPER_ORES).add(PlanetBlocks.ANORTHOSITE_COPPER_ORE, PlanetBlocks.MARTIAN_COPPER_ORE);


### PR DESCRIPTION
feat(sonic): overload mode now costs 2x as much fuel fix(sonic): max stack is 1

## About the PR
<!-- What did you change? -->
Overload can now light obsidian on fire & costs 2x fuel
Fix sonic stacking above 1
closes #1073
closes #1180


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
see relevant issues

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
feat(sonic): overload can light nether portals
tweak(sonic): overload consumes 2x fuel
fix(sonic): stacking above 1