### PR TITLE
Fix cartridges replacing occupied slots in waypoint banks

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/WaypointBankBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/WaypointBankBlockEntity.java
@@ -97,7 +97,7 @@ public class WaypointBankBlockEntity extends InteriorLinkableBlockEntity {
     private ActionResult insert(BlockState state, ItemStack stack, int slot) {
         WaypointData inserted = WaypointData.fromStack(stack);
 
-        if (inserted == null)
+        if (inserted == null || this.waypoints[slot] != null)
             return ActionResult.FAIL;
 
         stack.decrement(1);


### PR DESCRIPTION
## About the PR
This PR prevents cartridges in waypoint banks from being overridden/destroyed when inserting another cartridge in an already occupied slot.

## Why / Balance
Neither the waypoint bank, not cartridges themselves should be able to eat cartridges. :P

## Technical details
A check was added to the `insert` method of the waypoint bank blockentity to prevent the insertion if the slot is not null.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix occupied slots in waypoint banks from being overridden when trying to insert another cartridge there