### PR TITLE
Gallifrey Falls Keeps Turning Into Trenzalore, BUT NO MORE I SAY

### DIFF
--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -516,8 +516,8 @@ public class AITModClient implements ClientModInitializer {
     public void gallifreyanBOTI(WorldRenderContext context) {
         MinecraftClient client = MinecraftClient.getInstance();
         SinglePartEntityModel contents = new GallifreyFallsModel(GallifreyFallsModel.getTexturedModelData().createModel());
-        Identifier frameTex = BOTIPaintingEntityRenderer.GALLIFREY_FRAME_TEXTURE;
-        Identifier contentsTex = BOTIPaintingEntityRenderer.GALLIFREY_PAINTING_TEXTURE;
+        Identifier frameTex = GallifreyanPaintingEntityRenderer.GALLIFREY_FRAME_TEXTURE;
+        Identifier contentsTex = GallifreyanPaintingEntityRenderer.GALLIFREY_PAINTING_TEXTURE;
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
         MatrixStack stack = context.matrixStack();
@@ -543,8 +543,8 @@ public class AITModClient implements ClientModInitializer {
     public void trenzaloreBOTI(WorldRenderContext context) {
         MinecraftClient client = MinecraftClient.getInstance();
         SinglePartEntityModel contents = new TrenzalorePaintingModel(TrenzalorePaintingModel.getTexturedModelData().createModel());
-        Identifier frameTex = BOTIPaintingEntityRenderer.TRENZALORE_FRAME_TEXTURE;
-        Identifier contentsTex = BOTIPaintingEntityRenderer.TRENZALORE_PAINTING_TEXTURE;
+        Identifier frameTex = TrenzalorePaintingEntityRenderer.TRENZALORE_FRAME_TEXTURE;
+        Identifier contentsTex = TrenzalorePaintingEntityRenderer.TRENZALORE_PAINTING_TEXTURE;
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
         MatrixStack stack = context.matrixStack();

--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -152,7 +152,7 @@ public class AITModClient implements ClientModInitializer {
             WorldRenderEvents.AFTER_ENTITIES.register(this::exteriorBOTI);
             WorldRenderEvents.AFTER_ENTITIES.register(this::doorBOTI);
             WorldRenderEvents.AFTER_ENTITIES.register(this::gallifreyanBOTI);
-            WorldRenderEvents.END.register(this::trenzaloreBOTI);
+            WorldRenderEvents.AFTER_ENTITIES.register(this::trenzaloreBOTI);
             WorldRenderEvents.AFTER_ENTITIES.register(this::riftBOTI);
         }
 

--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -542,7 +542,7 @@ public class AITModClient implements ClientModInitializer {
 
     public void trenzaloreBOTI(WorldRenderContext context) {
         MinecraftClient client = MinecraftClient.getInstance();
-        SinglePartEntityModel contents = new TrenzalorePaintingModel(GallifreyFallsModel.getTexturedModelData().createModel());
+        SinglePartEntityModel contents = new TrenzalorePaintingModel(TrenzalorePaintingModel.getTexturedModelData().createModel());
         Identifier frameTex = BOTIPaintingEntityRenderer.TRENZALORE_FRAME_TEXTURE;
         Identifier contentsTex = BOTIPaintingEntityRenderer.TRENZALORE_PAINTING_TEXTURE;
         if (client.player == null || client.world == null) return;

--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -84,7 +84,6 @@ import dev.amble.ait.core.drinks.DrinkRegistry;
 import dev.amble.ait.core.drinks.DrinkUtil;
 import dev.amble.ait.core.entities.BOTIPaintingEntity;
 import dev.amble.ait.core.entities.RiftEntity;
-import dev.amble.ait.core.entities.TrenzalorePaintingEntity;
 import dev.amble.ait.core.item.*;
 import dev.amble.ait.core.tardis.Tardis;
 import dev.amble.ait.core.world.TardisServerWorld;
@@ -146,12 +145,14 @@ public class AITModClient implements ClientModInitializer {
         if (DependencyChecker.hasIris()) {
             WorldRenderEvents.END.register(this::exteriorBOTI);
             WorldRenderEvents.END.register(this::doorBOTI);
-            WorldRenderEvents.END.register(this::paintingBOTI);
+            WorldRenderEvents.END.register(this::gallifreyanBOTI);
+            WorldRenderEvents.END.register(this::trenzaloreBOTI);
             WorldRenderEvents.END.register(this::riftBOTI);
         } else {
             WorldRenderEvents.AFTER_ENTITIES.register(this::exteriorBOTI);
             WorldRenderEvents.AFTER_ENTITIES.register(this::doorBOTI);
-            WorldRenderEvents.AFTER_ENTITIES.register(this::paintingBOTI);
+            WorldRenderEvents.AFTER_ENTITIES.register(this::gallifreyanBOTI);
+            WorldRenderEvents.END.register(this::trenzaloreBOTI);
             WorldRenderEvents.AFTER_ENTITIES.register(this::riftBOTI);
         }
 
@@ -410,8 +411,8 @@ public class AITModClient implements ClientModInitializer {
         EntityRendererRegistry.register(AITEntityTypes.CONTROL_ENTITY_TYPE, ControlEntityRenderer::new);
         EntityRendererRegistry.register(AITEntityTypes.FALLING_TARDIS_TYPE, FallingTardisRenderer::new);
         EntityRendererRegistry.register(AITEntityTypes.FLIGHT_TARDIS_TYPE, FlightTardisRenderer::new);
-        EntityRendererRegistry.register(AITEntityTypes.GALLIFREY_FALLS_PAINTING_ENTITY_TYPE, BOTIPaintingEntityRenderer::new);
-        EntityRendererRegistry.register(AITEntityTypes.TRENZALORE_PAINTING_ENTITY_TYPE, BOTIPaintingEntityRenderer::new);
+        EntityRendererRegistry.register(AITEntityTypes.GALLIFREY_FALLS_PAINTING_ENTITY_TYPE, GallifreyanPaintingEntityRenderer::new);
+        EntityRendererRegistry.register(AITEntityTypes.TRENZALORE_PAINTING_ENTITY_TYPE, TrenzalorePaintingEntityRenderer::new);
 //        if (isUnlockedOnThisDay(Calendar.DECEMBER, 26)) {
 //            EntityRendererRegistry.register(AITEntityTypes.COBBLED_SNOWBALL_TYPE, FlyingItemEntityRenderer::new);
 //        }
@@ -512,7 +513,7 @@ public class AITModClient implements ClientModInitializer {
         }
     }
 
-    public void paintingBOTI(WorldRenderContext context) {
+    public void gallifreyanBOTI(WorldRenderContext context) {
         MinecraftClient client = MinecraftClient.getInstance();
         SinglePartEntityModel contents = new GallifreyFallsModel(GallifreyFallsModel.getTexturedModelData().createModel());
         Identifier frameTex = BOTIPaintingEntityRenderer.GALLIFREY_FRAME_TEXTURE;
@@ -520,7 +521,7 @@ public class AITModClient implements ClientModInitializer {
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
         MatrixStack stack = context.matrixStack();
-        for (BOTIPaintingEntity painting : BOTI.PAINTING_RENDER_QUEUE) {
+        for (BOTIPaintingEntity painting : BOTI.GALLIFREYAN_RENDER_QUEUE) {
             if (painting == null) continue;
             Vec3d pos = painting.getPos();
             stack.push();
@@ -531,17 +532,39 @@ public class AITModClient implements ClientModInitializer {
             stack.translate(0, -0.5f, 0.5);
             PaintingFrameModel frame = new PaintingFrameModel(PaintingFrameModel.getTexturedModelData().createModel());
             BlockPos blockPos = BlockPos.ofFloored(painting.getClientCameraPosVec(client.getTickDelta()));
-            if (painting instanceof TrenzalorePaintingEntity) {
-                contents = new TrenzalorePaintingModel(TrenzalorePaintingModel.getTexturedModelData().createModel());
-                frameTex = BOTIPaintingEntityRenderer.TRENZALORE_FRAME_TEXTURE;
-                contentsTex = BOTIPaintingEntityRenderer.TRENZALORE_PAINTING_TEXTURE;
-            }
             PaintingBOTI.renderBOTIPainting(stack, frame,
                     LightmapTextureManager.pack(world.getLightLevel(LightType.BLOCK, blockPos),
                             world.getLightLevel(LightType.SKY, blockPos)), contents, frameTex, contentsTex);
             stack.pop();
         }
-        BOTI.PAINTING_RENDER_QUEUE.clear();
+        BOTI.GALLIFREYAN_RENDER_QUEUE.clear();
+    }
+
+    public void trenzaloreBOTI(WorldRenderContext context) {
+        MinecraftClient client = MinecraftClient.getInstance();
+        SinglePartEntityModel contents = new TrenzalorePaintingModel(GallifreyFallsModel.getTexturedModelData().createModel());
+        Identifier frameTex = BOTIPaintingEntityRenderer.TRENZALORE_FRAME_TEXTURE;
+        Identifier contentsTex = BOTIPaintingEntityRenderer.TRENZALORE_PAINTING_TEXTURE;
+        if (client.player == null || client.world == null) return;
+        ClientWorld world = client.world;
+        MatrixStack stack = context.matrixStack();
+        for (BOTIPaintingEntity painting : BOTI.TRENZALORE_PAINTING_QUEUE) {
+            if (painting == null) continue;
+            Vec3d pos = painting.getPos();
+            stack.push();
+            stack.translate(pos.getX() - context.camera().getPos().getX(),
+                    pos.getY() - context.camera().getPos().getY(), pos.getZ() - context.camera().getPos().getZ());
+            stack.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180f));
+            stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(painting.getBodyYaw()));
+            stack.translate(0, -0.5f, 0.5);
+            PaintingFrameModel frame = new PaintingFrameModel(PaintingFrameModel.getTexturedModelData().createModel());
+            BlockPos blockPos = BlockPos.ofFloored(painting.getClientCameraPosVec(client.getTickDelta()));
+            PaintingBOTI.renderBOTIPainting(stack, frame,
+                    LightmapTextureManager.pack(world.getLightLevel(LightType.BLOCK, blockPos),
+                            world.getLightLevel(LightType.SKY, blockPos)), contents, frameTex, contentsTex);
+            stack.pop();
+        }
+        BOTI.TRENZALORE_PAINTING_QUEUE.clear();
     }
 
     public void riftBOTI(WorldRenderContext context) {

--- a/src/main/java/dev/amble/ait/client/boti/BOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/BOTI.java
@@ -25,7 +25,8 @@ public class BOTI {
     public static BOTIInit BOTI_HANDLER = new BOTIInit();
     public static AITBufferBuilderStorage AIT_BUF_BUILDER_STORAGE = new AITBufferBuilderStorage();
     public static Queue<DoorBlockEntity> DOOR_RENDER_QUEUE = new LinkedList<>();
-    public static Queue<BOTIPaintingEntity> PAINTING_RENDER_QUEUE = new LinkedList<>();
+    public static Queue<BOTIPaintingEntity> GALLIFREYAN_RENDER_QUEUE = new LinkedList<>();
+    public static Queue<BOTIPaintingEntity> TRENZALORE_PAINTING_QUEUE = new LinkedList<>();
     public static Queue<ExteriorBlockEntity> EXTERIOR_RENDER_QUEUE = new LinkedList<>();
     private static boolean HAS_BEEN_WARNED = false;
 

--- a/src/main/java/dev/amble/ait/client/renderers/entities/BOTIPaintingEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/BOTIPaintingEntityRenderer.java
@@ -4,18 +4,15 @@ package dev.amble.ait.client.renderers.entities;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
-import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 
 import dev.amble.ait.AITMod;
-import dev.amble.ait.client.boti.BOTI;
 import dev.amble.ait.core.entities.BOTIPaintingEntity;
 
 @Environment(value=EnvType.CLIENT)
-public class BOTIPaintingEntityRenderer
+public abstract class BOTIPaintingEntityRenderer
         extends EntityRenderer<BOTIPaintingEntity> {
     public static final Identifier GALLIFREY_PAINTING_TEXTURE = AITMod.id("textures/painting/gallifrey_falls/gallifrey_falls.png");
     public static final Identifier GALLIFREY_FRAME_TEXTURE = AITMod.id("textures/painting/gallifrey_falls/gallifrey_falls_frame.png");
@@ -23,11 +20,6 @@ public class BOTIPaintingEntityRenderer
     public static final Identifier TRENZALORE_FRAME_TEXTURE = AITMod.id("textures/painting/trenzalore/trenzalore_frame.png");
     public BOTIPaintingEntityRenderer(EntityRendererFactory.Context context) {
         super(context);
-    }
-
-    @Override
-    public void render(BOTIPaintingEntity paintingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
-        BOTI.PAINTING_RENDER_QUEUE.add(paintingEntity);
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/client/renderers/entities/BOTIPaintingEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/BOTIPaintingEntityRenderer.java
@@ -8,16 +8,11 @@ import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.util.Identifier;
 
-import dev.amble.ait.AITMod;
 import dev.amble.ait.core.entities.BOTIPaintingEntity;
 
 @Environment(value=EnvType.CLIENT)
 public abstract class BOTIPaintingEntityRenderer
         extends EntityRenderer<BOTIPaintingEntity> {
-    public static final Identifier GALLIFREY_PAINTING_TEXTURE = AITMod.id("textures/painting/gallifrey_falls/gallifrey_falls.png");
-    public static final Identifier GALLIFREY_FRAME_TEXTURE = AITMod.id("textures/painting/gallifrey_falls/gallifrey_falls_frame.png");
-    public static final Identifier TRENZALORE_PAINTING_TEXTURE = AITMod.id("textures/painting/trenzalore/trenzalore.png");
-    public static final Identifier TRENZALORE_FRAME_TEXTURE = AITMod.id("textures/painting/trenzalore/trenzalore_frame.png");
     public BOTIPaintingEntityRenderer(EntityRendererFactory.Context context) {
         super(context);
     }

--- a/src/main/java/dev/amble/ait/client/renderers/entities/GallifreyanPaintingEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/GallifreyanPaintingEntityRenderer.java
@@ -10,12 +10,15 @@ import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 
+import dev.amble.ait.AITMod;
 import dev.amble.ait.client.boti.BOTI;
 import dev.amble.ait.core.entities.BOTIPaintingEntity;
 
 @Environment(value=EnvType.CLIENT)
 public class GallifreyanPaintingEntityRenderer
         extends EntityRenderer<BOTIPaintingEntity> {
+    public static final Identifier GALLIFREY_PAINTING_TEXTURE = AITMod.id("textures/painting/gallifrey_falls/gallifrey_falls.png");
+    public static final Identifier GALLIFREY_FRAME_TEXTURE = AITMod.id("textures/painting/gallifrey_falls/gallifrey_falls_frame.png");
     public GallifreyanPaintingEntityRenderer(EntityRendererFactory.Context context) {
         super(context);
     }

--- a/src/main/java/dev/amble/ait/client/renderers/entities/GallifreyanPaintingEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/GallifreyanPaintingEntityRenderer.java
@@ -1,0 +1,33 @@
+package dev.amble.ait.client.renderers.entities;
+
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.EntityRenderer;
+import net.minecraft.client.render.entity.EntityRendererFactory;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.Identifier;
+
+import dev.amble.ait.client.boti.BOTI;
+import dev.amble.ait.core.entities.BOTIPaintingEntity;
+
+@Environment(value=EnvType.CLIENT)
+public class GallifreyanPaintingEntityRenderer
+        extends EntityRenderer<BOTIPaintingEntity> {
+    public GallifreyanPaintingEntityRenderer(EntityRendererFactory.Context context) {
+        super(context);
+    }
+
+    @Override
+    public void render(BOTIPaintingEntity paintingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
+        BOTI.GALLIFREYAN_RENDER_QUEUE.add(paintingEntity);
+    }
+
+    @Override
+    public Identifier getTexture(BOTIPaintingEntity entity) {
+        return null;
+    }
+
+}

--- a/src/main/java/dev/amble/ait/client/renderers/entities/TrenzalorePaintingEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/TrenzalorePaintingEntityRenderer.java
@@ -10,12 +10,15 @@ import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 
+import dev.amble.ait.AITMod;
 import dev.amble.ait.client.boti.BOTI;
 import dev.amble.ait.core.entities.BOTIPaintingEntity;
 
 @Environment(value=EnvType.CLIENT)
 public class TrenzalorePaintingEntityRenderer
         extends EntityRenderer<BOTIPaintingEntity> {
+    public static final Identifier TRENZALORE_PAINTING_TEXTURE = AITMod.id("textures/painting/trenzalore/trenzalore.png");
+    public static final Identifier TRENZALORE_FRAME_TEXTURE = AITMod.id("textures/painting/trenzalore/trenzalore_frame.png");
     public TrenzalorePaintingEntityRenderer(EntityRendererFactory.Context context) {
         super(context);
     }

--- a/src/main/java/dev/amble/ait/client/renderers/entities/TrenzalorePaintingEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/TrenzalorePaintingEntityRenderer.java
@@ -1,0 +1,33 @@
+package dev.amble.ait.client.renderers.entities;
+
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.EntityRenderer;
+import net.minecraft.client.render.entity.EntityRendererFactory;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.Identifier;
+
+import dev.amble.ait.client.boti.BOTI;
+import dev.amble.ait.core.entities.BOTIPaintingEntity;
+
+@Environment(value=EnvType.CLIENT)
+public class TrenzalorePaintingEntityRenderer
+        extends EntityRenderer<BOTIPaintingEntity> {
+    public TrenzalorePaintingEntityRenderer(EntityRendererFactory.Context context) {
+        super(context);
+    }
+
+    @Override
+    public void render(BOTIPaintingEntity paintingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
+        BOTI.TRENZALORE_PAINTING_QUEUE.add(paintingEntity);
+    }
+
+    @Override
+    public Identifier getTexture(BOTIPaintingEntity entity) {
+        return null;
+    }
+
+}


### PR DESCRIPTION
## About the PR
Fixes Gallifrey Falls deciding it wants to transition to Trenzalore.

## Why / Balance
We're clearly transpaintingphobic here at AIT Incorporated.

## Technical details
Separate the Trenzalore and Gallifrey Falls paintings so no more transpainting can occur.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->