### PR TITLE
Feat: Max range of 256 blocks for sonic summon

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
@@ -99,9 +99,11 @@ public class TardisSonicMode extends SonicMode {
             return false;
         }
 
-        // check if player is within range of TARDIS
+        // check if player is within range of and in same world as TARDIS
+        World tardisWorld = tardis.travel().position().getWorld();
+        boolean inSameWorld = player.getWorld().equals(tardisWorld);
         boolean isNearTardis = TardisUtil.isNearTardis(player, tardis, 256);
-        if (!isNearTardis) {
+        if (!inSameWorld || !isNearTardis) {
             player.sendMessage(Text.translatable("sonic.ait.mode.tardis.is_not_in_range"), true);
             return false;
         }

--- a/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.core.item.sonic;
 
+import dev.amble.ait.core.tardis.util.TardisUtil;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
@@ -12,7 +13,6 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -96,6 +96,13 @@ public class TardisSonicMode extends SonicMode {
 
         if (!tardis.subsystems().get(SubSystem.Id.STABILISERS).isUsable()) {
             player.sendMessage(Text.translatable("sonic.ait.mode.tardis.does_not_have_stabilisers"), true);
+            return false;
+        }
+
+        // check if player is within range of TARDIS
+        boolean isNearTardis = TardisUtil.isNearTardis(player, tardis, 256);
+        if (!isNearTardis) {
+            player.sendMessage(Text.translatable("sonic.ait.mode.tardis.is_not_in_range"), true);
             return false;
         }
 

--- a/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
@@ -465,4 +465,14 @@ public class TardisUtil {
 
         return Optional.ofNullable(nearestPlayer);
     }
+
+    public static boolean isNearTardis(PlayerEntity player, Tardis tardis, double radius) {
+        return radius >= distanceFromTardis(player, tardis);
+    }
+
+    public static double distanceFromTardis(PlayerEntity player, Tardis tardis) {
+        BlockPos pPos = player.getBlockPos();
+        BlockPos tPos = tardis.travel().position().getPos();
+        return Math.sqrt(tPos.getSquaredDistance(pPos));
+    }
 }

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1060,6 +1060,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("message.ait.all_types", "Consoles, Exteriors, Desktops & Sonic Casings");
         provider.addTranslation("screen.ait.sonic_casing", "Sonic Casing");
         provider.addTranslation("sonic.ait.mode.tardis.location_summon", "Summoned TARDIS To Your Location, Please Wait...");
+        provider.addTranslation("sonic.ait.mode.tardis.is_not_in_range",  "TARDIS is out of range!");
         provider.addTranslation("sonic.ait.mode.tardis.does_not_have_stabilisers",  "Remote Summoning Requires Stabilisers!");
         provider.addTranslation("sonic.ait.mode.tardis.refuel", "Engaged Handbrake, TARDIS Refueling...");
         provider.addTranslation("sonic.ait.mode.tardis.flight", "Disengaged Handbrake, TARDIS Dematerialising...");

--- a/src/main/resources/assets/ait/lang/en_us.existing.json
+++ b/src/main/resources/assets/ait/lang/en_us.existing.json
@@ -19,7 +19,5 @@
   "text.config.aitconfig.option.CUSTOM_MENU": "Custom Menu",
   "text.config.aitconfig.option.CUSTOM_MENU.tooltip": "Whether the custom title screen should show",
 
-  "screen.ait.security.title": "Security",
-  "screen.ait.security.leave_behind": "> Toggle leaving behind",
-  "screen.ait.security.hostile_alarms": "> Toggle hostile alarms"
+  "screen.ait.security.title": "Security"
 }


### PR DESCRIPTION
## About the PR
This adds a max range of 256 blocks to the sonic summon.

## Why / Balance
@Ouroboros-Games menioned in Discord that this limitation was in before the sonic rewrite and it was meant to give the Stattenheim Remote more reason to exist.

## Technical details
I saw that the old sonic code used `isNearTardis()` and this method still exists in [ExteriorAnimation](https://github.com/amblelabs/ait/blob/main/src/main/java/dev/amble/ait/core/tardis/animation/ExteriorAnimation.java#L93).
But because that class is marked as deprecated, I copied its code (which is all self-contained) to the `TardisUtil` class and make use of it from there.

So in the `TardisSonicMode` class I simply add a `isNearTardis()` check as a guard clause to determine if the player is within 256 blocks of the TARDIS.
If they are, the code just continues as before.
If they're not, then I display a (translatable) message to let the user know and return false.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- add: max range of 256 blocks for sonic summon