### PR TITLE
Various perf fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ dependencies {
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-    modApi("me.shedaniel.cloth:cloth-config-fabric:${project.}") {cloth_version
+    modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
@@ -47,7 +47,7 @@ public class TardisDesktop extends TardisComponent {
     private DirectedBlockPos doorPos;
     private final Corners corners;
     private final Set<BlockPos> consolePos;
-    private static final int RADIUS = 500;
+    public static final int RADIUS = 500;
     private static final Corners CORNERS;
 
     static {

--- a/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
+++ b/src/main/java/dev/amble/ait/core/tardis/manager/old/DeprecatedServerTardisManager.java
@@ -9,6 +9,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.mojang.datafixers.util.Either;
+import dev.amble.ait.core.util.WorldUtil;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.drtheo.multidim.MultiDim;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -56,7 +57,11 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
         ServerLifecycleEvents.SERVER_STOPPING.register(this::saveAndReset);
 
         ServerCrashEvent.EVENT.register(((server, report) -> this.reset())); // just panic and reset
-        WorldSaveEvent.EVENT.register(world -> this.save(world.getServer(), false));
+
+        WorldSaveEvent.EVENT.register(world -> {
+            if (world == WorldUtil.getOverworld())
+                this.save(world.getServer(), false);
+        });
 
         ServerTickEvents.START_SERVER_TICK.register(server -> {
             this.forEach(tardis -> {
@@ -207,8 +212,6 @@ public abstract class DeprecatedServerTardisManager extends TardisManager<Server
                 } else if (state == TravelHandlerBase.State.MAT) {
                     tardis.travel().finishRemat();
                 }
-
-                tardis.door().closeDoors();
             }
 
             this.fileManager.saveTardis(server, this, tardis);

--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.function.BooleanSupplier;
 
+import dev.amble.ait.core.tardis.TardisDesktop;
 import dev.amble.lib.util.ServerLifecycleHooks;
 import dev.drtheo.multidim.MultiDim;
 import dev.drtheo.multidim.MultiDimFileManager;
@@ -14,6 +15,10 @@ import dev.drtheo.multidim.api.MultiDimServerWorld;
 import dev.drtheo.multidim.api.WorldBlueprint;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.biome.Biome;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.world.ClientWorld;
@@ -59,6 +64,19 @@ public class TardisServerWorld extends MultiDimServerWorld {
             return false;
 
         return super.spawnEntity(entity);
+    }
+
+    // TODO: make this return a constant value
+    @Override
+    public RegistryEntry<Biome> getBiome(BlockPos pos) {
+        return super.getBiome(pos);
+    }
+
+    @Override
+    public boolean canPlayerModifyAt(PlayerEntity player, BlockPos pos) {
+        return super.canPlayerModifyAt(player, pos) &&
+                pos.getX() > -TardisDesktop.RADIUS && pos.getX() < TardisDesktop.RADIUS &&
+                pos.getZ() > -TardisDesktop.RADIUS && pos.getZ() < TardisDesktop.RADIUS;
     }
 
     public void setTardis(ServerTardis tardis) {

--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -40,7 +40,6 @@ import net.minecraft.world.spawner.Spawner;
 import dev.amble.ait.AITMod;
 import dev.amble.ait.core.AITDimensions;
 import dev.amble.ait.core.tardis.ServerTardis;
-import dev.amble.ait.core.tardis.manager.ServerTardisManager;
 
 public class TardisServerWorld extends MultiDimServerWorld {
 
@@ -54,13 +53,13 @@ public class TardisServerWorld extends MultiDimServerWorld {
 
     @Override
     public void tick(BooleanSupplier shouldKeepTicking) {
-        if (this.getTardis().shouldTick())
+        if (this.tardis != null && this.tardis.shouldTick())
             super.tick(shouldKeepTicking);
     }
 
     @Override
     public boolean spawnEntity(Entity entity) {
-        if (entity instanceof ItemEntity && this.getTardis().interiorChangingHandler().regenerating().get())
+        if (entity instanceof ItemEntity && this.tardis.interiorChangingHandler().regenerating().get())
             return false;
 
         return super.spawnEntity(entity);
@@ -84,10 +83,6 @@ public class TardisServerWorld extends MultiDimServerWorld {
     }
 
     public ServerTardis getTardis() {
-        if (this.tardis == null)
-            this.tardis = ServerTardisManager.getInstance().demandTardis(this.getServer(),
-                    UUID.fromString(this.getRegistryKey().getValue().getPath()));
-
         return tardis;
     }
 
@@ -111,11 +106,11 @@ public class TardisServerWorld extends MultiDimServerWorld {
         multidim.load(AITDimensions.TARDIS_WORLD_BLUEPRINT, saved.world());
 
         MultiDimMod.LOGGER.info("Time taken to load sub-world: {}", System.currentTimeMillis() - start);
-        return get(tardis);
-    }
 
-    public static ServerWorld get(ServerTardis tardis) {
-        return ServerLifecycleHooks.get().getWorld(keyForTardis(tardis));
+        TardisServerWorld world = (TardisServerWorld) server.getWorld(keyForTardis(tardis));
+        world.setTardis(tardis);
+
+        return world;
     }
 
     public static RegistryKey<World> keyForTardis(ServerTardis tardis) {

--- a/src/main/java/dev/amble/ait/mixin/server/multidim/MultiDimLoadFix.java
+++ b/src/main/java/dev/amble/ait/mixin/server/multidim/MultiDimLoadFix.java
@@ -25,9 +25,10 @@ public class MultiDimLoadFix {
         if (result != null)
             return result;
 
-        if (TardisServerWorld.isTardisDimension(key))
+        if (TardisServerWorld.isTardisDimension(key)) {
             return ServerTardisManager.getInstance().loadTardis(instance, TardisServerWorld.getTardisId(key))
                     .map(ServerTardis::world, e -> null);
+        }
 
         return null;
     }


### PR DESCRIPTION
## About the PR
This is another performance PR with general performance fixes.

## Why / Balance
Because the performance SUCKS.

## Technical details
This PR makes it so the doors don't close on world save. I dont know why this was even a thing. Next, players are now restricted in block placement. They can only place blocks in the 500 block radius from the center of the world (x: 0, z: 0). 
Also this PR forces the server tardis manager to save the tardises only when the overworld gets saved (and not the other 100 miniworlds).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- perf: general performance improvements