### PR TITLE
Fix unused warning-message and missing -title (as well as wording)

### DIFF
--- a/src/main/resources/assets/minecraft/lang/en_us.json
+++ b/src/main/resources/assets/minecraft/lang/en_us.json
@@ -1,6 +1,6 @@
 {
-  "selectWorld.warning.experimental.question": "The TARDIS' are experimental and could one day stop working. Do you wish to proceed with Gallifreyan technology?",
   "selectWorld.backupQuestion.experimental": "Trans-dimensional Engineering Detected!",
-  "selectWorld.backupWarning.experimental": "The TARDIS' are experimental and could one day stop working. Do you wish to proceed with messing around with Gallifreyan technology? GERONIMO!",
-  "selectWorld.warning.experimental.question": "The TARDIS' are experimental and could one day stop working. Do you wish to proceed with playing around with Gallifreyan technology?"
+  "selectWorld.backupWarning.experimental": "The TARDISes are experimental and could one day stop working. Do you wish to proceed messing around with Gallifreyan technology? GERONIMO!",
+  "selectWorld.warning.experimental.title": "Trans-dimensional Engineering Detected!",
+  "selectWorld.warning.experimental.question": "The TARDISes are experimental and could one day stop working. Do you wish to proceed playing around with Gallifreyan technology?"
 }


### PR DESCRIPTION
## About the PR
This PR adds a missing title to the experimental warnings and also removes an unused string from them.

## Why / Balance
To have title-consistency between the warning messages for the map-loading and map-creation screens.
To not have strings that can never be used/picked.

## Technical details
The strings for the experimental-warnings use `selectWorld.warning.experimental.question` two times, which means that only the last of the two is ever used.
In addition, there's title missing (`selectWorld.warning.experimental.title`), which means that it uses the vanilla title in that case.
But since the backup-map warning already uses a custom title ("Trans-dimensional Engineering Detected!"), it makes sense to add that to the warning during map creation as well.

So what I did in this PR is:
1. Remove the unused (first) instance of `selectWorld.warning.experimental.question`.
2. Add a `selectWorld.warning.experimental.title` with the same text as `selectWorld.backupQuestion.experimental` (i.e. "Trans-dimensional Engineering Detected!").

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: unused warning-message and missing -title (as well as some wording)