### PR TITLE
fix: capsule interior door BOTI portal clipping into the blocks behin…

### DIFF
--- a/src/main/java/dev/amble/ait/data/schema/door/impl/CapsuleDoorVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/door/impl/CapsuleDoorVariant.java
@@ -35,10 +35,10 @@ public class CapsuleDoorVariant extends DoorSchema {
     public Vec3d adjustPortalPos(Vec3d pos, Direction direction) {
         return switch (direction) {
             case DOWN, UP -> pos;
-            case NORTH -> pos.add(0, 0.04, -0.5);
-            case SOUTH -> pos.add(0, 0.04, 0.5);
-            case WEST -> pos.add(-0, 0.04, -0.5);
-            case EAST -> pos.add(0.0, 0.04, -0.5);
+            case NORTH -> pos.add(0, 0.04, -0.3);
+            case SOUTH -> pos.add(0, 0.04, 0.3);
+            case WEST -> pos.add(-0, 0.04, -0.3);
+            case EAST -> pos.add(0.0, 0.04, -0.3);
         };
 
     }


### PR DESCRIPTION
fixed https://github.com/amblelabs/ait/issues/1493

## About the PR
<!-- What did you change? -->

changed position of the interior door BOTI portal for the `CapsuleDoorVariant`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

If you moved far enough back from the door with that exterior enabled, the block behind the door would clip and z-fight with the BOTI portal

## Technical details
<!-- Summary of code changes for easier review. -->

Changed value `-0.5` to `-0.3` in the `CapsuleDoorVariant` class, under `adjustPortalPos`

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

NA

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

NON

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: capsule interior door BOTI portal clipping into the blocks behind it
