### PR TITLE
sonic screwdriver summon notify if no power

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/TardisSonicMode.java
@@ -97,6 +97,11 @@ public class TardisSonicMode extends SonicMode {
         boolean isNearTardis = TardisUtil.isNearTardis(player, tardis, 256);
         double distance = TardisUtil.distanceFromTardis(player, tardis);
 
+        if (!tardis.fuel().hasPower()){
+            player.sendMessage(Text.translatable("sonic.ait.mode.tardis.does_not_have_power"), true);
+            return false;
+        }
+
         if (tardis.fuel().getCurrentFuel() <= TardisUtil.estimatedFuelCost(player, tardis, distance)) {
             player.sendMessage(Text.translatable("sonic.ait.mode.tardis.insufficient_fuel"), true);
             return false;

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1131,6 +1131,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("sonic.ait.mode.tardis.location_summon", "Summoned TARDIS To Your Location, Please Wait...");
         provider.addTranslation("sonic.ait.mode.tardis.is_not_in_range",  "TARDIS is out of range!");
         provider.addTranslation("sonic.ait.mode.tardis.insufficient_fuel",  "TARDIS doesn't have enough fuel!");
+        provider.addTranslation("sonic.ait.mode.tardis.does_not_have_power",  "TARDIS doesn't have power!");
         provider.addTranslation("sonic.ait.mode.tardis.does_not_have_stabilisers",  "Remote Summoning Requires Stabilisers!");
         provider.addTranslation("sonic.ait.mode.tardis.refuel", "Engaged Handbrake, TARDIS Refueling...");
         provider.addTranslation("sonic.ait.mode.tardis.flight", "Disengaged Handbrake, TARDIS Dematerialising...");

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1131,7 +1131,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("sonic.ait.mode.tardis.location_summon", "Summoned TARDIS To Your Location, Please Wait...");
         provider.addTranslation("sonic.ait.mode.tardis.is_not_in_range",  "TARDIS is out of range!");
         provider.addTranslation("sonic.ait.mode.tardis.insufficient_fuel",  "TARDIS doesn't have enough fuel!");
-        provider.addTranslation("sonic.ait.mode.tardis.does_not_have_power",  "TARDIS doesn't have power!");
+        provider.addTranslation("sonic.ait.mode.tardis.does_not_have_power",  "TARDIS is powered off!");
         provider.addTranslation("sonic.ait.mode.tardis.does_not_have_stabilisers",  "Remote Summoning Requires Stabilisers!");
         provider.addTranslation("sonic.ait.mode.tardis.refuel", "Engaged Handbrake, TARDIS Refueling...");
         provider.addTranslation("sonic.ait.mode.tardis.flight", "Disengaged Handbrake, TARDIS Dematerialising...");


### PR DESCRIPTION
## About the PR
if the tardis has no power and you try and summon it, it will now send a message to the player saying the power is off

## Why / Balance
<img width="1874" height="201" alt="image" src="https://github.com/user-attachments/assets/1a911414-e537-4697-b339-f229819d9ba4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**

:cl:
- add sonic screwdriver summon notify if no power