### PR TITLE
Durability for Stat Remotes

### DIFF
--- a/src/main/java/dev/amble/ait/core/AITItems.java
+++ b/src/main/java/dev/amble/ait/core/AITItems.java
@@ -59,7 +59,7 @@ public class AITItems extends ItemContainer {
     // Functional Items
     @NoEnglish
     public static final Item REMOTE_ITEM = new RemoteItem(
-            new AItemSettings().group(AITItemGroups.MAIN).maxCount(1));
+            new AItemSettings().group(AITItemGroups.MAIN).maxCount(1).fireproof().maxDamageIfAbsent(300));
     @NoEnglish
     public static final Item ARTRON_COLLECTOR = new ArtronCollectorItem(
             new AItemSettings().group(AITItemGroups.MAIN).maxCount(1));


### PR DESCRIPTION
## About the PR
Added durability to stat remotes.

## Why / Balance
They're extremely unbalanced.

## Technical details
Added 300 durability to them.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->