### PR TITLE
Fix holographic text rendering of console generator

### DIFF
--- a/src/main/java/dev/amble/ait/client/renderers/consoles/ConsoleGeneratorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/consoles/ConsoleGeneratorRenderer.java
@@ -76,18 +76,18 @@ public class ConsoleGeneratorRenderer<T extends ConsoleGeneratorBlockEntity> imp
             Matrix4f matrix4f = matrices.peek().getPositionMatrix();
 
             textRenderer.draw(text, h + 0.35f, 0.0F, 0xFFFFFFFF, false, matrix4f, vertexConsumers,
-                    TextRenderer.TextLayerType.SEE_THROUGH, 0x000000, 0xf000f0);
+                    TextRenderer.TextLayerType.NORMAL, 0x000000, 0xf000f0);
             matrices.push();
             matrices.scale(0.2f, 0.2f, 0.2f);
             Matrix4f matrixcf = matrices.peek().getPositionMatrix();
             textRenderer.draw(type, l - 0.35f, 42.5F, ColorHelper.Argb.getArgb(1, 0, 175, 235), false, matrixcf, vertexConsumers,
-                    TextRenderer.TextLayerType.SEE_THROUGH, 0x000000, 0xf000f0);
+                    TextRenderer.TextLayerType.NORMAL, 0x000000, 0xf000f0);
             matrices.pop();
             matrices.push();
             matrices.scale(0.2f, 0.2f, 0.2f);
             Matrix4f matrixdf = matrices.peek().getPositionMatrix();
             textRenderer.draw(requirement, p - 0.35f, 55F, ColorHelper.Argb.getArgb(1, 255, 205, 0), false, matrixdf, vertexConsumers,
-                    TextRenderer.TextLayerType.SEE_THROUGH, 0x000000, 0xf000f0);
+                    TextRenderer.TextLayerType.NORMAL, 0x000000, 0xf000f0);
             matrices.pop();
             matrices.pop();
         }


### PR DESCRIPTION
## About the PR
The text renders behind other entities, like e.g. the engine or the wall monitor.
This PR makes it renders in front of these entities.

## Why / Balance
To make the text legible regardless any entities in the background.

## Technical details
I simply changed the layer type from `SEE_THROUGH` to `NORMAL`.

## Media
<img width="1667" height="1792" alt="image" src="https://github.com/user-attachments/assets/cf9f0e60-550b-44fb-aebd-7b0756ed5fc1" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- fix: holographic text of console generator was clipped by entities behind the console