### PR TITLE
Add TARDIS locator functionality to sonic scanning mode

### DIFF
--- a/src/main/java/dev/amble/ait/AITMod.java
+++ b/src/main/java/dev/amble/ait/AITMod.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 
-import dev.amble.ait.core.item.SonicItem;
 import dev.amble.lib.container.RegistryContainer;
 import dev.amble.lib.register.AmbleRegistries;
 import dev.amble.lib.util.ServerLifecycleHooks;
@@ -14,7 +13,6 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
-import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
 import net.fabricmc.fabric.api.loot.v2.LootTableEvents;
@@ -23,10 +21,6 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.particle.v1.FabricParticleTypes;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.block.Block;
-import net.minecraft.block.Blocks;
-import net.minecraft.item.Item;
-import net.minecraft.util.ActionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -260,22 +254,6 @@ public class AITMod implements ModInitializer {
             FlightCommand.register(dispatcher);
             SetDoorParticleCommand.register(dispatcher, registryAccess);
         }));
-
-        UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
-            // Player interacted with the block at the position of hitResult
-
-            if (!world.isClient()) {
-                Block hitBlock = world.getBlockState(hitResult.getBlockPos()).getBlock();
-                Item itemInHand = player.getStackInHand(hand).getItem();
-
-                // Enable sonic action when interacting with bell
-                if (!player.isSneaking() && hitBlock.equals(Blocks.BELL) && itemInHand instanceof SonicItem) {
-                    itemInHand.use(world, player, hand);
-                }
-            }
-
-            return ActionResult.PASS;
-        });
 
         ServerPlayNetworking.registerGlobalReceiver(TardisUtil.REGION_LANDING_CODE,
                 (server, player, handler, buf, responseSender) -> {

--- a/src/main/java/dev/amble/ait/AITMod.java
+++ b/src/main/java/dev/amble/ait/AITMod.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 
+import dev.amble.ait.core.item.SonicItem;
 import dev.amble.lib.container.RegistryContainer;
 import dev.amble.lib.register.AmbleRegistries;
 import dev.amble.lib.util.ServerLifecycleHooks;
@@ -13,6 +14,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
 import net.fabricmc.fabric.api.loot.v2.LootTableEvents;
@@ -21,6 +23,10 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.particle.v1.FabricParticleTypes;
 import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.util.ActionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -254,6 +260,22 @@ public class AITMod implements ModInitializer {
             FlightCommand.register(dispatcher);
             SetDoorParticleCommand.register(dispatcher, registryAccess);
         }));
