### PR TITLE
fix progress display on console monitors

### DIFF
--- a/src/main/java/dev/amble/ait/client/models/consoles/AlnicoConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/AlnicoConsoleModel.java
@@ -1494,13 +1494,10 @@ public class AlnicoConsoleModel extends ConsoleModel {
         MinecraftClient client = MinecraftClient.getInstance();
         TextRenderer renderer = client.textRenderer;
         TravelHandler travel = tardis.travel();
-        DirectedGlobalPos abpd = travel.getState() == TravelHandlerBase.State.FLIGHT
-                ? travel.getProgress()
-                : travel.position();
-        CachedDirectedGlobalPos dabpd = travel.destination();
-        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() != TravelHandlerBase.State.MAT
-                ? travel.getProgress()
-                : travel.position();
+        CachedDirectedGlobalPos abpd = travel.destination();
+        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() == TravelHandlerBase.State.MAT
+                ? travel.position()
+                : travel.getProgress();
 
         BlockPos abppPos = abpp.getPos();
         BlockPos abpdPos = abpd.getPos();

--- a/src/main/java/dev/amble/ait/client/models/consoles/CopperConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/CopperConsoleModel.java
@@ -1836,13 +1836,10 @@ public class CopperConsoleModel extends ConsoleModel {
         MinecraftClient client = MinecraftClient.getInstance();
         TextRenderer renderer = client.textRenderer;
         TravelHandler travel = tardis.travel();
-        DirectedGlobalPos abpd = travel.getState() == TravelHandlerBase.State.FLIGHT
-                ? travel.getProgress()
-                : travel.position();
-        CachedDirectedGlobalPos dabpd = travel.destination();
-        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() != TravelHandlerBase.State.MAT
-                ? travel.getProgress()
-                : travel.position();
+        CachedDirectedGlobalPos abpd = travel.destination();
+        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() == TravelHandlerBase.State.MAT
+                ? travel.position()
+                : travel.getProgress();
 
         BlockPos abppPos = abpp.getPos();
         BlockPos abpdPos = abpd.getPos();

--- a/src/main/java/dev/amble/ait/client/models/consoles/CoralConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/CoralConsoleModel.java
@@ -2541,13 +2541,10 @@ public class CoralConsoleModel extends ConsoleModel {
         MinecraftClient client = MinecraftClient.getInstance();
         TextRenderer renderer = client.textRenderer;
         TravelHandler travel = tardis.travel();
-        DirectedGlobalPos abpd = travel.getState() == TravelHandlerBase.State.FLIGHT
-                ? travel.getProgress()
-                : travel.position();
-        CachedDirectedGlobalPos dabpd = travel.destination();
-        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() != TravelHandlerBase.State.MAT
-                ? travel.getProgress()
-                : travel.position();
+        CachedDirectedGlobalPos abpd = travel.destination();
+        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() == TravelHandlerBase.State.MAT
+                ? travel.position()
+                : travel.getProgress();
 
         BlockPos abppPos = abpp.getPos();
         BlockPos abpdPos = abpd.getPos();

--- a/src/main/java/dev/amble/ait/client/models/consoles/CrystallineConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/CrystallineConsoleModel.java
@@ -1342,13 +1342,10 @@ public class CrystallineConsoleModel extends ConsoleModel {
         MinecraftClient client = MinecraftClient.getInstance();
         TextRenderer renderer = client.textRenderer;
         TravelHandler travel = tardis.travel();
-        DirectedGlobalPos abpd = travel.getState() == TravelHandlerBase.State.FLIGHT
-                ? travel.getProgress()
-                : travel.position();
-        CachedDirectedGlobalPos dabpd = travel.destination();
-        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() != TravelHandlerBase.State.MAT
-                ? travel.getProgress()
-                : travel.position();
+        CachedDirectedGlobalPos abpd = travel.destination();
+        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() == TravelHandlerBase.State.MAT
+                ? travel.position()
+                : travel.getProgress();
 
         BlockPos abppPos = abpp.getPos();
         BlockPos abpdPos = abpd.getPos();

--- a/src/main/java/dev/amble/ait/client/models/consoles/RenaissanceConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/RenaissanceConsoleModel.java
@@ -1446,13 +1446,10 @@ public class RenaissanceConsoleModel extends ConsoleModel {
         MinecraftClient client = MinecraftClient.getInstance();
         TextRenderer renderer = client.textRenderer;
         TravelHandler travel = tardis.travel();
-        DirectedGlobalPos abpd = travel.getState() == TravelHandlerBase.State.FLIGHT
-                ? travel.getProgress()
-                : travel.position();
-        CachedDirectedGlobalPos dabpd = travel.destination();
-        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() != TravelHandlerBase.State.MAT
-                ? travel.getProgress()
-                : travel.position();
+        CachedDirectedGlobalPos abpd = travel.destination();
+        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() == TravelHandlerBase.State.MAT
+                ? travel.position()
+                : travel.getProgress();
 
         BlockPos abppPos = abpp.getPos();
         BlockPos abpdPos = abpd.getPos();

--- a/src/main/java/dev/amble/ait/client/models/consoles/ToyotaConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/ToyotaConsoleModel.java
@@ -1786,13 +1786,10 @@ public class ToyotaConsoleModel extends ConsoleModel {
         MinecraftClient client = MinecraftClient.getInstance();
         TextRenderer renderer = client.textRenderer;
         TravelHandler travel = tardis.travel();
-        DirectedGlobalPos abpd = travel.getState() == TravelHandlerBase.State.FLIGHT
-                ? travel.getProgress()
-                : travel.position();
-        CachedDirectedGlobalPos dabpd = travel.destination();
-        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() != TravelHandlerBase.State.MAT
-                ? travel.getProgress()
-                : travel.position();
+        CachedDirectedGlobalPos abpd = travel.destination();
+        CachedDirectedGlobalPos abpp = travel.isLanded() || travel.getState() == TravelHandlerBase.State.MAT
+                ? travel.position()
+                : travel.getProgress();
 
         BlockPos abppPos = abpp.getPos();
         BlockPos abpdPos = abpd.getPos();


### PR DESCRIPTION
## About the PR
On consoles monitorss, the destination display shows travel progress just like the current position display does.
This behaves differently to the CRT monitor, wall-monitor and the internal monitor of the console, as the destination display 
on those remains fixed during flight.

This PR fixes that, so that the display of the destination coordinates on consoles with two monitors isn't lost during flight.
(Monitors with current-position will already show travel progress anyways.)

It also fixes the red cross and blue icons on the console monitors to indicate the correct position (current vs destination), to bring them in line with the CRT monitor, wall-monitor and the internal monitor of the consoles.

<details>
<summary>Click me for detailed comparison</summary>

**<ins>Before - when landed:<ins>**
- CRT monitor's upper part shows current pos, with red cross.
- CRT monitor's lower part shows destination pos, with blue plus sign.
- wallmonitor's upper part shows current pos.
- wallmonitor's lower part shows destination pos.
- console monitor with red cross shows *destination* pos. (i.e. wrong way around) 👎
- console monitor with blue plus sign shows *current* pos. (i.e. wrong way around) 👎

**<ins>Before - when in flight:<ins>**
- CRT monitor's current pos shows progress towards destination coords.
- CRT monitor's destination pos remains unchanged.
- wallmonitor's current pos shows progress towards destination coords.
- wallmonitor's destination pos remains unchanged.
- console monitor's current pos shows progress towards destination coords. (as expected) ✅
- console monitor's destination pos *also* shows progress towards destination coords. (i.e. unexpected) 👎

<hr>

**<ins>Now - when landed:<ins>**
- CRT monitor's upper part shows current pos, with red cross.
- CRT monitor's lower part shows destination pos, with blue plus sign.
- wallmonitor's upper part shows current pos.
- wallmonitor's lower part shows destination pos.
- console monitor with red cross shows current pos. ✅
- console monitor with blue plus sign shows destination pos. ✅

**<ins>Now - when in flight:<ins>**
- CRT monitor's current pos shows progress towards destination coords.
- CRT monitor's destination pos remains unchanged.
- wallmonitor's current pos shows progress towards destination coords.
- wallmonitor's destination pos remains unchanged.
- console monitor's current pos shows progress towards destination coords. ✅
- console monitor's destination pos remains unchanged. ✅
</details>

## Why / Balance
For UX consistency across all monitors.

## Technical details
I adjusted the variables for current-pos and destination-pos to be defined the same way that the CRT monitor, wall-monitor and internal monitor do it.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: console monitors (with a visible display) now show the same info and travel progress as the CRT monitor.