### PR TITLE
no more empty saves

### DIFF
--- a/src/main/java/dev/amble/ait/api/tardis/link/LinkableItem.java
+++ b/src/main/java/dev/amble/ait/api/tardis/link/LinkableItem.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
+import net.minecraft.nbt.NbtHelper;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.gui.screen.Screen;
@@ -96,22 +97,26 @@ public abstract class LinkableItem extends Item {
 
         // convert old string data
         if (element.getType() == NbtElement.STRING_TYPE) {
-            nbt.remove(path);
             UUID converted = UUID.fromString(element.asString());
 
             nbt.putUuid(path, converted);
             return converted;
         }
 
-        return nbt.getUuid(path);
+        return NbtHelper.toUuid(element);
     }
 
     public Tardis getTardis(World world, ItemStack stack) {
         if (world == null)
             return null;
 
+        UUID tardisId = this.getTardisId(stack);
+
+        if (tardisId == null)
+            return null;
+
         return TardisManager.with(world, (o, manager) ->
-                manager.demandTardis(o, this.getTardisId(stack)));
+                manager.demandTardis(o, tardisId));
     }
 
     public static <T> T apply(ItemStack stack, BiFunction<LinkableItem, ItemStack, T> f) {

--- a/src/main/java/dev/amble/ait/api/tardis/link/v2/TardisRef.java
+++ b/src/main/java/dev/amble/ait/api/tardis/link/v2/TardisRef.java
@@ -61,6 +61,9 @@ public class TardisRef implements Disposable {
     }
 
     public Tardis get() {
+        if (this.id == null)
+            return null;
+        
         if (this.cached != null && !this.shouldInvalidate())
             return this.cached;
 

--- a/src/main/java/dev/amble/ait/api/tardis/link/v2/TardisRef.java
+++ b/src/main/java/dev/amble/ait/api/tardis/link/v2/TardisRef.java
@@ -61,11 +61,11 @@ public class TardisRef implements Disposable {
     }
 
     public Tardis get() {
-        if (this.id == null)
-            return null;
-        
         if (this.cached != null && !this.shouldInvalidate())
             return this.cached;
+
+        if (this.id == null)
+            return null;
 
         this.cached = this.load.apply(this.id);
         return this.cached;

--- a/src/main/java/dev/amble/ait/client/tardis/manager/ClientTardisManager.java
+++ b/src/main/java/dev/amble/ait/client/tardis/manager/ClientTardisManager.java
@@ -88,12 +88,6 @@ public class ClientTardisManager extends TardisManager<ClientTardis, MinecraftCl
     }
 
     @Override
-    @Deprecated(forRemoval = true)
-    public void loadTardis(MinecraftClient client, UUID uuid, @Nullable Consumer<ClientTardis> consumer) {
-        // do nothing
-    }
-
-    @Override
     protected TardisMap.Direct<ClientTardis> lookup() {
         return lookup;
     }

--- a/src/main/java/dev/amble/ait/client/tardis/manager/ClientTardisManager.java
+++ b/src/main/java/dev/amble/ait/client/tardis/manager/ClientTardisManager.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.tardis.manager;
 
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -100,6 +101,7 @@ public class ClientTardisManager extends TardisManager<ClientTardis, MinecraftCl
     @Override
     @Deprecated
     public @Nullable ClientTardis demandTardis(MinecraftClient client, UUID uuid) {
+        Objects.requireNonNull(uuid);
         return this.lookup.get(uuid);
     }
 

--- a/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
+++ b/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
@@ -52,8 +52,7 @@ public class ClientTardisUtil {
             currentTardis = new TardisRef(id, uuid -> ClientTardisManager.getInstance().demandTardis(uuid));
         });
         ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {
-            if (currentTardis != null)
-                currentTardis = null;
+            currentTardis = null;
         });
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/TardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisManager.java
@@ -190,8 +190,6 @@ public abstract class TardisManager<T extends Tardis, C> {
     @Nullable @Deprecated
     public abstract T demandTardis(C c, UUID uuid);
 
-    public abstract void loadTardis(C c, UUID uuid, @Nullable Consumer<T> consumer);
-
     protected abstract TardisMap<?> lookup();
 
     public void reset() {

--- a/src/main/java/dev/amble/ait/core/tardis/manager/TardisFileManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/TardisFileManager.java
@@ -18,6 +18,7 @@ import dev.amble.ait.AITMod;
 import dev.amble.ait.core.tardis.ServerTardis;
 import dev.amble.ait.core.tardis.Tardis;
 import dev.amble.ait.core.tardis.TardisManager;
+import org.jetbrains.annotations.NotNull;
 
 public class TardisFileManager<T extends Tardis> {
 
@@ -79,18 +80,18 @@ public class TardisFileManager<T extends Tardis> {
              * if (version == 0) new JsonObjectTransform(object).transform();
              */
 
-            T tardis = function.apply(manager.getFileGson(), object);
+            T tardis = function.readTardis(manager.getFileGson(), object);
 
             AITMod.LOGGER.info("Deserialized {} in {}ms", tardis, System.currentTimeMillis() - start);
             return Either.left(tardis);
-        } catch (IOException e) {
+        } catch (Exception e) {
             AITMod.LOGGER.warn("Failed to load {}!", uuid);
             AITMod.LOGGER.warn(e.getMessage());
             return Either.right(e);
         }
     }
 
-    public void saveTardis(MinecraftServer server, TardisManager<T, ?> manager, T tardis) {
+    public void saveTardis(MinecraftServer server, TardisManager<T, ?> manager, @NotNull T tardis) {
         try {
             Path savePath = TardisFileManager.getSavePath(server, tardis.getUuid(), "json");
             Files.writeString(savePath, manager.getFileGson().toJson(tardis, ServerTardis.class));
@@ -122,6 +123,6 @@ public class TardisFileManager<T extends Tardis> {
 
     @FunctionalInterface
     public interface TardisLoader<T> {
-        T apply(Gson gson, JsonObject object);
+        T readTardis(Gson gson, JsonObject object);
     }
 }

--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -122,9 +122,6 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
         if (either == null)
             either = this.loadTardis(server, uuid);
 
-        if (either == null)
-            return null;
-
         return either.map(tardis -> tardis, o -> null);
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -152,7 +152,7 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
     }
 
     @NotNull
-    private Either<ServerTardis, Exception> loadTardis(MinecraftServer server, UUID uuid) {
+    public Either<ServerTardis, Exception> loadTardis(MinecraftServer server, UUID uuid) {
         Either<ServerTardis, Exception> result = this.fileManager.loadTardis(server, this, uuid, this);
 
         this.lookup.put(uuid, result);

--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -129,18 +129,6 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
     }
 
     @Override
-    public void loadTardis(@NotNull MinecraftServer server, @NotNull UUID uuid, Consumer<ServerTardis> consumer) {
-        Objects.requireNonNull(uuid);
-
-        Either<ServerTardis, Exception> either = this.loadTardis(server, uuid);
-
-        if (either == null || consumer == null)
-            return;
-
-        either.ifLeft(consumer);
-    }
-
-    @Override
     public void getTardis(MinecraftServer server, @NotNull UUID uuid, @NotNull Consumer<ServerTardis> consumer) {
         Objects.requireNonNull(uuid);
         Objects.requireNonNull(consumer);
@@ -150,10 +138,8 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
 
         Either<ServerTardis, ?> either = this.lookup.get(uuid);
 
-        if (either == null) {
-            this.loadTardis(server, uuid, consumer);
-            return;
-        }
+        if (either == null)
+            either = this.loadTardis(server, uuid);
 
         either.ifLeft(consumer);
     }
@@ -168,6 +154,7 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
         this.lookup.forEach((uuid, either) -> either.ifLeft(consumer));
     }
 
+    @NotNull
     private Either<ServerTardis, Exception> loadTardis(MinecraftServer server, UUID uuid) {
         Either<ServerTardis, Exception> result = this.fileManager.loadTardis(server, this, uuid, this);
 

--- a/src/main/java/dev/amble/ait/data/TardisMap.java
+++ b/src/main/java/dev/amble/ait/data/TardisMap.java
@@ -12,13 +12,6 @@ public abstract class TardisMap<T> extends ConcurrentHashMap<UUID, T> {
 
     private TardisMap() { }
 
-    @Nullable public T get(UUID id) {
-        if (id == null)
-            return null;
-
-        return super.get(id);
-    }
-
     public static class Direct<T extends Tardis> extends TardisMap<T> {
 
         public T put(T t) {
@@ -26,6 +19,14 @@ public abstract class TardisMap<T> extends ConcurrentHashMap<UUID, T> {
         }
     }
 
+    /**
+     * This type of tardis map has a {@link UUID} for a key and a {@link Either}<{@link Tardis}, {@link Exception}> for a value.
+     * The map will return {@link null} when no value is associated with the id and the {@link Either} if there is.
+     * <p>
+     * In case a tardis has failed to load, the {@link Either} will wrap an {@link Exception}.
+     *
+     * @param <T>
+     */
     public static class Optional<T extends Tardis> extends TardisMap<Either<T, Exception>> {
 
         private Either<T, Exception> wrap(T t) {


### PR DESCRIPTION
## About the PR
This PR makes it so if a tardis was not serialized properly and saved a corrupted file it won't brick your world anymore.

## Why / Balance
This happened on the official server. Not cool.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- Everything that uses `TardisManager`s has to provide non-null values.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: if a tardis fails to save it wont brick your world anymore