### PR TITLE
Rifts Are Now VISIBLE With BOTI Off

### DIFF
--- a/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
@@ -37,6 +37,7 @@ public class RiftEntityRenderer
     public void render(RiftEntity riftEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
         if (AITModClient.CONFIG.enableTardisBOTI) {
             BOTI.RIFT_RENDERING_QUEUE.add(riftEntity);
+            return;
         }
 
         matrixStack.push();

--- a/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
@@ -4,13 +4,17 @@ package dev.amble.ait.client.renderers.entities;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.RotationAxis;
 
 import dev.amble.ait.AITMod;
+import dev.amble.ait.client.AITModClient;
 import dev.amble.ait.client.boti.BOTI;
 import dev.amble.ait.client.models.decoration.GallifreyFallsModel;
 import dev.amble.ait.client.models.decoration.PaintingFrameModel;
@@ -31,7 +35,16 @@ public class RiftEntityRenderer
 
     @Override
     public void render(RiftEntity riftEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
-        BOTI.RIFT_RENDERING_QUEUE.add(riftEntity);
+        if (AITModClient.CONFIG.enableTardisBOTI) {
+            BOTI.RIFT_RENDERING_QUEUE.add(riftEntity);
+        }
+
+        matrixStack.push();
+        matrixStack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
+        matrixStack.translate(0, -0.9, 0.05);
+        matrixStack.scale(1, 1, 1);
+        frame.render(matrixStack, vertexConsumerProvider.getBuffer(RenderLayer.getEntityTranslucentCull(RIFT_TEXTURE)), 0xf000f0, OverlayTexture.DEFAULT_UV, 0.6f, 0.0f, 1, 1);
+        matrixStack.pop();
     }
 
     @Override


### PR DESCRIPTION
## About the PR
Rifts now render as purple lines when BOTI is off.

## Why / Balance
They can actually see them now.

## Technical details
Just made the BOTI queue get added to when its enabled, otherwise render static rift model.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: rifts now render when BOTI is off.