### PR TITLE
fix sonic modes making double calls

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/InteractionSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/InteractionSonicMode.java
@@ -28,14 +28,6 @@ public class InteractionSonicMode extends SonicMode {
     }
 
     @Override
-    public void stopUsing(ItemStack stack, World world, LivingEntity user, int ticks, int ticksLeft) {
-        if (!(world instanceof ServerWorld serverWorld))
-            return;
-
-        this.process(serverWorld, user, ticks);
-    }
-
-    @Override
     public void tick(ItemStack stack, World world, LivingEntity user, int ticks, int ticksLeft) {
         if (!(world instanceof ServerWorld serverWorld) || ticks % 10 != 0)
             return;

--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -34,14 +34,6 @@ public class OverloadSonicMode extends SonicMode {
     }
 
     @Override
-    public void stopUsing(ItemStack stack, World world, LivingEntity user, int ticks, int ticksLeft) {
-        if (!(world instanceof ServerWorld serverWorld))
-            return;
-
-        this.process(serverWorld, user, ticks);
-    }
-
-    @Override
     public void tick(ItemStack stack, World world, LivingEntity user, int ticks, int ticksLeft) {
         if (!(world instanceof ServerWorld serverWorld) || ticks % 10 != 0)
             return;

--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -13,7 +13,6 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.EntityHitResult;
@@ -51,13 +50,6 @@ public class ScanningSonicMode extends SonicMode {
     @Override
     public int maxTime() {
         return 5 * 60 * 20;
-    }
-
-    @Override
-    public boolean startUsing(ItemStack stack, World world, PlayerEntity user, Hand hand) {
-        if (world.isClient()) return false;
-
-        return this.process(stack, world, user);
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
@@ -10,7 +10,6 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
@@ -35,13 +34,6 @@ public class TardisSonicMode extends SonicMode {
             return;
 
         this.process(stack, world, player);
-    }
-
-    @Override
-    public boolean startUsing(ItemStack stack, World world, PlayerEntity user, Hand hand) {
-        if (world.isClient()) return false;
-
-        return this.process(stack, world, user);
     }
 
     public boolean process(ItemStack stack, World world, PlayerEntity user) {


### PR DESCRIPTION
## About the PR
Currently the sonic modes are being executed twice in a row.
In scanning mode, it prints the message with the Artron levels of the rift chunk **two times**.
In Overcharge or Interact mode it's a bit difficult to stop at the desired state of the targeted block.
For example if you try to turn a redstone lamp *on*, then if you stop the sonic right when the lamp turns on, the lamp gets toggled once more and turns *off*.

This PR fixes this, so that each sonic's mode-function is not toggled twice in a row anymore.

## Why / Balance
Better UX.
(I.e. no doubling up of messages or an additional toggling after sonic use has already stopped.)

## Technical details
The reason for the double-call is because both the `startUsing` and `tick` methods are called when the sonic is used.
First `startUsing` gets called and processes the respective mode-function.
Then `tick` gets called right afterwards and *also* processes the mode-function.

(Technically this also happens for the TARDIS mode, but it's not obvious because its messages are displayed on the action bar, where there is only ever one message visible. But it *is* being executed two times in a row.)

But for all the sonic modes, only `tick` is needed to process the sonic use, because even if the user clicks very shortly, `tick` is still called.
So we can leave out all `startUsing` (and `stopUsing`) calls, as they do nothing else than process the mode-function.
The result is that the mode-function is only executed once (per tick) and doesn't start (or stop) with a double-execution.

Which means that the Artron message in scanning mode will only display once.
And in overcharge or interaction mode you can now stop at the state you desire, without an extra execution throwing you off.


## Media
![image](https://github.com/user-attachments/assets/ec8ff2f0-52c6-47d0-93f9-7de29275fe37)
![image](https://github.com/user-attachments/assets/0b9966e2-5f05-4e3e-9f6c-39cc8a8d42e0)
![image](https://github.com/user-attachments/assets/b064ec86-594f-4320-b5cf-ea89f2684f3f)
![image](https://github.com/user-attachments/assets/c57b506c-538c-42ea-8aba-c9c8fe8a5de1)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- fix: fix sonic modes makes double calls