### PR TITLE
Fix disabling of experimental message for map backup-prompt

### DIFF
--- a/src/main/java/dev/amble/ait/mixin/client/experimental_screen/WorldOpenFlowsMixin.java
+++ b/src/main/java/dev/amble/ait/mixin/client/experimental_screen/WorldOpenFlowsMixin.java
@@ -1,25 +1,25 @@
 package dev.amble.ait.mixin.client.experimental_screen;
 
-import com.mojang.serialization.Lifecycle;
+import net.minecraft.client.gui.screen.Screen;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import net.minecraft.server.integrated.IntegratedServerLoader;
 
 import dev.amble.ait.AITMod;
 
 @Mixin(value = IntegratedServerLoader.class)
-public class WorldOpenFlowsMixin {
+public abstract class WorldOpenFlowsMixin {
 
-    @Inject(method = "tryLoad", at = @At(value = "INVOKE_ASSIGN", target = "Lcom/mojang/serialization/Lifecycle;experimental()Lcom/mojang/serialization/Lifecycle;", remap = false), cancellable = true)
-    private static void confirmWorldCreation(MinecraftClient client, CreateWorldScreen parent, Lifecycle lifecycle,
-            Runnable loader, boolean bypassWarnings, CallbackInfo ci) {
+    @Shadow protected abstract void start(Screen parent, String levelName, boolean safeMode, boolean canShowBackupPrompt);
+
+    @Inject(method = "start(Lnet/minecraft/client/gui/screen/Screen;Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/integrated/IntegratedServerLoader;start(Lnet/minecraft/client/gui/screen/Screen;Ljava/lang/String;ZZ)V", remap = false), cancellable = true)
+    private void skipBackupScreen(Screen parent, String levelName, CallbackInfo ci) {
         if (!AITMod.CONFIG.CLIENT.SHOW_EXPERIMENTAL_WARNING) {
-            loader.run();
+            this.start(parent, levelName, false, false);
             ci.cancel();
         }
     }


### PR DESCRIPTION
## About the PR
Currently when the "Show Experimental Warning" is set to "no", then the experimental-warning will only be disabled for the map _creation_ dialog. But it is also supposed to be disabled when opening existing maps, which it fails to do though.

This PR fixes this, so that the warning messages are not just disabled when creating a new map, but also when opening existing AIT maps.

## Why / Balance
Because it was supposed to work, as evidenced by the existence of the mixin made for that purpose ([WorldOpenFlowsMixin](https://github.com/amblelabs/ait/blob/main/src/main/java/dev/amble/ait/mixin/client/experimental_screen/WorldOpenFlowsMixin.java)).

## Technical details
If the `SHOW_EXPERIMENTAL_WARNING` setting is set to `false`, then the `confirmWorldCreation` method of the [WorldOpenFlowsMixin](https://github.com/amblelabs/ait/blob/main/src/main/java/dev/amble/ait/mixin/client/experimental_screen/WorldOpenFlowsMixin.java#L19) is supposed to prevent the MC backup-screen dialog when opening an existing world, but fails to do so.
Aside from that, it would also get called when creating a new map, which is redundant though because of the [CreateWorldScreenMixin](https://github.com/amblelabs/ait/blob/main/src/main/java/dev/amble/ait/mixin/client/experimental_screen/CreateWorldScreenMixin.java) already taking care of that (successfully).

So instead I hook into an earlier method of `IntegratedServerLoader`, which looks like this:
```java
public void start(Screen parent, String levelName) {
    this.start(parent, levelName, false, true);
}
```

The last boolean parameter determines if a backup screen is shown, so I simply replace this call and set that parameter to `false`.
This successfully prevents the backup screen from showing (if AIT's `SHOW_EXPERIMENTAL_WARNING` is disabled).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: disabled experimental messages still shown during opening of existing AIT maps