### PR TITLE
Fix/port eating cartridges and throwing exceptions

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/SonicPortControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/SonicPortControl.java
@@ -43,6 +43,9 @@ public class SonicPortControl extends Control {
                 item = butler.takeHandles();
             }
 
+            if (item == null)
+                return Result.FAILURE;
+
             player.getInventory().offerOrDrop(item);
             consoleBlockEntity.setSonicScrewdriver(ItemStack.EMPTY);
             return Result.SUCCESS;

--- a/src/main/java/dev/amble/ait/core/tardis/handler/WaypointHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/WaypointHandler.java
@@ -77,6 +77,9 @@ public class WaypointHandler extends KeyedTardisComponent {
 
         //this.tardis.travel().autopilot(true);
         CachedDirectedGlobalPos cached = this.get().getPos();
+        if (cached == null)
+            return;
+
         if (cached.getWorld() instanceof TardisServerWorld) {
             cached = CachedDirectedGlobalPos.create(TardisServerWorld.OVERWORLD, cached.getPos(), cached.getRotation());
         }

--- a/src/main/java/dev/amble/ait/core/tardis/handler/WaypointHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/WaypointHandler.java
@@ -69,6 +69,7 @@ public class WaypointHandler extends KeyedTardisComponent {
 
     public void clear(BlockPos console, boolean spawnItem) {
         this.set(null, console, spawnItem);
+        this.clearCartridge();
     }
 
     public void gotoWaypoint() {
@@ -110,7 +111,6 @@ public class WaypointHandler extends KeyedTardisComponent {
                 console.getZ(), createWaypointItem(waypoint));
 
         tardis.asServer().world().spawnEntity(entity);
-        this.clearCartridge();
     }
 
     public static ItemStack createWaypointItem(Waypoint waypoint) {


### PR DESCRIPTION
## About the PR
This PR fixes two issues:

1) Exceptions:
When the player tries to eject an item from either the sonic- or the console-port when the respective port is *empty*, then an exception is thrown (though the game doesn't crash).

2) Console eating waypoint cartridges:
When trying to eject a waypoint cartridge after swapping in another cartridge (i.e. without first ejecting the first one), then the previous cartridge will not actually be ejected and instead be gone for good.

## Why / Balance
The exceptions don't crash the game, but should be accounted for with null checks.
And the console destroying waypoint cartridges (after swapping in another cartridge) is unexpected behavior and could lead to unintended loss of cartridges.

## Technical details
For the exceptions, simple null checks have been added.
To prevent the console from eating/destroying cartridges, the `clearCartridge()` call has been moved to the `clear` method, so that the `hasCartridge` state doesn't become false in the case when a player is swapping in a different cartridge.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix sonic- and console-port throwing exceptions
- fix console part eating cartridges when swapping