### PR TITLE
fix missing text for waypoint error message

### DIFF
--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -767,6 +767,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("control.ait.console_port", "Console Port");
         provider.addTranslation("control.ait.mark_waypoint", "Save Waypoint");
         provider.addTranslation("control.ait.set_waypoint", "Load Waypoint");
+        provider.addTranslation("control.ait.set_waypoint.error", "Cannot travel to waypoint with handbrake engaged");
         provider.addTranslation("control.ait.increment", "Increment");
         provider.addTranslation("control.ait.x", "X");
         provider.addTranslation("control.ait.y", "Y");


### PR DESCRIPTION
## About the PR
Added the missing translatable text for the waypoint error message.
It's the one that happens if the handbrake is still engaged when trying to load a waypoint via the console.

## Why / Balance
Because otherwise it would display the translatable placeholder.

## Technical details
This PR adds a translatable entry in the `AITModDataGenerator` class.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: missing text for waypoint error message
-->