### PR TITLE
fix: siege held uuid backwards compat

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
@@ -167,7 +167,7 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
             }
         }
 
-        if (sneaking && tardis.siege().isActive() && !tardis.isSiegeBeingHeld()) {
+        if (sneaking && !tardis.isSiegeBeingHeld()) {
             SiegeTardisItem.pickupTardis(tardis, (ServerPlayerEntity) player);
             return;
         }

--- a/src/main/java/dev/amble/ait/core/item/SiegeTardisItem.java
+++ b/src/main/java/dev/amble/ait/core/item/SiegeTardisItem.java
@@ -49,7 +49,6 @@ public class SiegeTardisItem extends LinkableItem {
 
         if (!tardis.siege().isActive()) {
             tardis.setSiegeBeingHeld(null);
-            stack = ItemStack.EMPTY;
             return;
         }
 

--- a/src/main/java/dev/amble/ait/core/tardis/handler/SiegeHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/SiegeHandler.java
@@ -85,6 +85,12 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
         active.of(this, ACTIVE);
         heldKey.of(this, HELD_KEY);
         texture.of(this, TEXTURE);
+
+        // fix old data using new UUID(0, 0) instead of null.
+        UUID held = this.getHeldPlayerUUID();
+
+        if (held != null && held.getMostSignificantBits() == 0 && held.getLeastSignificantBits() == 0)
+            this.setSiegeBeingHeld(null);
     }
 
     public boolean isActive() {
@@ -92,7 +98,7 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
     }
 
     public boolean isSiegeBeingHeld() {
-        return heldKey.get() != null;
+        return this.isActive() && heldKey.get() != null;
     }
 
     public UUID getHeldPlayerUUID() {
@@ -157,16 +163,16 @@ public class SiegeHandler extends KeyedTardisComponent implements TardisTickable
         boolean freeze = this.siegeTime > 60 * 20 && !this.isSiegeBeingHeld()
                 && !this.tardis.subsystems().lifeSupport().isEnabled();
 
-        for (ServerPlayerEntity player : TardisUtil.getPlayersInsideInterior(this.tardis.asServer())) {
+        this.tardis.asServer().world().getPlayers().forEach(player -> {
             if (!player.isAlive() || !player.canFreeze())
-                continue;
+                return;
 
             if (freeze) {
                 this.freeze(player);
             } else {
                 this.unfreeze(player);
             }
-        }
+        });
     }
 
     private void freeze(ServerPlayerEntity player) {


### PR DESCRIPTION
## About the PR
This PR fixes the backwards compatibility between the new and one of the older releases.

## Why / Balance
One of the previous PRs allowed to use `null` values in properties. This PR fixes the backwards compatibility of the TARDIS' created before that release.

## Technical details
`SiegeHandler` was changed to use the null value to check whether the sieged tardis is being held or not, but the older versions used `new UUID(0, 0)`.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a 🆑 symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

🆑
- fix: siege should be held-able with TARDIS' created prior to one of the previous releases