### PR TITLE
skeleton keys can unsiege tardis now

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/DoorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/DoorBlockEntity.java
@@ -124,6 +124,14 @@ public class DoorBlockEntity extends InteriorLinkableBlockEntity {
             }
 
             return;
+        } else if (keyStack.getItem() instanceof KeyItem key && tardis.siege().isActive()
+                && !tardis.interiorChangingHandler().queued().get()) {
+            if (keyStack.isOf(AITItems.SKELETON_KEY) || key.isOf(keyStack, tardis)) {
+                tardis.siege().setActive(false);
+                tardis.door().setLocked(false);
+                tardis.door().openDoors();
+            }
+            return;
         }
 
         if (tardis.sonic().getExteriorSonic() != null) {

--- a/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
@@ -121,6 +121,14 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
             }
 
             return;
+        } else if (hand.getItem() instanceof KeyItem key && tardis.siege().isActive()
+                && !tardis.interiorChangingHandler().queued().get()) {
+            if (hand.isOf(AITItems.SKELETON_KEY) || key.isOf(hand, tardis)) {
+                tardis.siege().setActive(false);
+                tardis.door().setLocked(false);
+                tardis.door().openDoors();
+            }
+            return;
         }
 
         if (hasSonic) {


### PR DESCRIPTION
## About the PR
skeleton keys can unsiege tardis now

## Why / Balance
to make novas life easier

## Technical details
skeleton keys can unsiege tardis now

## Media

https://github.com/user-attachments/assets/ab3ed1ad-73b8-4e03-99c6-5603c4685786



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl:
- add skeleton keys can unsiege tardis now