### PR TITLE
Fix some controls being interact-able during growth state

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/control/ControlBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/control/ControlBlockEntity.java
@@ -100,9 +100,6 @@ public abstract class ControlBlockEntity extends InteriorLinkableBlockEntity {
         if (!(found.get() instanceof ServerTardis tardis))
             return false;
 
-        if (found.get().isGrowth())
-            return false;
-
         if (!this.control.canRun(tardis, user))
             return false;
 

--- a/src/main/java/dev/amble/ait/core/blockentities/control/ControlBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/control/ControlBlockEntity.java
@@ -100,6 +100,9 @@ public abstract class ControlBlockEntity extends InteriorLinkableBlockEntity {
         if (!(found.get() instanceof ServerTardis tardis))
             return false;
 
+        if (found.get().isGrowth())
+            return false;
+
         if (!this.control.canRun(tardis, user))
             return false;
 

--- a/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
@@ -378,14 +378,8 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
     }
 
     public boolean run(PlayerEntity player, World world, boolean leftClick) {
-        Tardis tardis = this.tardis().get();
-
-        if (world.isClient() || tardis.isGrowth())
+        if (world.isClient())
             return false;
-
-        if (world.getRandom().nextBetween(1, 10_000) == 72)
-            this.getWorld().playSound(null, this.getBlockPos(), AITSounds.EVEN_MORE_SECRET_MUSIC, SoundCategory.MASTER,
-                    1F, 1F);
 
         if (player.getMainHandStack().isOf(AITItems.TARDIS_ITEM))
             this.discard();
@@ -397,6 +391,8 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
             this.discard();
             return false;
         }
+
+        Tardis tardis = this.tardis().get();
 
         if (player.getMainHandStack().isOf(AITItems.SONIC_SCREWDRIVER) && this.getDurability() < 1.0f
                 && SonicItem.mode(player.getMainHandStack()) == SonicMode.Modes.TARDIS) {
@@ -415,6 +411,10 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
 
         if (!this.control.canRun(tardis, (ServerPlayerEntity) player))
             return false;
+
+        if (world.getRandom().nextBetween(1, 10_000) == 72)
+            this.getWorld().playSound(null, this.getBlockPos(), AITSounds.EVEN_MORE_SECRET_MUSIC, SoundCategory.MASTER,
+                    1F, 1F);
 
         boolean hasMallet = player.getMainHandStack().isOf(AITItems.HAMMER);
 

--- a/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
@@ -378,7 +378,9 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
     }
 
     public boolean run(PlayerEntity player, World world, boolean leftClick) {
-        if (world.isClient())
+        Tardis tardis = this.tardis().get();
+
+        if (world.isClient() || tardis.isGrowth())
             return false;
 
         if (world.getRandom().nextBetween(1, 10_000) == 72)
@@ -395,8 +397,6 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
             this.discard();
             return false;
         }
-
-        Tardis tardis = this.tardis().get();
 
         if (player.getMainHandStack().isOf(AITItems.SONIC_SCREWDRIVER) && this.getDurability() < 1.0f
                 && SonicItem.mode(player.getMainHandStack()) == SonicMode.Modes.TARDIS) {

--- a/src/main/java/dev/amble/ait/core/tardis/control/Control.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/Control.java
@@ -122,6 +122,9 @@ public class Control implements Identifiable {
     }
 
     public boolean canRun(Tardis tardis, ServerPlayerEntity user) {
+        if (tardis.isGrowth())
+            return false;
+
         if (this.requiresPower() && !tardis.fuel().hasPower())
             return false;
 


### PR DESCRIPTION
## About the PR
This PR prevents interact-ability of the console controls during a TARDIS' growth-state.

fixes #1525 

## Why / Balance
The console controls should not be interactable during growth mode, as the TARDIS has not yet fully formed.

## Technical details
There is a guard-clause early on in the control-code, which returns false if the TARDIS is in the growth-state (so that neither the sound for a control plays, nor a missing-subsystem message is displayed, etc.).

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: controls were interact-able during growth state, but shouldn't