### PR TITLE
fix: extreme shaking

### DIFF
--- a/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
+++ b/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
@@ -182,10 +182,15 @@ public class ClientTardisUtil {
         if (tardis == null)
             return 0;
 
+        Collection<BlockPos> consoles = tardis.getDesktop().getConsolePos();
+
+        if (consoles.isEmpty())
+            return 0;
+
         BlockPos pos = player.getBlockPos();
         double lowest = Double.MAX_VALUE;
-
-        for (BlockPos console : tardis.getDesktop().getConsolePos()) {
+        
+        for (BlockPos console : consoles) {
             double distance = Math.sqrt(pos.getSquaredDistance(console));
 
             if (distance < lowest)

--- a/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
+++ b/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
@@ -4,6 +4,7 @@ import static dev.amble.ait.core.tardis.util.TardisUtil.*;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
 
 import net.fabricmc.api.EnvType;


### PR DESCRIPTION
## About the PR
This PR fixes extreme shaking as seen in #1755. Fixes #1755.

## Why / Balance
Because such screen shaking makes the game unplayable.

## Technical details
Shaking intensity during flight depends on the distance from the console. If there's no console then the method `getDistanceToConsole` will return `Double.MAX_VALUE`, which somewhat makes sense logically, but breaks the logic. This PR updates this method to return 0 in case there are no consoles.

Although returning 0 doesn't make sense logically, this method returns 0 if it encounters an error (like, if the client player is not in a tardis, or, if theres, for some reason, the lack of the tardis object).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- `ClientTardisUtil#distanceFromConsole` does no longer return `Double.MAX_VALUE` if there are no consoles.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: no more extreme screen shaking when there are no consoles during flight