### PR TITLE
fix decay rate of engine durability

### DIFF
--- a/src/main/java/dev/amble/ait/core/engine/impl/EngineSystem.java
+++ b/src/main/java/dev/amble/ait/core/engine/impl/EngineSystem.java
@@ -64,7 +64,7 @@ public class EngineSystem extends DurableSubSystem {
 
     @Override
     protected int changeFrequency() {
-        return 1200; // drain 0.05 durability every minute
+        return 24000; // drain 0.05 durability every minute
     }
 
     @Override


### PR DESCRIPTION
## About the PR
Currently, the engine loses 1 durability every minute.
This PR changes the rate of durability loss to 0.05 every minute.

This will make the engine last for over 17 days instead of the about 20 hours it would last before.

Closes #1735

## Why / Balance
The original code comment mentions that the engine should lose 0.05 durability every minute, but the frequency set to a wrong amount which leads to the engine losing 19x more durability per minute.

## Technical details
This is the old code, which claims a loss of 0.05 durability every minute:
https://github.com/amblelabs/ait/blob/b31436d25a735c2f937c1c62bb03ed56bcaadf06/src/main/java/dev/amble/ait/core/engine/impl/EngineSystem.java#L67

But here we can see the durability would be reduced by 1 every 1200 ticks, which would equate to 1 every 60 seconds:
https://github.com/amblelabs/ait/blob/b31436d25a735c2f937c1c62bb03ed56bcaadf06/src/main/java/dev/amble/ait/core/engine/DurableSubSystem.java#L87

To fix this, I changed the frequency to 24000, which would reduce the durability by 1 every 1200 seconds (20 minutes).
And this results in exactly the 0.05 durability per minute as advertised by the comment.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: engine durability decayed too fast (lasted only ~20 hours instead of ~17 days)