### PR TITLE
revert world border restrictions & add biome caching

### DIFF
--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.function.BooleanSupplier;
 
-import dev.amble.ait.core.tardis.TardisDesktop;
 import dev.amble.lib.util.ServerLifecycleHooks;
 import dev.drtheo.multidim.MultiDim;
 import dev.drtheo.multidim.MultiDimFileManager;
@@ -15,7 +14,6 @@ import dev.drtheo.multidim.api.MultiDimServerWorld;
 import dev.drtheo.multidim.api.WorldBlueprint;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.biome.Biome;
@@ -46,6 +44,7 @@ public class TardisServerWorld extends MultiDimServerWorld {
     public static final String NAMESPACE = AITMod.MOD_ID + "-tardis";
 
     private ServerTardis tardis;
+    private RegistryEntry<Biome> cachedBiome;
 
     public TardisServerWorld(WorldBlueprint blueprint, MinecraftServer server, Executor workerExecutor, LevelStorage.Session session, ServerWorldProperties properties, RegistryKey<World> worldKey, DimensionOptions dimensionOptions, WorldGenerationProgressListener worldGenerationProgressListener, List<Spawner> spawners, @Nullable RandomSequencesState randomSequencesState, boolean created) {
         super(blueprint, server, workerExecutor, session, properties, worldKey, dimensionOptions, worldGenerationProgressListener, spawners, randomSequencesState, created);
@@ -65,17 +64,13 @@ public class TardisServerWorld extends MultiDimServerWorld {
         return super.spawnEntity(entity);
     }
 
-    // TODO: make this return a constant value
     @Override
     public RegistryEntry<Biome> getBiome(BlockPos pos) {
-        return super.getBiome(pos);
-    }
+        if (this.cachedBiome != null)
+            return cachedBiome;
 
-    @Override
-    public boolean canPlayerModifyAt(PlayerEntity player, BlockPos pos) {
-        return super.canPlayerModifyAt(player, pos) &&
-                pos.getX() > -TardisDesktop.RADIUS && pos.getX() < TardisDesktop.RADIUS &&
-                pos.getZ() > -TardisDesktop.RADIUS && pos.getZ() < TardisDesktop.RADIUS;
+        this.cachedBiome = super.getBiome(pos);
+        return cachedBiome;
     }
 
     public void setTardis(ServerTardis tardis) {


### PR DESCRIPTION
## About the PR
This PR reverts world border restrictions of the #1548 and adds biome caching to the tardis world.

## Why / Balance
A bunch of people came with pitchforks and torches.

## Technical details
Biome caching is done through lazy initialization.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: slightly improved biome check of the tardis world