### PR TITLE
fix lingering waterlogged property of door

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -1,7 +1,11 @@
 package dev.amble.ait.core.tardis.handler;
 
+import dev.amble.ait.core.tardis.Tardis;
 import dev.amble.lib.data.DirectedBlockPos;
 import net.fabricmc.fabric.api.util.TriState;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.state.property.Properties;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.particle.ParticleEffect;
@@ -225,6 +229,15 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
         this.setDoorState(DoorState.CLOSED);
     }
 
+    public static boolean removeWaterlogged(Tardis tardis) {
+        BlockPos pos = tardis.getDesktop().getDoorPos().getPos();
+        ServerWorld world = tardis.asServer().world();
+        BlockState blockState = world.getBlockState(pos);
+
+        return world.setBlockState(pos, blockState.with(Properties.WATERLOGGED, false),
+                Block.NOTIFY_ALL | Block.REDRAW_ON_MAIN_THREAD);
+    }
+
     private void setDoorState(DoorState newState) {
         if (this.locked() && newState != DoorState.CLOSED)
             return;
@@ -237,8 +250,10 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
             if (oldState == DoorState.CLOSED)
                 TardisEvents.DOOR_OPEN.invoker().onOpen(tardis());
 
-            if (newState == DoorState.CLOSED)
+            if (newState == DoorState.CLOSED) {
+                removeWaterlogged(this.tardis);
                 TardisEvents.DOOR_CLOSE.invoker().onClose(tardis());
+            }
         }
 
         this.doorState.set(newState);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/ShieldHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/ShieldHandler.java
@@ -56,6 +56,7 @@ public class ShieldHandler extends KeyedTardisComponent implements TardisTickabl
 
     public void enable() {
         this.shielded().set(true);
+        DoorHandler.removeWaterlogged(this.tardis);
         TardisEvents.TOGGLE_SHIELDS.invoker().onShields(this.tardis, true, this.visuallyShielded().get());
     }
 


### PR DESCRIPTION
## About the PR
This PR fixes the door remaining waterlogged after closing it or activating the shields.

## Why / Balance
Because there should be no water continuing to flow inside the TARDIS after the doors have been closed or the shields activated.

## Technical details
I'm not 100% confident about the locations where I disable the waterlogged property.
But I tried to place it as close to the final "close door" and "activate shields" places in the codebase as I could find.

I originally added it to the tick method of the `DoorBlockEntity`, but I thought checking this every tick was unnecessary and it would suffice to remove the waterlogged property only whenever the door-close or shield-activate events occurred.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: water (from landing underwater and opening the doors) kept flowing into the TARDIS despite closing the doors or activating the shields