### PR TITLE
add: safeguard circumvention option

### DIFF
--- a/src/main/java/dev/amble/ait/config/AITServerConfig.java
+++ b/src/main/java/dev/amble/ait/config/AITServerConfig.java
@@ -85,6 +85,10 @@ public class AITServerConfig {
     @IntField(min = -1)
     @SerialEntry public int maxTardises = -1;
 
+    @AutoGen(category = CATEGORY)
+    @Boolean(formatter = Boolean.Formatter.YES_NO, colored = true)
+    @SerialEntry public boolean disableSafeguards = false;
+
     public static class StringListFactory implements ListGroup.ValueFactory<String>, ListGroup.ControllerFactory<String> {
 
         // used by the reflections

--- a/src/main/java/dev/amble/ait/core/tardis/util/AsyncLocatorUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/AsyncLocatorUtil.java
@@ -42,7 +42,7 @@ public class AsyncLocatorUtil {
         int threads = Runtime.getRuntime().availableProcessors() / 2;
         AITMod.LOGGER.trace("Starting locating executor service with thread pool size of {}", threads);
 
-        if (threads <= 0) {
+        if (threads <= 0 && !AITMod.CONFIG.disableSafeguards) {
             AITMod.LOGGER.error("Failed to start locating executor service: thread pool size is 0 or less - {}. Available Processors {}", threads, Runtime.getRuntime().availableProcessors());
             return;
         }

--- a/src/main/resources/assets/ait/lang/en_us.existing.json
+++ b/src/main/resources/assets/ait/lang/en_us.existing.json
@@ -15,6 +15,7 @@
   "yacl3.config.ait:server.travelBlacklist": "TARDIS travel world blacklist",
   "yacl3.config.ait:server.riftSpawnBlacklist": "Rift spawn world blacklist",
   "yacl3.config.ait:server.riftDropBlacklist": "Rift drop world blacklist",
+  "yacl3.config.ait:server.disableSafeguards": "Disable Safeguards",
 
   "yacl3.config.ait:client.interiorHumVolume": "Interior hum volume",
   "yacl3.config.ait:client.customMenu": "Use custom main menu?",


### PR DESCRIPTION
## About the PR
Added a server config option to disable some safeguards.

## Why / Balance
In some cases, java is being told that there's only 1 available CPU core, which may not be the case. But async locator util has a safeguard in place to ensure that there is AT LEAST 2 cpu cores (to offload the threads to), otherwise it fails.

## Technical details
<!-- Summary of code changes for easier review. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None