### PR TITLE
Fix sonic locator bugs

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -91,13 +91,14 @@ public class ScanningSonicMode extends SonicMode {
 
         BlockState state = world.getBlockState(pos);
         Block block = state.getBlock();
+        Tardis tardis = SonicItem.getTardisStatic(world, stack);
 
         String blastRes = String.format("%.2f", block.getBlastResistance());
 
-        if (state.isIn(AITTags.Blocks.SONIC_CAN_LOCATE)) {
-            Tardis tardis = SonicItem.getTardisStatic(world, stack);
+        if (tardis != null && state.isIn(AITTags.Blocks.SONIC_CAN_LOCATE)) {
             BlockPos tPos = tardis.travel().position().getPos();
-            String dimensionText = MonitorUtil.truncateDimensionName(WorldUtil.worldText(world.getRegistryKey()).getString(), 20);
+            World tardisWorld = tardis.travel().position().getWorld();
+            String dimensionText = MonitorUtil.truncateDimensionName(WorldUtil.worldText(tardisWorld.getRegistryKey()).getString(), 20);
 
             Text coordinatesMessage = Text.translatable("item.sonic.scanning.locator_message.coordinates", tPos.getX(), tPos.getY(), tPos.getZ());
             Text fullMessage = Text.translatable("item.sonic.scanning.locator_message.title", dimensionText).append("\n").append(coordinatesMessage);


### PR DESCRIPTION
## About the PR
Fixes two bugs with the sonic's TARDIS locator functionality, as reported in #1636 and #1637:

- The message incorrectly shows the *player's* current dimension instead the dimension the TARDIS is located in.
- And the game crashes due to a NPE when the TARDIS linked to the sonic doesn't exist anymore.

## Why / Balance
Because less bugs > more bugs

## Technical details
It's two very small changes that should be apparent from the diff itself.
Basically I just included a null check for the TARDIS object, as well as replaced the use of `world` with the one derived from the TARDIS object.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Sonic's locator function crashed the game when the linked TARDIS didn't exist anymore.
- fix: Sonic's locator incorrectly showed the player's dimension instead the TARDIS' one.