### PR TITLE
feat: scan exterior in overload to cancel demat / toggle alarms etc

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -1,14 +1,26 @@
 package dev.amble.ait.core.item.sonic;
 
+import dev.amble.ait.api.tardis.link.v2.Linkable;
+import dev.amble.ait.api.tardis.link.v2.block.AbstractLinkableBlockEntity;
 import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.core.AITTags;
+import dev.amble.ait.core.blockentities.ExteriorBlockEntity;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.tardis.control.Control;
+import dev.amble.ait.core.tardis.control.impl.HADSControl;
+import dev.amble.ait.core.tardis.control.impl.HandBrakeControl;
+import dev.amble.ait.core.tardis.handler.travel.TravelHandler;
+import dev.amble.ait.core.tardis.handler.travel.TravelHandlerBase;
+import dev.amble.ait.data.Loyalty;
 import dev.amble.ait.data.schema.sonic.SonicSchema;
+import dev.amble.ait.registry.impl.ControlRegistry;
 import net.minecraft.block.*;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.BlockStateParticleEffect;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.state.property.Properties;
@@ -56,6 +68,16 @@ public class OverloadSonicMode extends SonicMode {
 
         if (!canMakeRedstoneTweak(ticks))
             return;
+
+        if (world.getBlockEntity(pos) instanceof AbstractLinkableBlockEntity ext && ext.isLinked()) {
+            // flick handbrake
+            ServerTardis tardis = ext.tardis().get().asServer();
+            if (tardis.loyalty().get((PlayerEntity) user).smallerThan(Loyalty.fromLevel(Loyalty.Type.COMPANION.level))) return;
+
+            getExpectedControl(tardis).handleRun(tardis, (ServerPlayerEntity) user, world, pos, false);
+            this.playFx(world, pos);
+            return;
+        }
 
         if (block instanceof DaylightDetectorBlock) {
             activateBlock(world, pos, user, state, blockHit);
@@ -105,6 +127,20 @@ public class OverloadSonicMode extends SonicMode {
                 world.emitGameEvent(user, GameEvent.BLOCK_PLACE, pos);
             }
         }
+    }
+
+    /**
+     * Interprets the control that the player is most likely trying to use
+     * @return Control
+     */
+    private static Control getExpectedControl(ServerTardis tardis) {
+        TravelHandler travel = tardis.travel();
+
+        if (travel.getState() == TravelHandlerBase.State.DEMAT || tardis.subsystems().engine().phaser().isPhasing()) {
+            return new HandBrakeControl();
+        }
+
+        return new HADSControl(); // ( alarm toggle )
     }
 
     private void activateBlock(ServerWorld world, BlockPos pos, LivingEntity user, BlockState state, BlockHitResult blockHitResult) {


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
If you now scan a tardis you are loyal to in overload mode, certain controls will run.
For example, a TARDIS which is dematting will flick the handbrake to cancel it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Funsies

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->