### PR TITLE
Change durability from magic number to constant

### DIFF
--- a/src/main/java/dev/amble/ait/client/renderers/SonicRendering.java
+++ b/src/main/java/dev/amble/ait/client/renderers/SonicRendering.java
@@ -209,7 +209,7 @@ public class SonicRendering {
         Text text = Text.empty();
 
         if (system instanceof DurableSubSystem) {
-            text = Text.literal((Math.round(((DurableSubSystem) be.system()).durability())) + " / 1250");
+            text = Text.literal((Math.round(((DurableSubSystem) be.system()).durability())) + " / " + DurableSubSystem.MAX_DURABILITY);
         }
         if (!system.isEnabled() && !(system instanceof EngineSystem)) {
             text = Text.translatable("tardis.message.subsystem.requires_link");

--- a/src/main/java/dev/amble/ait/core/engine/DurableSubSystem.java
+++ b/src/main/java/dev/amble/ait/core/engine/DurableSubSystem.java
@@ -8,7 +8,8 @@ import dev.amble.ait.api.tardis.TardisEvents;
 import dev.amble.ait.core.AITTags;
 
 public abstract class DurableSubSystem extends SubSystem {
-    private float durability = 1250;
+    public static final int MAX_DURABILITY = 1250;
+    private float durability = MAX_DURABILITY;
 
     protected DurableSubSystem(IdLike id) {
         super(id);
@@ -25,10 +26,10 @@ public abstract class DurableSubSystem extends SubSystem {
         return durability;
     }
 
-    private void setDurability(float durability) {
+    public void setDurability(float durability) {
         float before = this.durability;
 
-        this.durability = Math.max(0, Math.min(durability, 1250));
+        this.durability = Math.max(0, Math.min(durability, MAX_DURABILITY));
 
         this.onDurabilityChange(before, this.durability);
     }

--- a/src/main/java/dev/amble/ait/core/engine/block/SubSystemBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/engine/block/SubSystemBlockEntity.java
@@ -72,7 +72,7 @@ public class SubSystemBlockEntity extends FluidLinkBlockEntity {
 
     public ActionResult useOn(BlockState state, World world, boolean sneaking, PlayerEntity player, ItemStack hand) {
         if (this.system() instanceof DurableSubSystem durable) {
-            if (durable.isRepairItem(hand) && durable.durability() < 1250) {
+            if (durable.isRepairItem(hand) && durable.durability() < DurableSubSystem.MAX_DURABILITY) {
                 durable.addDurability(50);
                 hand.decrement(1);
                 world.playSound(null, this.getPos(), AITSounds.ENGINE_REFUEL, SoundCategory.BLOCKS, 0.5f, 1f);

--- a/src/main/java/dev/amble/ait/core/engine/block/generic/GenericStructureSystemBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/engine/block/generic/GenericStructureSystemBlockEntity.java
@@ -45,7 +45,7 @@ public class GenericStructureSystemBlockEntity extends StructureSystemBlockEntit
     public ActionResult useOn(BlockState state, World world, boolean sneaking, PlayerEntity player, ItemStack hand) {
         if (hand.isEmpty()) {
             if (this.system() != null && this.idSource != null) {
-                if (this.system() instanceof DurableSubSystem durable && (durable.isBroken() || durable.durability() < 1250)) {
+                if (this.system() instanceof DurableSubSystem durable && (durable.isBroken() || durable.durability() < DurableSubSystem.MAX_DURABILITY)) {
                     player.sendMessage(Text.translatable("tardis.message.engine.system_is_weakened"), true);
                     return ActionResult.SUCCESS;
                 }

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/ElectricalDischargeControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/ElectricalDischargeControl.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.core.tardis.control.impl;
 
+import dev.amble.ait.core.engine.DurableSubSystem;
 import dev.drtheo.scheduler.api.TimeUnit;
 import dev.drtheo.scheduler.api.common.Scheduler;
 import dev.drtheo.scheduler.api.common.TaskStage;

--- a/src/main/java/dev/amble/ait/core/tardis/handler/SubSystemHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/SubSystemHandler.java
@@ -112,7 +112,7 @@ public class SubSystemHandler extends KeyedTardisComponent implements TardisTick
 
         for (SubSystem next : this) {
             if (next instanceof DurableSubSystem durable)
-                durable.addDurability(1250);
+                durable.setDurability(DurableSubSystem.MAX_DURABILITY);
 
             next.setEnabled(true);
         }


### PR DESCRIPTION
## About the PR
This PR changes the subsystem maximum durability from magic numbers to a constant.
It also doesn't *add* the starting durability to the subsystems when a creative TARDIS is placed, but instead *sets* it.

## Why / Balance
To prevent redundancy and improve readability & maintainability.
And to reduce the number of calls when setting the initial durability of creatively placed TARDISes.

## Technical details
Replaced all occurrences of `1250` (only in context of subsystem durability) with the constant `MAX_DURABILITY` (stored in the class `DurableSubSystem`).
Changed call of `durable.addDurability()` (in `SubSystemHandler::repairAll()`) to `durable.setDurability()`.
For the latter I needed to make `DurableSubSystem::setDurability()` public.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- chore: change subsystem durability from magic number to constant