### PR TITLE
feat: tardis coral decor blocks and crafting

### DIFF
--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -117,6 +117,30 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
                     .input('C', AITItems.CORAL_FRAGMENT)
                     .criterion(hasItem(AITItems.CORAL_FRAGMENT), conditionsFromItem(AITItems.CORAL_FRAGMENT)));
 
+            provider.addShapedRecipe(ShapedRecipeJsonBuilder.create(RecipeCategory.TOOLS, AITBlocks.TARDIS_CORAL_BLOCK, 1)
+                    .pattern("##")
+                    .pattern("##")
+                    .input('#', AITItems.CORAL_FRAGMENT)
+                    .criterion(hasItem(AITItems.CORAL_FRAGMENT), conditionsFromItem(AITItems.CORAL_FRAGMENT)));
+
+            provider.addShapedRecipe(ShapedRecipeJsonBuilder.create(RecipeCategory.TOOLS, AITBlocks.TARDIS_CORAL_SLAB, 6)
+                    .pattern("###")
+                    .input('#', AITBlocks.TARDIS_CORAL_BLOCK)
+                    .criterion(hasItem(AITBlocks.TARDIS_CORAL_BLOCK), conditionsFromItem(AITBlocks.TARDIS_CORAL_BLOCK)));
+
+            provider.addShapedRecipe(ShapedRecipeJsonBuilder.create(RecipeCategory.TOOLS, AITBlocks.TARDIS_CORAL_STAIRS, 4)
+                    .pattern("#  ")
+                    .pattern("## ")
+                    .pattern("###")
+                    .input('#', AITBlocks.TARDIS_CORAL_BLOCK)
+                    .criterion(hasItem(AITBlocks.TARDIS_CORAL_BLOCK), conditionsFromItem(AITBlocks.TARDIS_CORAL_BLOCK)));
+            provider.addShapedRecipe(ShapedRecipeJsonBuilder.create(RecipeCategory.TOOLS, AITBlocks.TARDIS_CORAL_FAN, 3)
+                    .pattern(" # ")
+                    .pattern("###")
+                    .pattern(" # ")
+                    .input('#', AITItems.CORAL_FRAGMENT)
+                    .criterion(hasItem(AITItems.CORAL_FRAGMENT), conditionsFromItem(AITItems.CORAL_FRAGMENT)));
+
             provider.addBlastFurnaceRecipe(CookingRecipeJsonBuilder.createBlasting(Ingredient.ofItems(AITItems.ZEITON_SHARD),
                             RecipeCategory.MISC, AITItems.SUPERHEATED_ZEITON, 0.2f, 500)
                     .criterion(hasItem(AITItems.ZEITON_SHARD), conditionsFromItem(AITItems.ZEITON_SHARD)),


### PR DESCRIPTION
## About the PR
you can craft tardis coral and fans with coral fragments, and you can now craft tardis coral slabs and stairs

## Why / Balance
closes #1678 

## Media
![image](https://github.com/user-attachments/assets/329c1d70-9366-4ece-b093-83f547d49908)
![image](https://github.com/user-attachments/assets/5e2814f9-d200-44fc-b508-5f432c44b579)
![image](https://github.com/user-attachments/assets/ba8f1ca6-6576-4047-92ba-a4edaaa5f546)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->