### PR TITLE
re-initialize the executor service on server startup

### DIFF
--- a/src/main/java/dev/amble/ait/AITMod.java
+++ b/src/main/java/dev/amble/ait/AITMod.java
@@ -137,7 +137,7 @@ public class AITMod implements ModInitializer {
 
         ServerLifecycleHooks.init();
         NetworkUtil.init();
-        AsyncLocatorUtil.setupExecutorService();
+        AsyncLocatorUtil.init();
         SeatHandler.init();
 
         ConsoleRegistry.init();

--- a/src/main/java/dev/amble/ait/core/tardis/util/AsyncLocatorUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/AsyncLocatorUtil.java
@@ -28,9 +28,12 @@ public class AsyncLocatorUtil {
 
     public static ExecutorService LOCATING_EXECUTOR_SERVICE = null;
 
-    static {
+    public static void init() {
         ServerLifecycleEvents.SERVER_STOPPING.register(
-                (server) -> AsyncLocatorUtil.shutdownExecutorService());
+                server -> AsyncLocatorUtil.shutdownExecutorService());
+
+        ServerLifecycleEvents.SERVER_STARTING.register(
+                server -> AsyncLocatorUtil.setupExecutorService());
     }
 
     public static void setupExecutorService() {


### PR DESCRIPTION
## About the PR
This PR makes it so the executor service for the async locator util is re-initialized on server startup.

## Why / Balance
Fixes a bug in singleplayer that occurs when a player leaves a world and rejoins again and uses something that utilizes the async locator util (e.g. randomizer or the thingy that searches for structures).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: randomizer and structure locator no longer throw up when you rejoin the world