### PR TITLE
fix: control entity interactions

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/control/Control.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/Control.java
@@ -167,6 +167,7 @@ public class Control implements Identifiable {
         public boolean isSuccess() {
             return this == SUCCESS || this == SUCCESS_ALT;
         }
+
         public boolean isAltSound() {
             return this == SUCCESS_ALT || this == FAILURE;
         }


### PR DESCRIPTION
## About the PR
This PR fixes control entity interactions from multiple PRs.

## Why / Balance
Because controls are unusable otherwise lol.

## Technical details
Previously, it seems that hammer check would bypass the durability check. Also, the durability check would always return a true/false value even if the random check fails. E.g. if the control is slightly broken, it would return before executing the control's method.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: hammer no longer bypasses durability check
- fix: control entities can be interacted with again
- fix: you can interact with slightly broken controls again