### PR TITLE
Lazy tardis ticking

### DIFF
--- a/src/main/java/dev/amble/ait/compat/gravity/GravityHandler.java
+++ b/src/main/java/dev/amble/ait/compat/gravity/GravityHandler.java
@@ -1,19 +1,19 @@
 package dev.amble.ait.compat.gravity;
 
-import java.util.List;
-
 import gravity_changer.EntityTags;
 import gravity_changer.api.GravityChangerAPI;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.TypeFilter;
 import net.minecraft.util.math.Direction;
 
 import dev.amble.ait.AITMod;
@@ -25,7 +25,6 @@ import dev.amble.ait.client.screens.interior.InteriorSettingsScreen;
 import dev.amble.ait.client.screens.widget.DynamicPressableTextWidget;
 import dev.amble.ait.core.tardis.Tardis;
 import dev.amble.ait.core.tardis.manager.ServerTardisManager;
-import dev.amble.ait.core.tardis.util.TardisUtil;
 import dev.amble.ait.data.Exclude;
 import dev.amble.ait.data.properties.Property;
 import dev.amble.ait.data.properties.Value;
@@ -59,11 +58,11 @@ public class GravityHandler extends KeyedTardisComponent implements TardisTickab
     }
 
     private void onTick() {
-        List<LivingEntity> list = TardisUtil.getLivingInInterior(this.tardis, EntityTags::canChangeGravity);
-
-        for (LivingEntity entity : list) {
-            GravityChangerAPI.getGravityComponent(entity).setBaseGravityDirection(this.direction.get());
-        }
+        this.tardis.asServer().worldRef().ifPresent(world -> {
+            for (Entity entity : world.getEntitiesByType(TypeFilter.instanceOf(LivingEntity.class), EntityTags::canChangeGravity)) {
+                GravityChangerAPI.getGravityComponent(entity).setBaseGravityDirection(this.direction.get());
+            }
+        });
     }
 
     private static void syncToServer(Tardis tardis, Direction direction) {

--- a/src/main/java/dev/amble/ait/core/advancement/TardisCriterions.java
+++ b/src/main/java/dev/amble/ait/core/advancement/TardisCriterions.java
@@ -63,7 +63,7 @@ public class TardisCriterions {
 
             Advancement advancement = player.getServer().getAdvancementLoader().get(new Identifier("ait/enter_tardis"));
             if (player.getWorld() instanceof TardisServerWorld && !player.getAdvancementTracker().getProgress(advancement).isDone()) {
-                Scheduler.get().runTaskLater(() -> tardis.asServer().getInteriorWorld().playSound(null, player.getBlockPos(), AITSounds.WONDERFUL_TIME_IN_SPACE,
+                Scheduler.get().runTaskLater(() -> tardis.asServer().worldRef().get().playSound(null, player.getBlockPos(), AITSounds.WONDERFUL_TIME_IN_SPACE,
                         SoundCategory.PLAYERS, 0.6f, 1.0f), TimeUnit.TICKS, 400);
             }
             TardisCriterions.ENTER_TARDIS.trigger(player);

--- a/src/main/java/dev/amble/ait/core/blocks/DoorBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/DoorBlock.java
@@ -1,7 +1,6 @@
 package dev.amble.ait.core.blocks;
 
 import dev.amble.lib.data.CachedDirectedGlobalPos;
-import dev.amble.lib.util.ServerLifecycleHooks;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.*;
@@ -62,15 +61,15 @@ public class DoorBlock extends HorizontalDirectionalBlock implements BlockEntity
     }
 
     private static void setDoorLight(Tardis tardis, int level) {
-        if (ServerLifecycleHooks.get() == null) return; // beautiful jank
+        tardis.asServer().worldRef().ifPresent(world -> {
+            BlockPos pos = tardis.getDesktop().getDoorPos().getPos();
 
-        World world = tardis.asServer().getInteriorWorld();
-        BlockPos pos = tardis.getDesktop().getDoorPos().getPos();
+            BlockState state = world.getBlockState(pos);
+            if (!(state.getBlock() instanceof DoorBlock))
+                return;
 
-        BlockState state = world.getBlockState(pos);
-        if (!(state.getBlock() instanceof DoorBlock))
-            return;
-        world.setBlockState(pos, state.with(LEVEL_4, level));
+            world.setBlockState(pos, state.with(LEVEL_4, level));
+        });
     }
 
     public DoorBlock(Settings settings) {

--- a/src/main/java/dev/amble/ait/core/item/InteriorTeleporterItem.java
+++ b/src/main/java/dev/amble/ait/core/item/InteriorTeleporterItem.java
@@ -74,7 +74,7 @@ public class InteriorTeleporterItem extends LinkableItem { // todo - new model +
         user.getItemCooldownManager().set(this, 16 * 20);
 
         BlockPos door = tardis.getDesktop().getDoorPos().getPos();
-        createTeleportEffect(tardis.asServer().getInteriorWorld(), door.toCenterPos().subtract(0, 0.5, 0), PARTICLE_SUCCESS);
+        createTeleportEffect(tardis.asServer().worldRef().get(), door.toCenterPos().subtract(0, 0.5, 0), PARTICLE_SUCCESS);
         world.playSound(null, door, AITSounds.DING, SoundCategory.PLAYERS, 1f, 1f);
         world.playSound(null, door, AITSounds.LAND_THUD, SoundCategory.PLAYERS, 1f, 1f);
 

--- a/src/main/java/dev/amble/ait/core/tardis/ServerTardis.java
+++ b/src/main/java/dev/amble/ait/core/tardis/ServerTardis.java
@@ -8,6 +8,8 @@ import java.util.function.Consumer;
 
 import com.google.gson.InstanceCreator;
 
+import dev.amble.ait.core.tardis.handler.travel.TravelHandler;
+import dev.drtheo.multidim.MultiDim;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 
@@ -89,6 +91,18 @@ public class ServerTardis extends Tardis {
             this.world = TardisServerWorld.create(this);
 
         return this.world;
+    }
+
+    public boolean shouldTick() {
+        if (this.world != null && !this.world.getPlayers().isEmpty())
+            return true;
+
+        TravelHandler travel = this.travel();
+
+        if (travel == null)
+            return false;
+
+        return travel.position().getWorld().shouldTickEntity(travel.position().getPos());
     }
 
     public static Object creator() {

--- a/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
@@ -147,7 +147,7 @@ public class TardisDesktop extends TardisComponent {
             TardisEvents.RECONFIGURE_DESKTOP.invoker().reconfigure(this.tardis);
 
         ServerTardis tardis = this.tardis.asServer();
-        ServerWorld world = tardis.getInteriorWorld();
+        ServerWorld world = tardis.worldRef().get();
 
         Optional<StructureTemplate> optional = this.schema.findTemplate();
 
@@ -173,7 +173,7 @@ public class TardisDesktop extends TardisComponent {
 
     public ActionQueue createDesktopClearQueue() {
         ServerTardis tardis = this.tardis.asServer();
-        ServerWorld world = tardis.getInteriorWorld();
+        ServerWorld world = tardis.worldRef().get();
         int chunkRadius = ChunkSectionPos.getSectionCoord(RADIUS);
 
         TardisUtil.getEntitiesInBox(AbstractDecorationEntity.class, world, corners.getBox(), frame -> true)
@@ -213,7 +213,7 @@ public class TardisDesktop extends TardisComponent {
     }
 
     public void cacheConsole(BlockPos consolePos) {
-        World dim = this.tardis.asServer().getInteriorWorld();
+        World dim = this.tardis.asServer().worldRef().get();
         dim.playSound(null, consolePos, SoundEvents.BLOCK_BEACON_DEACTIVATE, SoundCategory.BLOCKS, 0.5f, 1.0f);
 
         if (dim.getBlockEntity(consolePos) instanceof ConsoleBlockEntity entity) {
@@ -239,7 +239,9 @@ public class TardisDesktop extends TardisComponent {
     public void playSoundAtEveryConsole(SoundEvent sound, SoundCategory category, float volume, float pitch) {
         if (!this.isServer()) return;
 
-        this.getConsolePos().forEach(consolePos -> playSoundAtConsole(this.tardis.asServer().getInteriorWorld(), consolePos, sound, category, volume, pitch));
+        this.tardis.asServer().worldRef().ifPresent(world ->
+                this.getConsolePos().forEach(consolePos ->
+                        playSoundAtConsole(world, consolePos, sound, category, volume, pitch)));
     }
 
     public void playSoundAtEveryConsole(SoundEvent sound, SoundCategory category) {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/ButlerHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/ButlerHandler.java
@@ -37,7 +37,7 @@ public class ButlerHandler extends KeyedTardisComponent implements ArtronHolderI
 
     public void insertHandles(ItemStack handlesMyBoy, BlockPos consolePos) {
         insertAnyHandles(this.handles, handlesMyBoy,
-                stack -> spawnItem(tardis.asServer().getInteriorWorld(), consolePos, stack));
+                stack -> spawnItem(tardis.asServer().worldRef().get(), consolePos, stack));
     }
 
     public ItemStack takeHandles() {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -244,7 +244,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
      * @param cPos The position of the console to replace.
      */
     private void replaceConsoleWithGrowth(BlockPos cPos) {
-        ServerWorld world = tardis.asServer().getInteriorWorld();
+        ServerWorld world = tardis.asServer().worldRef().get();
 
         if (!(world.getBlockEntity(cPos) instanceof ConsoleBlockEntity console))
             return;
@@ -283,7 +283,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         DirectedBlockPos door = this.tardis.getDesktop().getDoorPos();
 
         CachedDirectedGlobalPos safe = CachedDirectedGlobalPos.create(
-                this.tardis.asServer().getInteriorWorld(),
+                this.tardis.asServer().worldRef().get(),
                 door.getPos().offset(door.toMinecraftDirection(), 2),
                 door.getRotation()
         );
@@ -328,7 +328,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
 
             if (!isQueued) {
                 if (server.getTicks() % 200 == 0 && this.hasEnoughPlasmicMaterial())
-                    this.tardis.asServer().getInteriorWorld().getPlayers().forEach(player ->
+                    this.tardis.asServer().worldRef().get().getPlayers().forEach(player ->
                             player.sendMessage(HINT_TEXT, true));
 
                 if (this.tardis.door().isClosed()) {
@@ -352,7 +352,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
 
         if (!TardisUtil.isInteriorEmpty(tardis.asServer())) {
             if (this.regenerating.get()) {
-                PlayerEntity target = TardisUtil.getAnyPlayerInsideInterior(tardis.asServer().getInteriorWorld());
+                PlayerEntity target = TardisUtil.getAnyPlayerInsideInterior(tardis.asServer().worldRef().get());
 
                 if (this.tardis().subsystems().lifeSupport().isEnabled()) {
                     TardisUtil.teleportOutside(tardis.asServer(), target);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/SiegeHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/SiegeHandler.java
@@ -143,9 +143,7 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
             this.siegeTime = 0;
         }
 
-        for (BlockPos console : this.tardis.getDesktop().getConsolePos()) {
-            TardisDesktop.playSoundAtConsole(tardis.asServer().getInteriorWorld(), console, sound, SoundCategory.BLOCKS, 3f, 1f);
-        }
+        tardis.getDesktop().playSoundAtEveryConsole(sound, SoundCategory.BLOCKS, 3f, 1f);
 
         this.tardis.removeFuel(0.01 * FuelHandler.TARDIS_MAX_FUEL * this.tardis.travel().instability());
         this.active.set(siege);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/SonicHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/SonicHandler.java
@@ -66,7 +66,7 @@ public class SonicHandler extends KeyedTardisComponent implements ArtronHolderIt
 
     public void insertConsoleSonic(ItemStack sonic, BlockPos consolePos) {
         insertAnySonic(this.consoleSonic, sonic,
-                stack -> spawnItem(tardis.asServer().getInteriorWorld(), consolePos, stack));
+                stack -> spawnItem(tardis.asServer().worldRef().get(), consolePos, stack));
     }
 
     public void insertExteriorSonic(ItemStack sonic) {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/WaypointHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/WaypointHandler.java
@@ -96,10 +96,10 @@ public class WaypointHandler extends KeyedTardisComponent {
         if (!this.hasCartridge())
             return;
 
-        ItemEntity entity = new ItemEntity(tardis.asServer().getInteriorWorld(), console.getX(), console.getY(),
+        ItemEntity entity = new ItemEntity(tardis.asServer().worldRef().get(), console.getX(), console.getY(),
                 console.getZ(), createWaypointItem(waypoint));
 
-        tardis.asServer().getInteriorWorld().spawnEntity(entity);
+        tardis.asServer().worldRef().get().spawnEntity(entity);
         this.clearCartridge();
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/handler/distress/DistressCall.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/distress/DistressCall.java
@@ -140,7 +140,11 @@ public record DistressCall(Sender sender, String message, int lifetime, int crea
         if (!target.stats().receiveCalls().get()) return; // ignore if doesnt want to receive
 
         // spawn distress item at door
-        ServerWorld world = target.getInteriorWorld();
+        ServerWorld world = target.worldRef().getOrDefault(() -> null);
+
+        // womp womp
+        if (world == null) return;
+
         Vec3d pos = TardisUtil.offsetInteriorDoorPosition(target);
 
         ItemStack created = HypercubeItem.create(copyForSend(this, world.getServer().getTicks()));

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/CrashableTardisTravel.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/CrashableTardisTravel.java
@@ -1,23 +1,18 @@
 package dev.amble.ait.core.tardis.handler.travel;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
 import dev.amble.lib.data.CachedDirectedGlobalPos;
-import dev.amble.lib.util.ServerLifecycleHooks;
 import dev.drtheo.queue.api.ActionQueue;
 
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.explosion.Explosion;
 
 import dev.amble.ait.AITMod;
 import dev.amble.ait.api.tardis.TardisEvents;
@@ -25,7 +20,6 @@ import dev.amble.ait.core.tardis.Tardis;
 import dev.amble.ait.core.tardis.TardisDesktop;
 import dev.amble.ait.core.tardis.handler.ServerAlarmHandler;
 import dev.amble.ait.core.tardis.handler.TardisCrashHandler;
-import dev.amble.ait.core.tardis.util.TardisUtil;
 import dev.amble.ait.data.properties.bool.BoolValue;
 
 public sealed interface CrashableTardisTravel permits TravelHandler {
@@ -66,37 +60,33 @@ public sealed interface CrashableTardisTravel permits TravelHandler {
 
         Tardis tardis = this.tardis();
         int power = this.speed() + this.getHammerUses() + 1;
-        List<Explosion> explosions = new ArrayList<>();
-
-        ServerWorld world = tardis.asServer().getInteriorWorld();
-        MinecraftServer server = ServerLifecycleHooks.get();
-
-        boolean fireGriefing = server.getGameRules().getBoolean(AITMod.TARDIS_FIRE_GRIEFING);
-
-        tardis.getDesktop().getConsolePos().forEach(console -> {
-            TardisDesktop.playSoundAtConsole(world, console, SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 3f, 1f);
-
-            startCrashEffects(tardis, console, power);
-        });
 
         if (tardis.sequence().hasActiveSequence())
             tardis.sequence().setActiveSequence(null, true);
 
-        Random random = AITMod.RANDOM;
+        tardis.asServer().worldRef().ifPresent(world -> {
+            tardis.getDesktop().getConsolePos().forEach(console -> {
+                TardisDesktop.playSoundAtConsole(world, console, SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 3f, 1f);
 
-        for (ServerPlayerEntity player : TardisUtil.getPlayersInsideInterior(tardis.asServer())) {
-            float xVel = random.nextFloat(-2f, 3f);
-            float yVel = random.nextFloat(-1f, 2f);
-            float zVel = random.nextFloat(-2f, 3f);
+                startCrashEffects(tardis, console);
+            });
 
-            player.setVelocity(xVel * power, yVel * power, zVel * power);
-            player.addStatusEffect(new StatusEffectInstance(StatusEffects.BLINDNESS, 40 * power, 1, true, false, false));
-            player.addStatusEffect(new StatusEffectInstance(StatusEffects.WEAKNESS, 40 * power, 1, true, false, false));
-            player.addStatusEffect(new StatusEffectInstance(StatusEffects.NAUSEA, 40 * power, 2, true, false, false));
+            Random random = AITMod.RANDOM;
 
-            int damage = (int) Math.round(0.5 * power);
-            player.damage(world.getDamageSources().generic(), damage);
-        }
+            for (ServerPlayerEntity player : world.getPlayers()) {
+                float xVel = random.nextFloat(-2f, 3f);
+                float yVel = random.nextFloat(-1f, 2f);
+                float zVel = random.nextFloat(-2f, 3f);
+
+                player.setVelocity(xVel * power, yVel * power, zVel * power);
+                player.addStatusEffect(new StatusEffectInstance(StatusEffects.BLINDNESS, 40 * power, 1, true, false, false));
+                player.addStatusEffect(new StatusEffectInstance(StatusEffects.WEAKNESS, 40 * power, 1, true, false, false));
+                player.addStatusEffect(new StatusEffectInstance(StatusEffects.NAUSEA, 40 * power, 2, true, false, false));
+
+                int damage = (int) Math.round(0.5 * power);
+                player.damage(world.getDamageSources().generic(), damage);
+            }
+        });
 
         tardis.door().setLocked(true);
         tardis.alarm().enable(ServerAlarmHandler.AlarmType.CRASHING);
@@ -120,21 +110,16 @@ public sealed interface CrashableTardisTravel permits TravelHandler {
     }
 
 
-    default void startCrashEffects(Tardis tardis, BlockPos console, int power) {
-        ServerWorld world = tardis.asServer().getInteriorWorld();
-        MinecraftServer server = world.getServer();
+    default void startCrashEffects(Tardis tardis, BlockPos console) {
+        tardis.asServer().worldRef().ifPresent(world -> {
+            MinecraftServer server = world.getServer();
 
-        if (!server.getGameRules().getBoolean(AITMod.TARDIS_FIRE_GRIEFING)) {
-            return;
-        }
+            if (!server.getGameRules().getBoolean(AITMod.TARDIS_FIRE_GRIEFING)) {
+                return;
+            }
 
-        world.playSound(null, console, SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 3.0f, 1.0f);
-        world.playSound(null, console, SoundEvents.ENTITY_WITHER_HURT, SoundCategory.BLOCKS, 3.0f, 1.0f);
-
-    }
-
-    private float calculateFireProbability(double distance, int maxRadius) {
-        float normalizedDistance = (float) (distance / (maxRadius * maxRadius));
-        return Math.max(0.0f, 1.0f - normalizedDistance);
+            world.playSound(null, console, SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 3.0f, 1.0f);
+            world.playSound(null, console, SoundEvents.ENTITY_WITHER_HURT, SoundCategory.BLOCKS, 3.0f, 1.0f);
+        });
     }
 }

--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -57,7 +57,7 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
 
         ServerTickEvents.START_SERVER_TICK.register(server -> {
             this.forEach(tardis -> {
-                if (tardis.isRemoved())
+                if (tardis.isRemoved() || !tardis.shouldTick())
                     return;
 
                 tardis.tick(server);

--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Either;
+import dev.amble.ait.core.world.TardisServerWorld;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.drtheo.multidim.MultiDim;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -176,7 +177,6 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
     public void remove(MinecraftServer server, ServerTardis tardis) {
         tardis.setRemoved(true);
 
-        ServerWorld tardisWorld = tardis.getInteriorWorld();
         CachedDirectedGlobalPos exteriorPos = tardis.travel().position();
 
         if (exteriorPos != null) {
@@ -189,7 +189,7 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
             world.removeBlockEntity(pos);
         }
 
-        MultiDim.get(server).remove(tardisWorld.getRegistryKey());
+        MultiDim.get(server).remove(TardisServerWorld.keyForTardis(tardis));
 
         this.sendTardisRemoval(server, tardis);
 

--- a/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
@@ -332,21 +332,6 @@ public class TardisUtil {
         return world == null ? List.of() : world.getPlayers();
     }
 
-    public static List<LivingEntity> getLivingInInterior(ServerTardis tardis, Predicate<LivingEntity> predicate) {
-        ServerWorld world = tardis.worldRef().getOrDefault(() -> null);
-
-        if (world == null)
-            return List.of();
-
-        for (Entity entity : world.getEntitiesByType(TypeFilter.instanceOf(LivingEntity.class), predicate)) {
-            if (entity instanceof LivingEntity living && predicate.test(living)) {
-                return List.of(living);
-            }
-        }
-
-        return List.of();
-    }
-
     public static <T extends Entity> List<T> getEntitiesInBox(Class<T> clazz, World world, Box box,
             Predicate<T> predicate) {
         return fastFlatLookup(clazz, world, box, predicate);

--- a/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
@@ -79,8 +79,6 @@ public class TardisUtil {
 
                 if (!tardis.loyalty().get(player).isOf(Loyalty.Type.PILOT))
                     return;
-                /*if (tardis.<OvergrownHandler>handler(TardisComponent.Id.OVERGROWN).overgrown().get())
-                    return;*/
 
                 player.getWorld().playSound(null, player.getBlockPos(), AITSounds.SNAP, SoundCategory.PLAYERS, 4f, 1f);
 
@@ -91,7 +89,7 @@ public class TardisUtil {
                         : exteriorPos;
 
                 if ((player.squaredDistanceTo(exteriorPos.getX(), exteriorPos.getY(), exteriorPos.getZ())) > 200
-                        && !player.getWorld().equals(tardis.getInteriorWorld()))
+                        && player.getWorld() != tardis.worldRef().get())
                     return;
 
                 if (!player.isSneaking()) {
@@ -242,14 +240,14 @@ public class TardisUtil {
 
     public static void teleportInside(ServerTardis tardis, Entity entity) {
         TardisEvents.ENTER_TARDIS.invoker().onEnter(tardis, entity);
-        TardisUtil.teleportWithDoorOffset(tardis.getInteriorWorld(), entity, tardis.getDesktop().getDoorPos());
+        TardisUtil.teleportWithDoorOffset(tardis.worldRef().get(), entity, tardis.getDesktop().getDoorPos());
     }
 
     public static void teleportToInteriorPosition(ServerTardis tardis, Entity entity, BlockPos pos) {
         if (entity instanceof ServerPlayerEntity player) {
             TardisEvents.ENTER_TARDIS.invoker().onEnter(tardis, entity);
 
-            WorldUtil.teleportToWorld(player, tardis.getInteriorWorld(),
+            WorldUtil.teleportToWorld(player, tardis.worldRef().get(),
                     new Vec3d(pos.getX(), pos.getY(), pos.getZ()), entity.getYaw(), player.getPitch());
 
             player.networkHandler.sendPacket(new EntityVelocityUpdateS2CPacket(player));
@@ -325,16 +323,27 @@ public class TardisUtil {
         return null;
     }
 
+    /**
+     * @deprecated Use the {@link ServerTardis#worldRef()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static List<ServerPlayerEntity> getPlayersInsideInterior(ServerTardis tardis) {
-        return tardis.getInteriorWorld().getPlayers();
+        ServerWorld world = tardis.worldRef().getOrDefault(() -> null);
+        return world == null ? List.of() : world.getPlayers();
     }
 
-    public static List<LivingEntity> getLivingInInterior(Tardis tardis, Predicate<LivingEntity> predicate) {
-        for (Entity entity : ((ServerTardis) tardis).getInteriorWorld().getEntitiesByType(TypeFilter.instanceOf(LivingEntity.class), predicate)) {
+    public static List<LivingEntity> getLivingInInterior(ServerTardis tardis, Predicate<LivingEntity> predicate) {
+        ServerWorld world = tardis.worldRef().getOrDefault(() -> null);
+
+        if (world == null)
+            return List.of();
+
+        for (Entity entity : world.getEntitiesByType(TypeFilter.instanceOf(LivingEntity.class), predicate)) {
             if (entity instanceof LivingEntity living && predicate.test(living)) {
                 return List.of(living);
             }
         }
+
         return List.of();
     }
 
@@ -419,6 +428,11 @@ public class TardisUtil {
     }
 
     public static List<LivingEntity> getLivingEntitiesInInterior(Tardis tardis, int area) {
+        ServerWorld world = tardis.asServer().worldRef().get();
+
+        if (world == null)
+            return List.of();
+
         DirectedBlockPos directedPos = tardis.getDesktop().getDoorPos();
 
         if (directedPos == null)
@@ -426,11 +440,16 @@ public class TardisUtil {
 
         BlockPos pos = tardis.getDesktop().getDoorPos().getPos();
 
-        return tardis.asServer().getInteriorWorld().getEntitiesByClass(LivingEntity.class,
+        return world.getEntitiesByClass(LivingEntity.class,
                 new Box(pos.north(area).east(area).up(area), pos.south(area).west(area).down(area)), (e) -> true);
     }
 
     public static List<Entity> getEntitiesInInterior(Tardis tardis, int area) {
+        ServerWorld world = tardis.asServer().worldRef().getOrDefault(() -> null);
+
+        if (world == null)
+            return List.of();
+
         DirectedBlockPos directedPos = tardis.getDesktop().getDoorPos();
 
         if (directedPos == null)
@@ -438,8 +457,8 @@ public class TardisUtil {
 
         BlockPos pos = directedPos.getPos();
 
-        return tardis.asServer().getInteriorWorld().getEntitiesByClass(Entity.class,
-                new Box(pos.north(area).east(area).up(area), pos.south(area).west(area).down(area)), (e) -> true);
+        return world.getEntitiesByClass(Entity.class,
+                new Box(pos.north(area).east(area).up(area), pos.south(area).west(area).down(area)), e -> true);
     }
 
     public static List<LivingEntity> getLivingEntitiesInInterior(ServerTardis tardis) {
@@ -447,7 +466,12 @@ public class TardisUtil {
     }
 
     public static boolean isInteriorEmpty(ServerTardis tardis) {
-        return TardisUtil.getAnyPlayerInsideInterior(tardis.getInteriorWorld()) == null;
+        ServerWorld world = tardis.worldRef().getOrDefault(() -> null);
+
+        if (world == null)
+            return true;
+
+        return world.getPlayers().isEmpty();
     }
 
     public static void sendMessageToInterior(ServerTardis tardis, Text text) {

--- a/src/main/java/dev/amble/ait/core/util/Lazy.java
+++ b/src/main/java/dev/amble/ait/core/util/Lazy.java
@@ -1,5 +1,9 @@
 package dev.amble.ait.core.util;
 
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class Lazy<T> {
@@ -11,17 +15,43 @@ public class Lazy<T> {
 
     public Lazy(Supplier<T> creator) {
         this.creator = creator;
-        this.invalidate();
     }
 
     public T get() {
-        if (this.value == null)
+        if (!cached) {
             value = creator.get();
+            cached = true;
+        }
 
         return value;
     }
 
     public void invalidate() {
         this.value = null;
+        this.cached = false;
+    }
+
+    public boolean isCached() {
+        return cached;
+    }
+
+    public void ifPresent(Consumer<? super T> action) {
+        if (cached)
+            action.accept(value);
+    }
+
+    public void ifPresentOrElse(Consumer<? super T> action, Runnable emptyAction) {
+        if (cached) {
+            action.accept(value);
+        } else {
+            emptyAction.run();
+        }
+    }
+
+    public T getOrDefault(Supplier<? extends T> supplier) {
+        if (this.cached)
+            return value;
+
+        return supplier.get();
     }
 }

--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -76,7 +76,7 @@ public class TardisServerWorld extends MultiDimServerWorld {
         return ServerLifecycleHooks.get().getWorld(keyForTardis(tardis));
     }
 
-    private static RegistryKey<World> keyForTardis(ServerTardis tardis) {
+    public static RegistryKey<World> keyForTardis(ServerTardis tardis) {
         return RegistryKey.of(RegistryKeys.WORLD, idForTardis(tardis));
     }
 


### PR DESCRIPTION
## About the PR
This PR adds lazy tardis ticking.

## Why / Balance
Previously, the tardises would tick in any condition, even if they are not loaded outside or inside. Now they don't!

## Technical details
Besides that, the PR fixes AIT to lazily load the world instead of getting it loaded right away. Unfortunately, as of the currently used version of multidim this won't actually guarantee lazy world loading.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- `TardisDesktop#getInteriorWorld` -> `TardisDesktop#worldRef`

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- perf: improved ticking large amounts of tardises