### PR TITLE
Fix dev exterior textures not appearing

### DIFF
--- a/src/main/java/dev/amble/ait/client/models/doors/exclusive/DoomDoorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/doors/exclusive/DoomDoorModel.java
@@ -16,9 +16,9 @@ public class DoomDoorModel extends DoorModel {
     private final ModelPart doom;
 
     public static final Identifier DOOM_DOOR = new Identifier(AITMod.MOD_ID,
-            "textures/blockentities/exteriors/doom/doom_door.png");
+            "textures/blockentities/exteriors/exclusive/doom/doom_door.png");
     public static final Identifier DOOM_DOOR_OPEN = new Identifier(AITMod.MOD_ID,
-            "textures/blockentities/exteriors/doom/doom_door_open.png");
+            "textures/blockentities/exteriors/exclusive/doom/doom_door_open.png");
 
     public DoomDoorModel(ModelPart root) {
         this.doom = root.getChild("doom");

--- a/src/main/java/dev/amble/ait/data/schema/exterior/variant/exclusive/wanderer/client/ClientBoothWandererVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/exterior/variant/exclusive/wanderer/client/ClientBoothWandererVariant.java
@@ -14,7 +14,7 @@ public class ClientBoothWandererVariant extends ClientExteriorVariantSchema {
 
     protected static final String CATEGORY_PATH = "textures/blockentities/exteriors/exclusive/wanderer";
     protected static final String TEXTURE_PATH = CATEGORY_PATH + "/wanderer.png";
-    protected static final String EMISSIVE_TEXTURE_PATH = CATEGORY_PATH + "/wanderer_emissive.png";
+    protected static final String EMISSIVE_TEXTURE_PATH = CATEGORY_PATH + "/wanderer_emission.png";
 
     public ClientBoothWandererVariant() {
         super(AITMod.id("exterior/exclusive/wanderer"));


### PR DESCRIPTION
## About the PR
This PR fixes the dev door textures not showing up in-game.

## Why / Balance
To have their textures show up properly in-game.

## Technical details
The doom door was missing the "exclusive" subfolder in its path.
The wanderer booth's emissive texture filename is different than it was referred to in code.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: textures for some dev exteriors not appearing