### PR TITLE
Feature: Client config option to toggle CRT- and console-monitor text on/off

### DIFF
--- a/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
+++ b/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
@@ -60,6 +60,10 @@ public class AITClientConfig {
 
     @AutoGen(category = CATEGORY)
     @Boolean(formatter = Boolean.Formatter.YES_NO, colored = true)
+    @SerialEntry public boolean showConsoleMonitorText = true;
+
+    @AutoGen(category = CATEGORY)
+    @Boolean(formatter = Boolean.Formatter.YES_NO, colored = true)
     @SerialEntry public boolean renderDematParticles = true;
 
     @AutoGen(category = CATEGORY)

--- a/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
+++ b/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
@@ -64,6 +64,10 @@ public class AITClientConfig {
 
     @AutoGen(category = CATEGORY)
     @Boolean(formatter = Boolean.Formatter.YES_NO, colored = true)
+    @SerialEntry public boolean showCRTMonitorText = true;
+
+    @AutoGen(category = CATEGORY)
+    @Boolean(formatter = Boolean.Formatter.YES_NO, colored = true)
     @SerialEntry public boolean renderDematParticles = true;
 
     @AutoGen(category = CATEGORY)

--- a/src/main/java/dev/amble/ait/client/renderers/consoles/ConsoleRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/consoles/ConsoleRenderer.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.renderers.consoles;
 
+import dev.amble.ait.client.AITModClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumerProvider;
@@ -143,7 +144,7 @@ public class ConsoleRenderer<T extends ConsoleBlockEntity> implements BlockEntit
 
         profiler.swap("monitor");
 
-        if (hasPower) {
+        if (hasPower && AITModClient.CONFIG.showConsoleMonitorText) {
             model.renderMonitorText(tardis, entity, matrices, vertexConsumers, light, overlay);
         }
 

--- a/src/main/java/dev/amble/ait/client/renderers/monitors/MonitorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/monitors/MonitorRenderer.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.renderers.monitors;
 
+import dev.amble.ait.client.AITModClient;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 
 import net.minecraft.block.BlockState;
@@ -81,6 +82,9 @@ public class MonitorRenderer<T extends MonitorBlockEntity> implements BlockEntit
         Tardis tardis = entity.tardis().get();
 
         if (!tardis.fuel().hasPower())
+            return;
+
+        if (!AITModClient.CONFIG.showCRTMonitorText)
             return;
 
         matrices.push();

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -824,9 +824,9 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("yacl3.config.ait:server.maxTardises", "Max Amount Of Tardises");
         provider.addTranslation("yacl3.config.ait:client.showConsoleMonitorText", "Show text on console monitors?");
         provider.addTranslation("yacl3.config.ait:client.renderDematParticles", "Render demat particles?");
-		provider.addTranslation("yacl3.config.ait:client.animateConsole", "Animate console?");
-		provider.addTranslation("yacl3.config.ait:client.animateDoors", "Animate doors?");
-		provider.addTranslation("yacl3.config.ait:client.temperatureType", "Temperature type");
+        provider.addTranslation("yacl3.config.ait:client.animateConsole", "Animate console?");
+        provider.addTranslation("yacl3.config.ait:client.animateDoors", "Animate doors?");
+        provider.addTranslation("yacl3.config.ait:client.temperatureType", "Temperature type");
 
         provider.addTranslation("text.autoconfig.aitconfig.category.client", "Client");
         provider.addTranslation("text.autoconfig.aitconfig.option.CLIENT.SHOW_EXPERIMENTAL_WARNING", "Show Experimental Warning");

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -823,6 +823,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("yacl3.config.ait:server.sendBulk", "Send Bulk?");
         provider.addTranslation("yacl3.config.ait:server.maxTardises", "Max Amount Of Tardises");
         provider.addTranslation("yacl3.config.ait:client.showConsoleMonitorText", "Show text on console monitors?");
+        provider.addTranslation("yacl3.config.ait:client.showCRTMonitorText", "Show text on CRT monitors?");
         provider.addTranslation("yacl3.config.ait:client.renderDematParticles", "Render demat particles?");
         provider.addTranslation("yacl3.config.ait:client.animateConsole", "Animate console?");
         provider.addTranslation("yacl3.config.ait:client.animateDoors", "Animate doors?");

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -823,6 +823,10 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("yacl3.config.ait:server.sendBulk", "Send Bulk?");
         provider.addTranslation("yacl3.config.ait:server.maxTardises", "Max Amount Of Tardises");
         provider.addTranslation("yacl3.config.ait:client.showConsoleMonitorText", "Show text on console monitors?");
+        provider.addTranslation("yacl3.config.ait:client.renderDematParticles", "Render demat particles?");
+		provider.addTranslation("yacl3.config.ait:client.animateConsole", "Animate console?");
+		provider.addTranslation("yacl3.config.ait:client.animateDoors", "Animate doors?");
+		provider.addTranslation("yacl3.config.ait:client.temperatureType", "Temperature type");
 
         provider.addTranslation("text.autoconfig.aitconfig.category.client", "Client");
         provider.addTranslation("text.autoconfig.aitconfig.option.CLIENT.SHOW_EXPERIMENTAL_WARNING", "Show Experimental Warning");

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -822,6 +822,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("yacl3.config.ait:server.travelPerTick", "Travel Per Tick");
         provider.addTranslation("yacl3.config.ait:server.sendBulk", "Send Bulk?");
         provider.addTranslation("yacl3.config.ait:server.maxTardises", "Max Amount Of Tardises");
+        provider.addTranslation("yacl3.config.ait:client.showConsoleMonitorText", "Show text on console monitors?");
 
         provider.addTranslation("text.autoconfig.aitconfig.category.client", "Client");
         provider.addTranslation("text.autoconfig.aitconfig.option.CLIENT.SHOW_EXPERIMENTAL_WARNING", "Show Experimental Warning");


### PR DESCRIPTION
## About the PR
This PR adds a client config option to toggle the text display on CRT and console-monitors on/off. (default: on)

Closes #1700

## Why / Balance
So that people can use it for different RP scenarios, or they just prefer the monitors for decorative purposes, etc.

## Media

<img width="1614" height="1076" alt="image" src="https://github.com/user-attachments/assets/e2d364f2-a1a1-4b3f-88ff-d5f814896171" />

<img width="1614" height="1069" alt="image" src="https://github.com/user-attachments/assets/94b22470-92c1-449f-8f13-17dbb1583911" />

</br>
</br>

<details>
<summary><ins>Another example</ins></summary>

<img width="1614" height="1918" alt="image" src="https://github.com/user-attachments/assets/05252b83-acd0-40cd-bb0c-6bf61175734b" />
</details>


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- add: Client option to toggle CRT- and console-monitor text on/off