### PR TITLE
fix sticky controls being bypass-able via left-click

### DIFF
--- a/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
@@ -192,27 +192,6 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
             return ActionResult.SUCCESS;
         }
 
-        if (isSticky()) {
-            if (player.getMainHandStack().isOf(Items.SHEARS)) {
-                this.playSound(SoundEvents.ENTITY_SHEEP_SHEAR, 1, 1);
-                this.dataTracker.set(STICKY, false);
-                return ActionResult.FAIL;
-            }
-
-            this.playSound(SoundEvents.BLOCK_SLIME_BLOCK_BREAK, 0.4f, 1);
-            player.getWorld().addParticle(
-                    new BlockStateParticleEffect(ParticleTypes.BLOCK, Blocks.SLIME_BLOCK.getDefaultState()),
-                    this.getX(), this.getY(), this.getZ(),
-                    0.2, 0.5, -0.1
-            );
-
-            return ActionResult.FAIL;
-        } else if (player.getMainHandStack().isOf(Items.SLIME_BALL)) {
-            this.playSound(SoundEvents.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
-            this.dataTracker.set(STICKY, true);
-            return ActionResult.FAIL;
-        }
-
         if (hand == Hand.MAIN_HAND && !this.run(player, player.getWorld(), false))
             this.playFailFx();
 
@@ -378,6 +357,27 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
     }
 
     public boolean run(PlayerEntity player, World world, boolean leftClick) {
+        if (isSticky()) {
+            if (player.getMainHandStack().isOf(Items.SHEARS)) {
+                this.playSound(SoundEvents.ENTITY_SHEEP_SHEAR, 1, 1);
+                this.dataTracker.set(STICKY, false);
+                return true;
+            }
+
+            this.playSound(SoundEvents.BLOCK_SLIME_BLOCK_BREAK, 0.4f, 1);
+            player.getWorld().addParticle(
+                    new BlockStateParticleEffect(ParticleTypes.BLOCK, Blocks.SLIME_BLOCK.getDefaultState()),
+                    this.getX(), this.getY(), this.getZ(),
+                    0.2, 0.5, -0.1
+            );
+
+            return true;
+        } else if (player.getMainHandStack().isOf(Items.SLIME_BALL)) {
+            this.playSound(SoundEvents.BLOCK_SLIME_BLOCK_BREAK, 1, 1);
+            this.dataTracker.set(STICKY, true);
+            return true;
+        }
+
         if (world.isClient())
             return false;
 


### PR DESCRIPTION
## About the PR
This PR fixes the sticky-controls feature (#1503) being bypassed when punching (i.e. left-clicking) controls.

## Why / Balance
When controls are being made sticky, then it shouldn't matter if we left- or right-click them.
They should prevent the control from operating in either case.

## Technical details
(The mentioned methods all relate to [ConsoleControlEntity](https://github.com/amblelabs/ait/blob/main/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java))

When interacting (i.e. right-clicking) with a control, the `interact` method is called, at the end of which the `run` method is called (which executes the main functionality of the control).
The `interact` method handles sticky controls and prevents `run` from being called.
But when punching (i.e. left-clicking) a sticky control, this calls `run` directly and thus bypasses `interact`, which means the stickiness will be bypassed as well.

This PR moves the stickiness logic from the `interact` method into the `run`method.
I also set `true` for its various returns, so that their own sound plays.
Otherwise when `run` returns from its call in `interact`, the fail sound-FX would play and mask the stickiness-sound FX.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: sticky keys could be bypassed via punching / left-clicking controls