### PR TITLE
Sticky keys

### DIFF
--- a/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
@@ -192,11 +192,6 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
             return ActionResult.FAIL;
         }
 
-        if (player.getMainHandStack().getItem() == Items.SHEARS) {
-            this.playSound(SoundEvents.ENTITY_SHEEP_SHEAR, 1, 1);
-            this.dataTracker.set(STICKY, false);
-        }
-
         if (getSticky()) {
             if (player.getMainHandStack().getItem() == Items.SHEARS) {
                 this.playSound(SoundEvents.ENTITY_SHEEP_SHEAR, 1, 1);

--- a/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
@@ -135,7 +135,7 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
         nbt.putInt("sequenceColor", this.getSequenceIndex());
         nbt.putBoolean("wasSequenced", this.wasSequenced());
         nbt.putFloat("durability", this.getDurability());
-        nbt.putBoolean("sticky", this.getSticky());
+        nbt.putBoolean("sticky", this.isSticky());
     }
 
     @Override
@@ -192,7 +192,7 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
             return ActionResult.FAIL;
         }
 
-        if (getSticky()) {
+        if (isSticky()) {
             if (player.getMainHandStack().getItem() == Items.SHEARS) {
                 this.playSound(SoundEvents.ENTITY_SHEEP_SHEAR, 1, 1);
                 this.dataTracker.set(STICKY, false);
@@ -354,7 +354,7 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
     public float getDurability() {
         return this.dataTracker.get(DURABILITY);
     }
-    public boolean getSticky() {
+    public boolean isSticky() {
         return this.dataTracker.get(STICKY);
     }
     public DurabilityStates getDurabilityState(float durability) {

--- a/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
@@ -8,6 +8,7 @@ import dev.drtheo.scheduler.api.TimeUnit;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Vector3f;
 
+import net.minecraft.block.Blocks;
 import net.minecraft.entity.*;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.data.DataTracker;
@@ -19,6 +20,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtHelper;
+import net.minecraft.particle.BlockStateParticleEffect;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
@@ -65,6 +67,8 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
             TrackedDataHandlerRegistry.BOOLEAN);
     private static final TrackedData<Float> DURABILITY = DataTracker.registerData(ConsoleControlEntity.class,
             TrackedDataHandlerRegistry.FLOAT);
+    private static final TrackedData<Boolean> STICKY = DataTracker.registerData(ConsoleControlEntity.class,
+            TrackedDataHandlerRegistry.BOOLEAN);
 
     private BlockPos consoleBlockPos;
     private Control control;
@@ -112,6 +116,7 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
         this.dataTracker.startTracking(WAS_SEQUENCED, false);
         this.dataTracker.startTracking(ON_DELAY, false);
         this.dataTracker.startTracking(DURABILITY, MAX_DURABILITY);
+        this.dataTracker.startTracking(STICKY, false);
     }
 
     @Override
@@ -130,6 +135,7 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
         nbt.putInt("sequenceColor", this.getSequenceIndex());
         nbt.putBoolean("wasSequenced", this.wasSequenced());
         nbt.putFloat("durability", this.getDurability());
+        nbt.putBoolean("sticky", this.getSticky());
     }
 
     @Override
@@ -161,6 +167,8 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
 
         if (nbt.contains("durability"))
             this.setDurability(nbt.getFloat("durability"));
+        if (nbt.contains("sticky"))
+            this.setSticky(nbt.getBoolean("sticky"));
     }
 
     @Override
@@ -177,14 +185,45 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
             return ActionResult.SUCCESS;
         }
 
+
         handStack.useOnEntity(player, this, hand);
 
-        if (handStack.getItem() instanceof ControlBlockItem)
+        if (handStack.getItem() instanceof ControlBlockItem) {
             return ActionResult.FAIL;
+        }
+
+        if (player.getMainHandStack().getItem() == Items.SHEARS) {
+            this.playSound(SoundEvents.ENTITY_SHEEP_SHEAR, 1, 1);
+            this.dataTracker.set(STICKY, false);
+        }
+
+        if (getSticky()) {
+            if (player.getMainHandStack().getItem() == Items.SHEARS) {
+                this.playSound(SoundEvents.ENTITY_SHEEP_SHEAR, 1, 1);
+                this.dataTracker.set(STICKY, false);
+                return ActionResult.FAIL;
+            }
+
+            this.playSound(SoundEvents.BLOCK_SLIME_BLOCK_BREAK, 0.4f, 1);
+            player.getWorld().addParticle(
+                    new BlockStateParticleEffect(ParticleTypes.BLOCK, Blocks.SLIME_BLOCK.getDefaultState()),
+                    this.getX(), this.getY(), this.getZ(),
+                    0.2, 0.5, -0.1
+            );
+
+            return ActionResult.FAIL;
+        } else {
+            if (player.getMainHandStack().getItem() == Items.SLIME_BALL) {
+                this.playSound(SoundEvents.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
+                this.dataTracker.set(STICKY, true);
+                return ActionResult.FAIL;
+            }
+        }
 
         if (hand == Hand.MAIN_HAND && !this.run(player, player.getWorld(), false)) {
             this.playFailFx();
         }
+
 
         return ActionResult.SUCCESS;
     }
@@ -320,13 +359,18 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
     public float getDurability() {
         return this.dataTracker.get(DURABILITY);
     }
+    public boolean getSticky() {
+        return this.dataTracker.get(STICKY);
+    }
     public DurabilityStates getDurabilityState(float durability) {
         return DurabilityStates.get(durability);
     }
     public void setDurability(float durability) {
         this.dataTracker.set(DURABILITY, durability);
     }
-
+    public void setSticky(boolean sticky) {
+        this.dataTracker.set(STICKY, sticky);
+    }
     public void addDurability(float durability) {
         this.setDurability(Math.min(durability, MAX_DURABILITY));
     }
@@ -410,6 +454,7 @@ public class ConsoleControlEntity extends LinkableDummyLivingEntity {
 
         this.getConsole().ifPresent(console -> this.getWorld().playSound(null, this.getBlockPos(), this.control.getSound(console.getTypeSchema(), result), SoundCategory.BLOCKS, 0.7f,
                 1f));
+
 
         return result.isSuccess();
     }


### PR DESCRIPTION
## About the PR
added the option to prank your friends by right clicking a slimeball on the control to lock it and shears to unlock it.

## Why / Balance
it makes it more interactive

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Locking controls by using slime to stick them and shears to remove them!
-->