### PR TITLE
Fix inconsistent sonic summon behavior for sonic

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
@@ -58,8 +58,7 @@ public class TardisSonicMode extends SonicMode {
             HitResult hitResult = SonicMode.getHitResult(user, 2);
 
             // summon to selected block
-            if (hitResult instanceof BlockHitResult blockHit)
-                return this.interactBlock(stack, world, player, blockHit.getBlockPos());
+            return this.interactBlock(stack, world, player, BlockPos.ofFloored(hitResult.getPos()));
         }
         boolean isLookingUp = user.getPitch() < 0;
 


### PR DESCRIPTION
## About the PR
When **_landing types are disabled_**, then pointing the sonic (in TARDIS mode) at the floor beneath you (or at half a block away from the one you are standing on) will make the TARDIS land one block inside the floor.
This PR changes the way the Y coordinate is determined, so that this no longer happens.

<details>

<ins>Set-up:</ins>
- Disable the TARDIS' **_horizontal and vertical landing type_** (i.e. "disengaged" and "none", respectively).
- Stand on a flat floor with a thickness of at least two blocks.

<ins>Then, with the sonic in TARDIS mode:</ins>
- If you point and click on the same block you're standing on
=> TARDIS will land in that spot, **_but one block in the floor_**.
- If you point and click on block next to the one you're standing on (specifically, the half of that block closest to you)
=> TARDIS will land on that spot, **but one block in the floor**.

It's fine when clicking on blocks with a distance of >= 2 though, as the TARDIS will then always land on the floor and not one block down in it.

<ins>Expectation:</ins>
The TARDIS should always land *on* the floor pointed at and not in the ground (especially if landing types are disabled).
</details>

## Why / Balance
It is counter-intuitive that the TARDIS would land inside the floor if you clicked on the floor.

## Technical details
When clicking on top of a block (with the sonic in TARDIS-mode), then we get a `HitResult` object.
A cast of this type (i.e. to `BlockHitResult`) is used to retrieve the block position to point the TARDIS at (`blockHit.getBlockPos()`).
Unfortunately, this can lead to a Y position one lower than it should, resulting in the TARDIS materializing in the floor.

Instead I replaced `blockHit.getBlockPos()` with `BlockPos.ofFloored(hitResult.getPos())` to get a floored block position based on the raw position of the `HitResult` object.
This will preserve the Y coordinate such that the TARDIS will no longer materialize in the floor (when we clicked on top of the floor).

<ins>Results:</ins>
Raw position clicked on (X, Y, Z): `(-732.4603282685405, 114.0, -944.1389916206703)`
Block position before: `{x=-733, y=113, z=-945}`
Block position after: `{x=-733, y=114, z=-945}`

As you can see, with the original code the block position has a Y of 113, which is one less than the 114 that we pointed at with the sonic. But with the new way of retrieving the block position, the Y is preserved at 114.

## Media
![image](https://github.com/user-attachments/assets/c6a0fc73-6566-4270-8b95-4e6be4aee807)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- fix: TARDIS sometimes landing in floor when summoned