### PR TITLE
EnumMap thread safety

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/TardisHandlersManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisHandlersManager.java
@@ -16,13 +16,12 @@ import dev.amble.ait.api.tardis.TardisComponent;
 import dev.amble.ait.api.tardis.TardisTickable;
 import dev.amble.ait.data.Exclude;
 import dev.amble.ait.data.enummap.ConcurrentEnumMap;
-import dev.amble.ait.data.enummap.EnumMap;
 import dev.amble.ait.registry.impl.TardisComponentRegistry;
 
 public class TardisHandlersManager extends TardisComponent implements TardisTickable {
 
     @Exclude
-    private final EnumMap<IdLike, TardisComponent> handlers = new ConcurrentEnumMap<>(TardisComponentRegistry::values,
+    private final ConcurrentEnumMap<IdLike, TardisComponent> handlers = new ConcurrentEnumMap<>(TardisComponentRegistry::values,
             TardisComponent[]::new);
 
     public TardisHandlersManager() {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/SubSystemHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/SubSystemHandler.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.Consumer;
 
 import com.google.gson.*;
+import dev.amble.ait.data.enummap.ConcurrentEnumMap;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,11 +19,10 @@ import dev.amble.ait.core.engine.SubSystem;
 import dev.amble.ait.core.engine.impl.*;
 import dev.amble.ait.core.engine.registry.SubSystemRegistry;
 import dev.amble.ait.data.Exclude;
-import dev.amble.ait.data.enummap.EnumMap;
 
 public class SubSystemHandler extends KeyedTardisComponent implements TardisTickable, Iterable<SubSystem> {
     @Exclude
-    private final EnumMap<SubSystem.IdLike, SubSystem> systems = new EnumMap<>(SubSystemRegistry::values,
+    private final ConcurrentEnumMap<SubSystem.IdLike, SubSystem> systems = new ConcurrentEnumMap<>(SubSystemRegistry::values,
             SubSystem[]::new);
 
     static {

--- a/src/main/java/dev/amble/ait/data/enummap/ConcurrentEnumMap.java
+++ b/src/main/java/dev/amble/ait/data/enummap/ConcurrentEnumMap.java
@@ -25,6 +25,11 @@ public class ConcurrentEnumMap<K extends Ordered, V> extends EnumMap<K, V> {
     }
 
     @Override
+    public synchronized V get(K k) {
+        return super.get(k);
+    }
+
+    @Override
     public synchronized V get(int index) {
         return super.get(index);
     }

--- a/src/main/java/dev/amble/ait/data/enummap/ConcurrentEnumMap.java
+++ b/src/main/java/dev/amble/ait/data/enummap/ConcurrentEnumMap.java
@@ -10,30 +10,22 @@ import java.util.function.Supplier;
  */
 public class ConcurrentEnumMap<K extends Ordered, V> extends EnumMap<K, V> {
 
-    private final Object lock = new Object();
-
     public ConcurrentEnumMap(Supplier<K[]> values, Function<Integer, V[]> supplier) {
         super(values, supplier);
     }
 
     @Override
-    public V put(K k, V v) {
-        synchronized (lock) {
-            return super.put(k, v);
-        }
+    public synchronized V put(K k, V v) {
+        return super.put(k, v);
     }
 
     @Override
-    public void clear() {
-        synchronized (lock) {
-            super.clear();
-        }
+    public synchronized void clear() {
+        super.clear();
     }
 
     @Override
-    public V get(int index) {
-        synchronized (lock) {
-            return super.get(index);
-        }
+    public synchronized V get(int index) {
+        return super.get(index);
     }
 }


### PR DESCRIPTION
## About the PR
This is a follow up PR to my `EnumMap` thread safety fix.

## Why / Balance
The previous PR, while reducing the amount of race conditions, still
 showed the buggy behavior of returning nulls.

## Technical details
Apparently, I've forgotten to override the get-by-index method.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a 🆑 symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
🆑
- fix: more stability