### PR TITLE
fix: removed "likes pottery shards"

### DIFF
--- a/src/main/resources/data/ait/opinion/item/likes_pottery_shards.json
+++ b/src/main/resources/data/ait/opinion/item/likes_pottery_shards.json
@@ -1,8 +1,0 @@
-{
-  "id": "ait:pottery_shards",
-  "stack": {
-    "id": "minecraft:pottery_shards",
-    "Count": 1
-  },
-  "loyalty": 5
-}


### PR DESCRIPTION
## About the PR
Removed "likes pottery shards"

## Why / Balance
Was invalid so air would be "correct" making it so you could easly get loyalty

## Technical details
I just removed pottery shards lol

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- Removed pottery shards from opinions