### PR TITLE
fix: adjusted the fuel and travel tick formulas

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/FuelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/FuelHandler.java
@@ -161,8 +161,8 @@ public class FuelHandler extends KeyedTardisComponent implements ArtronHolder, T
         this.removeFuel(20 * 5 * tardis.travel().instability());
     }
 
-    public static double getPerTickFuelCost(double speed, double instability) {
-        return 20 * Math.pow(4, speed) * instability;
+    public static double getPerTickFuelCost(int speed, int instability) {
+        return speed + instability - 1;
     }
 
     public static double getPerTickFuelCost(TravelHandler travel){
@@ -174,7 +174,7 @@ public class FuelHandler extends KeyedTardisComponent implements ArtronHolder, T
             return;
 
         TravelHandler travel = this.tardis.travel();
-        this.removeFuel(FuelHandler.getPerTickFuelCost(travel));
+        this.removeFuel(20 * FuelHandler.getPerTickFuelCost(travel));
 
         if (!tardis.fuel().hasPower())
             travel.crash();
@@ -199,7 +199,6 @@ public class FuelHandler extends KeyedTardisComponent implements ArtronHolder, T
 
             this.addFuel(20 * toAdd);
         }
-
 
         if (!this.refueling().get() && tardis.fuel().hasPower() && !tardis.isGrowth()) {
             double instability = tardis.travel().instability();

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/ProgressiveTravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/ProgressiveTravelHandler.java
@@ -195,7 +195,7 @@ public abstract class ProgressiveTravelHandler extends TravelHandlerBase {
         }
 
         if (server.getTicks() % (this.maxSpeed.get() - this.speed() + 1) == 0)
-            this.setFlightTicks(this.getFlightTicks() + AITMod.CONFIG.travelPerTick);
+            this.setFlightTicks(this.getFlightTicks() + AITMod.CONFIG.travelPerTick + this.instability() - 1);
     }
 
     public void triggerSequencingDuringFlight(Tardis tardis) {

--- a/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
@@ -484,7 +484,7 @@ public class TardisUtil {
     }
 
     public static double estimatedFuelCost(PlayerEntity player, Tardis tardis, double distance){
-        double speed = Math.max(tardis.travel().speed(), 1);
+        int speed = Math.max(tardis.travel().speed(), 1);
         double ticksRequired = distance / speed;
         double perTick = FuelHandler.getPerTickFuelCost(speed, tardis.travel().instability());
         return perTick * ticksRequired;


### PR DESCRIPTION
## About the PR
This PR adjusts the travel and fuel formulas to be more consistent and less buggy.

## Why / Balance
Previous (2 y/o) formulas used XOR instead of using power (which was certainly NOT a feature), resulting in higher speeds consuming less fuel than they should. Travel didn't consider instability as travel speed boost.

## Technical details
The new formulas are now linear. The travel formula now adds the `instability - 1` to flight ticks (per flight tick, ofc).


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a 🆑 symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
🆑
- fix: hammer now boosts travel speed again
- fix: flying on max speed doesn't drain your tardis to 0 artron