### PR TITLE
Update HandlesResponseRegistry.java With New Commands

### DIFF
--- a/src/main/java/dev/amble/ait/registry/impl/HandlesResponseRegistry.java
+++ b/src/main/java/dev/amble/ait/registry/impl/HandlesResponseRegistry.java
@@ -364,6 +364,111 @@ public class HandlesResponseRegistry {
                 return AITMod.id("progress");
             }
         });
+
+        HandlesResponseRegistry.register(new HandlesResponse() {
+			@Override
+			public boolean run(ServerPlayerEntity player, HandlesSound source, ServerTardis tardis) {
+				sendChat(player, Text.literal("Toggled Shields."));
+				tardis.shields().visuallyShielded().toggle();
+				return success(source);
+			}
+
+			@Override
+			public List<String> getCommandWords() {
+				return List.of("toggle shields", "shields");
+			}
+
+			@Override
+			public Identifier id() {
+				return AITMod.id("toggle_shields");
+			}
+		});
+
+		HandlesResponseRegistry.register(new HandlesResponse() {
+			@Override
+			public boolean run(ServerPlayerEntity player, HandlesSound source, ServerTardis tardis) {
+				if (tardis.isRefueling()) {
+					sendChat(player, Text.literal("Refueling is already enabled."));
+					return failure(source);
+				}
+
+				sendChat(player, Text.literal("Enabling Refueling."));
+				tardis.setRefueling(true);
+				return success(source);
+			}
+
+			@Override
+			public List<String> getCommandWords() {
+				return List.of("refuel");
+			}
+
+			@Override
+			public Identifier id() {
+				return AITMod.id("enable_refuel");
+			}
+		});
+
+		HandlesResponseRegistry.register(new HandlesResponse() {
+			@Override
+			public boolean run(ServerPlayerEntity player, HandlesSound source, ServerTardis tardis) {
+				if (!tardis.isRefueling()) {
+					sendChat(player, Text.literal("Refueling is already disabled."));
+					return failure(source);
+				}
+
+				sendChat(player, Text.literal("Disabling Refueling."));
+				tardis.setRefueling(false);
+				return success(source);
+			}
+
+			@Override
+			public List<String> getCommandWords() {
+				return List.of("stop refuel");
+			}
+
+			@Override
+			public Identifier id() {
+				return AITMod.id("disable_refuel");
+			}
+		});
+
+		HandlesResponseRegistry.register(new HandlesResponse() {
+			@Override
+			public boolean run(ServerPlayerEntity player, HandlesSound source, ServerTardis tardis) {
+				sendChat(player, Text.literal("Protocol 3 Toggled."));
+				tardis.cloak().cloaked().toggle();
+				return success(source);
+			}
+
+			@Override
+			public List<String> getCommandWords() {
+				return List.of("p3");
+			}
+
+			@Override
+			public Identifier id() {
+				return AITMod.id("toggle_cloak");
+			}
+		});
+
+		HandlesResponseRegistry.register(new HandlesResponse() {
+			@Override
+			public boolean run(ServerPlayerEntity player, HandlesSound source, ServerTardis tardis) {
+				sendChat(player, Text.literal("Anti-Gravs Toggled."));
+				tardis.travel().antigravs().toggle();
+				return success(source);
+			}
+
+			@Override
+			public List<String> getCommandWords() {
+				return List.of("antigravs");
+			}
+
+			@Override
+			public Identifier id() {
+				return AITMod.id("toggle_antigravs");
+			}
+		});
     }
 
 


### PR DESCRIPTION
## About the PR
Added in code for:
Toggle Shields Command
Toggle Anti-Gravs Command
Toggle Cloak/Protocol 3 Command
Toggle Refuel On/Off Commands

## Why / Balance
This would provide a much needed buff to Handles while also keeping him from being too OP.

## Technical details
Updated HandlesResponseRegistry.java with commands for Toggling Shields, Anti-Gravs, Cloak, and two commands for Refuel on/off.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
The changes made do not break on dedicated servers nor do they break on singleplayer worlds.

**Changelog**
:cl:
- add: Added Toggle Shields, Toggle Anti-Gravs, Toggle Cloak/Protocol 3, and Toggle Refuel On/Off Commands to Handles.