### PR TITLE
fix warning of interior change cost

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -60,6 +60,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
     private static final Property<Identifier> QUEUED_INTERIOR_PROPERTY = new Property<>(Property.IDENTIFIER, "queued_interior", new Identifier(""));
     private static final BoolProperty QUEUED = new BoolProperty("queued");
     private static final BoolProperty REGENERATING = new BoolProperty("regenerating");
+    private static final int MIN_FUEL_COST = 5000;
 
     public static final int MAX_PLASMIC_MATERIAL_AMOUNT = 8;
     private static final Text HINT_TEXT = Text.translatable("tardis.message.growth.hint").formatted(Formatting.DARK_GRAY, Formatting.ITALIC);
@@ -175,7 +176,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         if (!this.canQueue())
             return;
 
-        if (tardis.fuel().getCurrentFuel() < 5000) {
+        if (tardis.fuel().getCurrentFuel() < (MIN_FUEL_COST * tardis.travel().instability())) {
             tardis.asServer().world().getPlayers().forEach(player -> {
                 player.sendMessage(
                         Text.translatable("tardis.message.interiorchange.not_enough_fuel").formatted(Formatting.RED),
@@ -233,7 +234,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
                         travel.forceDemat();
                         this.replaceAllConsolesWithGrowth();
                     } else {
-                        tardis.removeFuel(5000 * tardis.travel().instability());
+                        tardis.removeFuel(MIN_FUEL_COST * tardis.travel().instability());
                     }
 
                     TardisUtil.sendMessageToLinked(tardis.asServer(), Text.translatable("tardis.message.interiorchange.success", tardis.stats().getName(), tardis.getDesktop().getSchema().name()));


### PR DESCRIPTION
## About the PR
This PR includes the instability in the fuel-check for interior changes.

## Why / Balance
The interior change reduces the fuel by 5000 Artron multiplied by the instability.
But the check that displays a warning when there is too little fuel only checks against 5000 Artron.
That means that as long as someone has >= 5000 Artron, the interior change will be successful.
But this is exactly what the fuel check is supposed to prevent, i.e. one should need 5000 x instability of Artron.

## Technical details
This PR simply adds the TARDIS' current instability value as a factor to the fuel cost (i.e. `5000 * tardis.travel().instability()`.
It also converts the base Artron cost to a constant (i.e. `MIN_FUEL_COST` instead of `5000`).

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: the check for interior change did not include the increased fuel cost due to instability