### PR TITLE
fix: dont render emission if there's no power power and no alarms

### DIFF
--- a/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
@@ -1,6 +1,7 @@
 package dev.amble.ait.client.boti;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import dev.amble.ait.client.util.ClientTardisUtil;
 import org.joml.Vector3f;
 import org.lwjgl.opengl.GL11;
 
@@ -11,8 +12,6 @@ import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.model.SinglePartEntityModel;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.entity.passive.SheepEntity;
-import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.RotationAxis;
@@ -130,27 +129,16 @@ public class TardisDoorBOTI extends BOTI {
             stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
             stack.scale(scale.x, scale.y, scale.z);
             if (variant.emission() != null) {
-                float u;
-                float t;
-                float s;
+                float u = 1;
+                float t = 1;
+                float s = 1;
 
                 if ((stats.getName() != null && "partytardis".equals(stats.getName().toLowerCase()) || (!tardis.extra().getInsertedDisc().isEmpty()))) {
-                    int m = 25;
-                    int n = MinecraftClient.getInstance().player.age / m + MinecraftClient.getInstance().player.getId();
-                    int o = DyeColor.values().length;
-                    int p = n % o;
-                    int q = (n + 1) % o;
-                    float r = ((float) (MinecraftClient.getInstance().player.age % m)) / m;
-                    float[] fs = SheepEntity.getRgbColor(DyeColor.byId(p));
-                    float[] gs = SheepEntity.getRgbColor(DyeColor.byId(q));
-                    s = fs[0] * (1f - r) + gs[0] * r;
-                    t = fs[1] * (1f - r) + gs[1] * r;
-                    u = fs[2] * (1f - r) + gs[2] * r;
-                } else {
-                    float[] hs = new float[]{1.0f, 1.0f, 1.0f};
-                    s = hs[0];
-                    t = hs[1];
-                    u = hs[2];
+                    final float[] rgb = ClientTardisUtil.getPartyColors();
+
+                    u = rgb[0];
+                    t = rgb[1];
+                    s = rgb[2];
                 }
 
                 boolean power = tardis.fuel().hasPower();

--- a/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
+++ b/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
@@ -14,8 +14,11 @@ import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.passive.SheepEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.registry.RegistryKey;
+import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -275,5 +278,24 @@ public class ClientTardisUtil {
 
     public static float getAlarmDeltaForLerp() {
         return (float) getAlarmDelta() / MAX_ALARM_DELTA_TICKS;
+    }
+
+    public static float[] getPartyColors() {
+        final int m = 25;
+        final PlayerEntity player = MinecraftClient.getInstance().player;
+
+        int n = player.age / m + player.getId();
+        int o = DyeColor.values().length;
+        int p = n % o;
+        int q = (n + 1) % o;
+        float r = ((float)(player.age % m)) / m;
+        float[] fs = SheepEntity.getRgbColor(DyeColor.byId(p));
+        float[] gs = SheepEntity.getRgbColor(DyeColor.byId(q));
+
+        float s = fs[0] * (1f - r) + gs[0] * r;
+        float t = fs[1] * (1f - r) + gs[1] * r;
+        float u = fs[2] * (1f - r) + gs[2] * r;
+
+        return new float[] { s, t, u };
     }
 }

--- a/src/main/java/dev/amble/ait/client/util/FoggyUtils.java
+++ b/src/main/java/dev/amble/ait/client/util/FoggyUtils.java
@@ -8,10 +8,8 @@ import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.model.json.ModelTransformationMode;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EquipmentSlot;
-import net.minecraft.entity.passive.SheepEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.util.DyeColor;
 import net.minecraft.util.math.MathHelper;
 
 import dev.amble.ait.core.AITDimensions;
@@ -27,10 +25,9 @@ public class FoggyUtils {
         Tardis tardis = ClientTardisUtil.getCurrentTardis();
 
         if (mc.player != null && !mc.player.isSpectator() && mc.world != null && mc.world.getRegistryKey().equals(AITDimensions.SPACE)) {
+            // EW WTF IS THAT
             for (Planet planet : Space.getInstance().getPlanets()) {
-                //System.out.println(planet + ":" + (planet.render().position().distanceTo(mc.player.getPos()) /*< planet.render().radius()*/) + ":" + planet.render().radius());
                 if (planet != PlanetRegistry.getInstance().get(mc.world) && planet.render().position().distanceTo(mc.player.getPos()) < planet.render().radius()) {
-                    //System.out.println(planet);
                     MatrixStack stack = new MatrixStack();
                     stack.push();
                     stack.translate(0, 0, -2);
@@ -51,10 +48,10 @@ public class FoggyUtils {
             }
         }
 
-        if (tardis == null || tardis.getExterior() == null)
+        if (tardis == null)
             return;
 
-        if (ClientTardisUtil.isPlayerInATardis() && !tardis.isGrowth()
+        if (!tardis.isGrowth()
                 && ClientTardisUtil.getAlarmDelta() != ClientTardisUtil.MAX_ALARM_DELTA_TICKS) {
             RenderSystem.setShaderFogStart(MathHelper.lerp(ClientTardisUtil.getAlarmDeltaForLerp(), -8, 10));
             RenderSystem.setShaderFogEnd(MathHelper.lerp(ClientTardisUtil.getAlarmDeltaForLerp(), 11, 32));
@@ -63,7 +60,7 @@ public class FoggyUtils {
             MinecraftClient.getInstance().gameRenderer.getCamera().getSubmersionType();
         }
 
-        if (ClientTardisUtil.isPlayerInATardis() && !tardis.isGrowth()
+        if (tardis.isGrowth()
                 && ClientTardisUtil.getPowerDelta() != ClientTardisUtil.MAX_POWER_DELTA_TICKS) {
             RenderSystem.setShaderFogStart(MathHelper.lerp(ClientTardisUtil.getPowerDeltaForLerp(), -8, 24));
             RenderSystem.setShaderFogEnd(MathHelper.lerp(ClientTardisUtil.getPowerDeltaForLerp(), 11, 32));
@@ -71,7 +68,7 @@ public class FoggyUtils {
             RenderSystem.setShaderFogColor(0, 0, 0, tardis.siege().isActive() ? 0.85f : 1f);
         }
 
-        if (ClientTardisUtil.isPlayerInATardis() && tardis.crash().isToxic() && tardis.fuel().hasPower()) {
+        if (tardis.crash().isToxic() && tardis.fuel().hasPower()) {
             RenderSystem
                     .setShaderFogStart(MathHelper.lerp(MinecraftClient.getInstance().getTickDelta() / 100f, -8, 24));
             RenderSystem.setShaderFogEnd(MathHelper.lerp(MinecraftClient.getInstance().getTickDelta() / 100f, 11, 32));
@@ -83,58 +80,17 @@ public class FoggyUtils {
                     stack.isIn(AITTags.Items.FULL_RESPIRATORS) ? 0.015f : 0.35f);
         }
 
-        if (ClientTardisUtil.isPlayerInATardis()
-                && !tardis.isGrowth()
+        if (!tardis.isGrowth()
                 && ("partytardis".equalsIgnoreCase(String.valueOf(tardis.stats().getName()))
                 || !tardis.extra().getInsertedDisc().isEmpty())) {
 
+            final float[] rgb = ClientTardisUtil.getPartyColors();
             MinecraftClient minecraftClient = MinecraftClient.getInstance();
-
-            int m = 25;
-            int n = minecraftClient.player.age / m + minecraftClient.player.getId();
-            int o = DyeColor.values().length;
-            int p = n % o;
-            int q = (n + 1) % o;
-            float rProgress = ((float)(minecraftClient.player.age % m)) / m;
-            float[] fs = SheepEntity.getRgbColor(DyeColor.byId(p));
-            float[] gs = SheepEntity.getRgbColor(DyeColor.byId(q));
-            float red = fs[0] * (1f - rProgress) + gs[0] * rProgress;
-            float green = fs[1] * (1f - rProgress) + gs[1] * rProgress;
-            float blue = fs[2] * (1f - rProgress) + gs[2] * rProgress;
 
             RenderSystem.setShaderFogStart(MathHelper.lerp(minecraftClient.getTickDelta() / 100f, -8, 24));
             RenderSystem.setShaderFogEnd(MathHelper.lerp(minecraftClient.getTickDelta() / 100f, 20, 40));
             RenderSystem.setShaderFogShape(FogShape.SPHERE);
-            RenderSystem.setShaderFogColor(red, green, blue, 0.25f);
+            RenderSystem.setShaderFogColor(rgb[0], rgb[1], rgb[2], 0.25f);
         }
-
-
-        /*
-         * if (!AITMod.AIT_CONFIG.DISABLE_LOYALTY_FOG() &&
-         * ClientTardisUtil.isPlayerInATardis() && !tardis.crash().isToxic() &&
-         * !tardis.alarm().enabled().get() && tardis.fuel().hasPower() ) {
-         * RenderSystem.setShaderFogStart(MathHelper.lerp(MinecraftClient.getInstance().
-         * getTickDelta() / 100f, -8, 24));
-         * RenderSystem.setShaderFogEnd(MathHelper.lerp(MinecraftClient.getInstance().
-         * getTickDelta() / 100f, 11, 32));
-         * RenderSystem.setShaderFogShape(FogShape.CYLINDER);
-         *
-         * int loyaltyLevel =
-         * tardis.loyalty().get(MinecraftClient.getInstance().player).level();
-         * RenderSystem.setShaderFogColor(1 - loyaltyLevel / 100f, 0, loyaltyLevel /
-         * 100f, 0.025f); }
-         */
-
-        /*
-         * if(MinecraftClient.getInstance().world != null
-         * &&MinecraftClient.getInstance().world.getRegistryKey() ==
-         * AITDimensions.TIME_VORTEX_WORLD) {
-         * RenderSystem.setShaderFogStart(MathHelper.lerp(MinecraftClient.getInstance().
-         * getTickDelta() / 100f, -8, 24));
-         * RenderSystem.setShaderFogEnd(MathHelper.lerp(MinecraftClient.getInstance().
-         * getTickDelta() / 100f, 11, 32));
-         * RenderSystem.setShaderFogShape(FogShape.SPHERE);
-         * RenderSystem.setShaderFogColor(0.3f, 0.3f, 0.3f, 0.35f); }
-         */
     }
 }


### PR DESCRIPTION
## About the PR
This PR makes it so the emission layer doesn't render for no power and no alarm exterior.

## Why / Balance
Because some no power exteriors look weird now.

## Technical details
Basically, the code was tinting the emission layer near-black color instead of just not rendering the emission layer. A lot of exteriors depended on that behavior so they started to look really weird after this change.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a 🆑 symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

🆑
- fix: render unpowered exterior emission properly