### PR TITLE
Fix ability to circumvent valid Y-coordinate ranges for dimensions

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/DimensionControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/DimensionControl.java
@@ -3,6 +3,7 @@ package dev.amble.ait.core.tardis.control.impl;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import dev.amble.ait.core.tardis.control.impl.pos.PosType;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -50,7 +51,11 @@ public class DimensionControl extends Control {
 
             return dims.get(index);
         }).thenAccept(destWorld -> {
-            travel.forceDestination(cached -> cached.world(destWorld));
+            travel.destination(cached -> {
+                CachedDirectedGlobalPos cachedPos = cached.world(destWorld);
+                BlockPos clampedPos = PosType.clamp(cachedPos.getPos(), 0, destWorld);
+                return cachedPos.pos(clampedPos);
+            });
             messagePlayer(player, destWorld, LockedDimensionRegistry.getInstance().isUnlocked(tardis, destWorld));
         });
 

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/pos/PosType.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/pos/PosType.java
@@ -15,13 +15,7 @@ public enum PosType implements StringIdentifiable {
     Y() {
         @Override
         public BlockPos add(BlockPos pos, int amount, World world) {
-            if (world.getRegistryKey() == World.NETHER) {
-                return pos.withY(MathHelper.clamp(pos.getY() + amount, world.getBottomY(), 120));
-            }
-
-            return pos.withY(MathHelper.clamp(pos.getY() + amount, world.getBottomY(), world.getTopY() - 1)); // i hate
-                                                                                                                // you
-                                                                                                                // loqor
+            return PosType.clamp(pos, amount, world);
         }
 
         @Override
@@ -36,6 +30,15 @@ public enum PosType implements StringIdentifiable {
             return pos.add(0, 0, amount);
         }
     };
+
+    // Clamps the Y coordinate of a position depending on the world.
+    public static BlockPos clamp(BlockPos pos, int amount, World world) {
+        if (world.getRegistryKey() == World.NETHER) {
+            return pos.withY(MathHelper.clamp(pos.getY() + amount, world.getBottomY(), 120));
+        }
+
+        return pos.withY(MathHelper.clamp(pos.getY() + amount, world.getBottomY(), world.getTopY() - 1));
+    }
 
     // adds an amount to a blockpos based on this type
     public abstract BlockPos add(BlockPos pos, int amount);


### PR DESCRIPTION
## About the PR
This PR fixes the ability to make the TARDIS land beyond the valid maximum Y coordinate of a dimension, as well as beyond the worldborder coordinates.

<details>
<summary>Details</summary>

When entering a Y coordinate via the console controls, its range of valid coordinates will be determined by the current dimension target. But after switching to a new dimension target, the Y is not automatically adjusted to the valid range for the newly chosen dimension.
(Only after clicking the Y control again will the coordinates be adjusted.)

This can lead to e.g. being able to travel above the valid heights of dimensions (e.g. on top of the Nether roof, above the build height of the Overworld, etc.)

For example one could set the dimension to "Space", enter the max Y of 2031 and then switch to the Overworld dimension.
As long as the Y control isn't touched again, the target Y coordinate will stay at 2031 and the TARDIS *will* land there (if the vertical land type isn't enabled).
This would lead the TARDIS exterior to not be rendered and also not fall to the ground.
</details>

## Why / Balance
Because one is not supposed to circumvent these limitations.
Otherwise people TARDISes could end up above the Nether roof, above the build height or outside the world border.

## Technical details
The Y control has a block of code that clamps the Y coordinate depending on the target dimension.
I extracted that block of code into its own static function and use that for both the Y control, and now for the dimension control as well.
Additionally I make the dimension control now use `TravelHandler::destination` instead of `TravelHandler::forceDestination`, to make it honor the worldborder too.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: The dimension control can no longer be used to land outside the valid Y range or outside the worldborder.