### PR TITLE
Revert "fix disabling of map backup-prompt not working"

### DIFF
--- a/src/main/java/dev/amble/ait/mixin/client/experimental_screen/WorldOpenFlowsMixin.java
+++ b/src/main/java/dev/amble/ait/mixin/client/experimental_screen/WorldOpenFlowsMixin.java
@@ -1,25 +1,25 @@
 package dev.amble.ait.mixin.client.experimental_screen;
 
-import net.minecraft.client.gui.screen.Screen;
+import com.mojang.serialization.Lifecycle;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.world.CreateWorldScreen;
 import net.minecraft.server.integrated.IntegratedServerLoader;
 
 import dev.amble.ait.AITMod;
 
 @Mixin(value = IntegratedServerLoader.class)
-public abstract class WorldOpenFlowsMixin {
+public class WorldOpenFlowsMixin {
 
-    @Shadow protected abstract void start(Screen parent, String levelName, boolean safeMode, boolean canShowBackupPrompt);
-
-    @Inject(method = "start(Lnet/minecraft/client/gui/screen/Screen;Ljava/lang/String;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/integrated/IntegratedServerLoader;start(Lnet/minecraft/client/gui/screen/Screen;Ljava/lang/String;ZZ)V", remap = false), cancellable = true)
-    private void skipBackupScreen(Screen parent, String levelName, CallbackInfo ci) {
+    @Inject(method = "tryLoad", at = @At(value = "INVOKE_ASSIGN", target = "Lcom/mojang/serialization/Lifecycle;experimental()Lcom/mojang/serialization/Lifecycle;", remap = false), cancellable = true)
+    private static void confirmWorldCreation(MinecraftClient client, CreateWorldScreen parent, Lifecycle lifecycle,
+            Runnable loader, boolean bypassWarnings, CallbackInfo ci) {
         if (!AITMod.CONFIG.CLIENT.SHOW_EXPERIMENTAL_WARNING) {
-            this.start(parent, levelName, false, false);
+            loader.run();
             ci.cancel();
         }
     }


### PR DESCRIPTION
## About the PR
This reverts commit f4406a22539b127691dd94d31678b02d11c63525.
Apparently the previous PR works when testing via IDE, but the built JAR seems to fail the injection of the mixin.
Until I figure out a fix, this should probably be reverted.

## Why / Balance
Creates a crash on trying to load/create a map.

## Technical details
Produces this exception:
```
Caused by: org.spongepowered.asm.mixin.injection.throwables.InjectionError: Critical injection failure: Callback method skipBackupScreen(Lnet/minecraft/class_437;Ljava/lang/String;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V in ait.mixins.json:client.experimental_screen.WorldOpenFlowsMixin from mod ait failed injection check, (0/1) succeeded. Scanned 0 target(s). Using refmap ait-refmap.json
    at org.spongepowered.asm.mixin.injection.struct.InjectionInfo.postInject(InjectionInfo.java:531)
    at org.spongepowered.asm.mixin.transformer.MixinTargetContext.applyInjections(MixinTargetContext.java:1490)
    at org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyInjections(MixinApplicatorStandard.java:752)
    at org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.applyMixin(MixinApplicatorStandard.java:330)
    at org.spongepowered.asm.mixin.transformer.MixinApplicatorStandard.apply(MixinApplicatorStandard.java:246)
    at org.spongepowered.asm.mixin.transformer.TargetClassContext.apply(TargetClassContext.java:437)
    at org.spongepowered.asm.mixin.transformer.TargetClassContext.applyMixins(TargetClassContext.java:418)
    at org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:363)
    ... 36 more
```

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] It does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Revert problematic fix of map backup-warning