+
+        UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
+            // Player interacted with the block at the position of hitResult
+
+            if (!world.isClient()) {
+                Block hitBlock = world.getBlockState(hitResult.getBlockPos()).getBlock();
+                Item itemInHand = player.getStackInHand(hand).getItem();
+
+                // Enable sonic action when interacting with bell
+                if (!player.isSneaking() && hitBlock.equals(Blocks.BELL) && itemInHand instanceof SonicItem) {
+                    itemInHand.use(world, player, hand);
+                }
+            }
+
+            return ActionResult.PASS;
+        });
 
         ServerPlayNetworking.registerGlobalReceiver(TardisUtil.REGION_LANDING_CODE,
                 (server, player, handler, buf, responseSender) -> {

--- a/src/main/java/dev/amble/ait/core/AITTags.java
+++ b/src/main/java/dev/amble/ait/core/AITTags.java
@@ -13,6 +13,7 @@ public class AITTags {
 
     public static class Blocks {
         public static final TagKey<Block> SONIC_INTERACTABLE = createTag("sonic_interactable");
+        public static final TagKey<Block> SONIC_CAN_LOCATE = createTag("sonic_can_locate");
         public static final TagKey<Block> FLUID_LINK_CAN_CONNECT = createTag("fluid_link_can_connect");
 
         private static TagKey<Block> createTag(String name) {

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -36,8 +36,6 @@ import dev.amble.ait.data.landing.LandingPadRegion;
 import dev.amble.ait.data.landing.LandingPadSpot;
 import dev.amble.ait.data.schema.sonic.SonicSchema;
 
-import java.util.Arrays;
-
 public class ScanningSonicMode extends SonicMode {
     private static final Text RIFT_FOUND = Text.translatable("message.ait.sonic.riftfound").formatted(Formatting.AQUA)
             .formatted(Formatting.BOLD);
@@ -109,14 +107,14 @@ public class ScanningSonicMode extends SonicMode {
             Tardis tardis = SonicItem.getTardisStatic(world, stack);
             BlockPos tPos = tardis.travel().position().getPos();
             String dimensionText = MonitorUtil.truncateDimensionName(WorldUtil.worldText(world.getRegistryKey()).getString(), 20);
-            String coordinatesText = Text.translatable("item.sonic.scanning.locator_message.coordinates").getString();
-            String locationText = String.format("%s\n%s: %s %s %s", dimensionText, coordinatesText, tPos.getX(), tPos.getY(), tPos.getZ());
-            Text message = Text.translatable("item.sonic.scanning.locator_message.title").append(locationText);
+
+            Text coordinatesMessage = Text.translatable("item.sonic.scanning.locator_message.coordinates", tPos.getX(), tPos.getY(), tPos.getZ());
+            Text fullMessage = Text.translatable("item.sonic.scanning.locator_message.title", dimensionText).append("\n").append(coordinatesMessage);
 
             // Output looks like:
             // TARDIS Location: {DIMENSION}
             // Coordinates: {X} {Y} {Z}
-            user.sendMessage(message);
+            user.sendMessage(fullMessage);
         }
 
         String toolRequirement = "item.sonic.scanning.any_tool";

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -102,8 +102,7 @@ public class ScanningSonicMode extends SonicMode {
 
         String blastRes = String.format("%.2f", block.getBlastResistance());
 
-        if (state.isIn(AITTags.Blocks.SONIC_CAN_LOCATE))
-        {
+        if (state.isIn(AITTags.Blocks.SONIC_CAN_LOCATE)) {
             Tardis tardis = SonicItem.getTardisStatic(world, stack);
             BlockPos tPos = tardis.travel().position().getPos();
             String dimensionText = MonitorUtil.truncateDimensionName(WorldUtil.worldText(world.getRegistryKey()).getString(), 20);

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.core.item.sonic;
 
+import dev.amble.ait.core.AITBlocks;
 import dev.amble.lib.api.ICantBreak;
 
 import net.minecraft.block.Block;
@@ -32,6 +33,8 @@ import dev.amble.ait.core.world.TardisServerWorld;
 import dev.amble.ait.data.landing.LandingPadRegion;
 import dev.amble.ait.data.landing.LandingPadSpot;
 import dev.amble.ait.data.schema.sonic.SonicSchema;
+
+import java.util.Arrays;
 
 public class ScanningSonicMode extends SonicMode {
     private static final Text RIFT_FOUND = Text.translatable("message.ait.sonic.riftfound").formatted(Formatting.AQUA)
@@ -98,6 +101,27 @@ public class ScanningSonicMode extends SonicMode {
         Block block = state.getBlock();
 
         String blastRes = String.format("%.2f", block.getBlastResistance());
+
+        Block[] validLocatorBlocks = {
+                AITBlocks.ZEITON_BLOCK,
+                AITBlocks.ZEITON_COBBLE,
+                AITBlocks.BUDDING_ZEITON,
+                AITBlocks.COMPACT_ZEITON,
+                AITBlocks.SMALL_ZEITON_BUD,
+                AITBlocks.MEDIUM_ZEITON_BUD,
+                AITBlocks.LARGE_ZEITON_BUD,
+                AITBlocks.ZEITON_CLUSTER,
+        };
+
+        if (Arrays.asList(validLocatorBlocks).contains(block))
+        {
+            Tardis tardis = SonicItem.getTardisStatic(world, stack);
+            int x = tardis.travel().position().getPos().getX();
+            int y = tardis.travel().position().getPos().getY();
+            int z = tardis.travel().position().getPos().getZ();
+            Text message = Text.translatable("item.sonic.scanning.locator_message").append(String.format("%s %s %s", x, y, z));
+            user.sendMessage(message);
+        }
 
         String toolRequirement = "item.sonic.scanning.any_tool";
         if (block instanceof ICantBreak) {

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -109,8 +109,9 @@ public class ScanningSonicMode extends SonicMode {
             Tardis tardis = SonicItem.getTardisStatic(world, stack);
             BlockPos tPos = tardis.travel().position().getPos();
             String dimensionText = MonitorUtil.truncateDimensionName(WorldUtil.worldText(world.getRegistryKey()).getString(), 20);
-            String locationText = String.format("%s\nCoordinates: %s %s %s", dimensionText, tPos.getX(), tPos.getY(), tPos.getZ());
-            Text message = Text.translatable("item.sonic.scanning.locator_message").append(locationText);
+            String coordinatesText = Text.translatable("item.sonic.scanning.locator_message.coordinates").getString();
+            String locationText = String.format("%s\n%s: %s %s %s", dimensionText, coordinatesText, tPos.getX(), tPos.getY(), tPos.getZ());
+            Text message = Text.translatable("item.sonic.scanning.locator_message.title").append(locationText);
 
             // Output looks like:
             // TARDIS Location: {DIMENSION}

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -1,6 +1,6 @@
 package dev.amble.ait.core.item.sonic;
 
-import dev.amble.ait.core.AITBlocks;
+import dev.amble.ait.core.AITTags;
 import dev.amble.lib.api.ICantBreak;
 
 import net.minecraft.block.Block;
@@ -102,18 +102,7 @@ public class ScanningSonicMode extends SonicMode {
 
         String blastRes = String.format("%.2f", block.getBlastResistance());
 
-        Block[] validLocatorBlocks = {
-                AITBlocks.ZEITON_BLOCK,
-                AITBlocks.ZEITON_COBBLE,
-                AITBlocks.BUDDING_ZEITON,
-                AITBlocks.COMPACT_ZEITON,
-                AITBlocks.SMALL_ZEITON_BUD,
-                AITBlocks.MEDIUM_ZEITON_BUD,
-                AITBlocks.LARGE_ZEITON_BUD,
-                AITBlocks.ZEITON_CLUSTER,
-        };
-
-        if (Arrays.asList(validLocatorBlocks).contains(block))
+        if (state.isIn(AITTags.Blocks.SONIC_CAN_LOCATE))
         {
             Tardis tardis = SonicItem.getTardisStatic(world, stack);
             int x = tardis.travel().position().getPos().getX();

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -1,6 +1,8 @@
 package dev.amble.ait.core.item.sonic;
 
 import dev.amble.ait.core.AITTags;
+import dev.amble.ait.core.util.MonitorUtil;
+import dev.amble.ait.core.util.WorldUtil;
 import dev.amble.lib.api.ICantBreak;
 
 import net.minecraft.block.Block;
@@ -105,10 +107,14 @@ public class ScanningSonicMode extends SonicMode {
         if (state.isIn(AITTags.Blocks.SONIC_CAN_LOCATE))
         {
             Tardis tardis = SonicItem.getTardisStatic(world, stack);
-            int x = tardis.travel().position().getPos().getX();
-            int y = tardis.travel().position().getPos().getY();
-            int z = tardis.travel().position().getPos().getZ();
-            Text message = Text.translatable("item.sonic.scanning.locator_message").append(String.format("%s %s %s", x, y, z));
+            BlockPos tPos = tardis.travel().position().getPos();
+            String dimensionText = MonitorUtil.truncateDimensionName(WorldUtil.worldText(world.getRegistryKey()).getString(), 20);
+            String locationText = String.format("%s\nCoordinates: %s %s %s", dimensionText, tPos.getX(), tPos.getY(), tPos.getZ());
+            Text message = Text.translatable("item.sonic.scanning.locator_message").append(locationText);
+
+            // Output looks like:
+            // TARDIS Location: {DIMENSION}
+            // Coordinates: {X} {Y} {Z}
             user.sendMessage(message);
         }
 

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1013,8 +1013,8 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("item.sonic.scanning.stone_tool", "Stone Tool");
         provider.addTranslation("item.sonic.scanning.no_tool", "Hand (No Tool)");
         provider.addTranslation("item.sonic.scanning.cant_break", "Can't Break Block!");
-        provider.addTranslation("item.sonic.scanning.locator_message.title", "TARDIS location: ");
-        provider.addTranslation("item.sonic.scanning.locator_message.coordinates", "Coordinates");
+        provider.addTranslation("item.sonic.scanning.locator_message.title", "TARDIS location: %s");
+        provider.addTranslation("item.sonic.scanning.locator_message.coordinates", "Coordinates: %s %s %s");
 
 
         // Loyalty Messages In Bed

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1013,7 +1013,8 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("item.sonic.scanning.stone_tool", "Stone Tool");
         provider.addTranslation("item.sonic.scanning.no_tool", "Hand (No Tool)");
         provider.addTranslation("item.sonic.scanning.cant_break", "Can't Break Block!");
-        provider.addTranslation("item.sonic.scanning.locator_message", "TARDIS location: ");
+        provider.addTranslation("item.sonic.scanning.locator_message.title", "TARDIS location: ");
+        provider.addTranslation("item.sonic.scanning.locator_message.coordinates", "Coordinates");
 
 
         // Loyalty Messages In Bed

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1013,6 +1013,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("item.sonic.scanning.stone_tool", "Stone Tool");
         provider.addTranslation("item.sonic.scanning.no_tool", "Hand (No Tool)");
         provider.addTranslation("item.sonic.scanning.cant_break", "Can't Break Block!");
+        provider.addTranslation("item.sonic.scanning.locator_message", "TARDIS location: ");
 
 
         // Loyalty Messages In Bed

--- a/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
+++ b/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
@@ -58,6 +58,10 @@ public class AITBlockTagProvider extends AmbleBlockTagProvider {
                 .add(Blocks.DAYLIGHT_DETECTOR)
                 .add(Blocks.OBSIDIAN);
 
+        getOrCreateTagBuilder(AITTags.Blocks.SONIC_CAN_LOCATE).add(AITBlocks.ZEITON_BLOCK).add(AITBlocks.ZEITON_COBBLE)
+                .add(AITBlocks.BUDDING_ZEITON).add(AITBlocks.COMPACT_ZEITON).add(AITBlocks.SMALL_ZEITON_BUD)
+                .add(AITBlocks.MEDIUM_ZEITON_BUD).add(AITBlocks.LARGE_ZEITON_BUD).add(AITBlocks.ZEITON_CLUSTER);
+
         getOrCreateTagBuilder(BlockTags.COAL_ORES).add(PlanetBlocks.ANORTHOSITE_COAL_ORE, PlanetBlocks.MARTIAN_COAL_ORE);
         getOrCreateTagBuilder(BlockTags.COPPER_ORES).add(PlanetBlocks.ANORTHOSITE_COPPER_ORE, PlanetBlocks.MARTIAN_COPPER_ORE);
         getOrCreateTagBuilder(BlockTags.IRON_ORES).add(PlanetBlocks.ANORTHOSITE_COPPER_ORE, PlanetBlocks.MARTIAN_COPPER_ORE);

--- a/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
+++ b/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
@@ -60,7 +60,8 @@ public class AITBlockTagProvider extends AmbleBlockTagProvider {
 
         getOrCreateTagBuilder(AITTags.Blocks.SONIC_CAN_LOCATE).add(AITBlocks.ZEITON_BLOCK).add(AITBlocks.ZEITON_COBBLE)
                 .add(AITBlocks.BUDDING_ZEITON).add(AITBlocks.COMPACT_ZEITON).add(AITBlocks.SMALL_ZEITON_BUD)
-                .add(AITBlocks.MEDIUM_ZEITON_BUD).add(AITBlocks.LARGE_ZEITON_BUD).add(AITBlocks.ZEITON_CLUSTER);
+                .add(AITBlocks.MEDIUM_ZEITON_BUD).add(AITBlocks.LARGE_ZEITON_BUD).add(AITBlocks.ZEITON_CLUSTER)
+                .add(Blocks.BELL);
 
         getOrCreateTagBuilder(BlockTags.COAL_ORES).add(PlanetBlocks.ANORTHOSITE_COAL_ORE, PlanetBlocks.MARTIAN_COAL_ORE);
         getOrCreateTagBuilder(BlockTags.COPPER_ORES).add(PlanetBlocks.ANORTHOSITE_COPPER_ORE, PlanetBlocks.MARTIAN_COPPER_ORE);

--- a/src/main/java/dev/amble/ait/mixin/server/BellBlockMixin.java
+++ b/src/main/java/dev/amble/ait/mixin/server/BellBlockMixin.java
@@ -43,8 +43,7 @@ public class BellBlockMixin {
         // sonic summon used on bell (locator feature) -> play cloister sound
         if (entity instanceof PlayerEntity
                 && itemInHand.getItem() instanceof SonicItem
-                && SonicItem.mode(itemInHand) == SonicMode.Modes.SCANNING)
-        {
+                && SonicItem.mode(itemInHand) == SonicMode.Modes.SCANNING) {
             world.playSound(null, pos, AITSounds.CLOISTER, SoundCategory.BLOCKS, 2.0F, 1.0F);
             cir.cancel();
         }

--- a/src/main/java/dev/amble/ait/mixin/server/BellBlockMixin.java
+++ b/src/main/java/dev/amble/ait/mixin/server/BellBlockMixin.java
@@ -1,0 +1,52 @@
+package dev.amble.ait.mixin.server;
+
+import dev.amble.ait.core.AITSounds;
+import dev.amble.ait.core.item.SonicItem;
+import dev.amble.ait.core.item.sonic.SonicMode;
+import net.minecraft.block.BellBlock;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = BellBlock.class)
+public class BellBlockMixin {
+
+    @Inject(method = "onUse", at = @At(value = "HEAD"))
+    private void ait$onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit, CallbackInfoReturnable<ActionResult> cir) {
+        if (!world.isClient()) {
+            Item itemInHand = player.getStackInHand(hand).getItem();
+
+            // sonic summon used on bell (locator feature) -> do not ignore sonic use
+            if (!player.isSneaking() && itemInHand instanceof SonicItem) {
+                itemInHand.use(world, player, hand);
+            }
+        }
+    }
+
+    @Inject(method = "ring(Lnet/minecraft/entity/Entity;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;playSound(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/sound/SoundEvent;Lnet/minecraft/sound/SoundCategory;FF)V"), cancellable = true)
+    public void ait$playSound(Entity entity, World world, BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> cir) {
+        ItemStack itemInHand = ((PlayerEntity) entity).getActiveItem();
+
+        // sonic summon used on bell (locator feature) -> play cloister sound
+        if (entity instanceof PlayerEntity
+                && itemInHand.getItem() instanceof SonicItem
+                && SonicItem.mode(itemInHand) == SonicMode.Modes.SCANNING)
+        {
+            world.playSound(null, pos, AITSounds.CLOISTER, SoundCategory.BLOCKS, 2.0F, 1.0F);
+            cir.cancel();
+        }
+    }
+}

--- a/src/main/java/dev/amble/ait/mixin/server/BellBlockMixin.java
+++ b/src/main/java/dev/amble/ait/mixin/server/BellBlockMixin.java
@@ -4,15 +4,10 @@ import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.core.item.SonicItem;
 import dev.amble.ait.core.item.sonic.SonicMode;
 import net.minecraft.block.BellBlock;
-import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.SoundCategory;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
-import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
@@ -24,28 +19,18 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(value = BellBlock.class)
 public class BellBlockMixin {
 
-    @Inject(method = "onUse", at = @At(value = "HEAD"))
-    private void ait$onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit, CallbackInfoReturnable<ActionResult> cir) {
-        if (!world.isClient()) {
-            Item itemInHand = player.getStackInHand(hand).getItem();
-
-            // sonic summon used on bell (locator feature) -> do not ignore sonic use
-            if (!player.isSneaking() && itemInHand instanceof SonicItem) {
-                itemInHand.use(world, player, hand);
-            }
-        }
-    }
-
     @Inject(method = "ring(Lnet/minecraft/entity/Entity;Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/Direction;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;playSound(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/sound/SoundEvent;Lnet/minecraft/sound/SoundCategory;FF)V"), cancellable = true)
     public void ait$playSound(Entity entity, World world, BlockPos pos, Direction direction, CallbackInfoReturnable<Boolean> cir) {
-        ItemStack itemInHand = ((PlayerEntity) entity).getActiveItem();
 
         // sonic summon used on bell (locator feature) -> play cloister sound
-        if (entity instanceof PlayerEntity
-                && itemInHand.getItem() instanceof SonicItem
-                && SonicItem.mode(itemInHand) == SonicMode.Modes.SCANNING) {
-            world.playSound(null, pos, AITSounds.CLOISTER, SoundCategory.BLOCKS, 2.0F, 1.0F);
-            cir.cancel();
+        if (!world.isClient() && entity instanceof PlayerEntity player) {
+            ItemStack itemInHand = player.getMainHandStack();
+
+            if (itemInHand.getItem() instanceof SonicItem && SonicItem.mode(itemInHand) == SonicMode.Modes.SCANNING) {
+                world.playSound(null, pos, AITSounds.CLOISTER, SoundCategory.BLOCKS, 2.0F, 1.0F);
+                itemInHand.use(world, player, player.getActiveHand());
+                cir.cancel();
+            }
         }
     }
 }

--- a/src/main/resources/ait.mixins.json
+++ b/src/main/resources/ait.mixins.json
@@ -24,6 +24,7 @@
     "rwf.DismountEntityMixin",
     "rwf.LivingEntityAccessor",
     "server.BedInTardisMixin",
+    "server.BellBlockMixin",
     "server.EnderDragonFightAccessor",
     "server.ItemEntityMixin",
     "server.MinecraftServerMixin",


### PR DESCRIPTION
## About the PR
This PR adds a TARDIS locator ability to the sonic scanning mode.
When in scanning mode, interacting (right-clicking) on any Zeiton block will display the linked TARDIS' coordinates.

The Zeiton block requirement is to balance it a bit. The in-world idea is:
The sonic needs to interact with some Zeiton to make it resonate at the linked TARDIS' frequency, which sends a pulse through space-time that gets reflected by the linked TARDIS, kind of like space-time sonar.

Not sure if that is a satisfying explanation, but if you want other blocks as a requirement or don't want the block limitation at all, let me know. :)

## Why / Balance
It provides yet another alternative to get back to one's TARDIS, next to the Stattenheim Remote and the Hazandra.
The former gets the TARDIS to the player, if there's enough fuel.
The latter teleports the player into the interior, which is quite powerful, but requires preparation (i.e. linking the Hazandra before losing the TARDIS).
The locator functionality of this PR provides a last ditch effort to get to one's TARDIS, on foot if necessary.


## Technical details
During a scan of the sonic I check if the targeted block is one of the Zeiton blocks.
If so, I retrieve the current coordinates of the TARDIS that the sonic is linked to and display them to the user.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- add: TARDIS locator functionality to sonic scanning mode