### PR TITLE
make tardis worlds tick lazily

### DIFF
--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executor;
+import java.util.function.BooleanSupplier;
 
 import dev.amble.lib.util.ServerLifecycleHooks;
 import dev.drtheo.multidim.MultiDim;
@@ -47,6 +48,12 @@ public class TardisServerWorld extends MultiDimServerWorld {
     }
 
     @Override
+    public void tick(BooleanSupplier shouldKeepTicking) {
+        if (this.tardis.shouldTick())
+            super.tick(shouldKeepTicking);
+    }
+
+    @Override
     public boolean spawnEntity(Entity entity) {
         if (entity instanceof ItemEntity && this.getTardis().interiorChangingHandler().regenerating().get())
             return false;
@@ -85,7 +92,7 @@ public class TardisServerWorld extends MultiDimServerWorld {
 
         multidim.load(AITDimensions.TARDIS_WORLD_BLUEPRINT, saved.world());
 
-        MultiDimMod.LOGGER.info("Time taken: {}", System.currentTimeMillis() - start);
+        MultiDimMod.LOGGER.info("Time taken to load sub-world: {}", System.currentTimeMillis() - start);
         return get(tardis);
     }
 


### PR DESCRIPTION
## About the PR
This PR makes it so tardis worlds tick with the tardises they are linked to.

## Why / Balance
For performance, of course!

## Technical details
This PR utilizes the `ServerTardis#shouldTick` method, which was implemented in #1509.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: tardis' interior no longer ticks if no one is inside or outside (or if the tardis' interior chunks aren't loaded).