### PR TITLE
toggleable darkness effect when tardis is powered off

### DIFF
--- a/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
+++ b/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
@@ -72,6 +72,10 @@ public class AITClientConfig {
 
     @AutoGen(category = CATEGORY)
     @Boolean(formatter = Boolean.Formatter.YES_NO, colored = true)
+    @SerialEntry public boolean powerOffDarkness = true;
+
+    @AutoGen(category = CATEGORY)
+    @Boolean(formatter = Boolean.Formatter.YES_NO, colored = true)
     @SerialEntry public boolean animateConsole = true;
 
     @AutoGen(category = CATEGORY)

--- a/src/main/java/dev/amble/ait/client/util/FoggyUtils.java
+++ b/src/main/java/dev/amble/ait/client/util/FoggyUtils.java
@@ -2,6 +2,7 @@ package dev.amble.ait.client.util;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 
+import dev.amble.ait.client.AITModClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.FogShape;
 import net.minecraft.client.render.OverlayTexture;
@@ -62,12 +63,14 @@ public class FoggyUtils {
 
         if (tardis.isGrowth()
                 || ClientTardisUtil.getPowerDelta() != ClientTardisUtil.MAX_POWER_DELTA_TICKS) {
+            if (!AITModClient.CONFIG.powerOffDarkness) return;
             RenderSystem.setShaderFogStart(MathHelper.lerp(ClientTardisUtil.getPowerDeltaForLerp(), -8, 24));
             RenderSystem.setShaderFogEnd(MathHelper.lerp(ClientTardisUtil.getPowerDeltaForLerp(), 11, 32));
             RenderSystem.setShaderFogShape(FogShape.SPHERE);
             RenderSystem.setShaderFogColor(0, 0, 0, tardis.siege().isActive() ? 0.85f : 1f);
         }
         if (tardis.crash().isToxic() && tardis.fuel().hasPower()) {
+
             RenderSystem
                     .setShaderFogStart(MathHelper.lerp(MinecraftClient.getInstance().getTickDelta() / 100f, -8, 24));
             RenderSystem.setShaderFogEnd(MathHelper.lerp(MinecraftClient.getInstance().getTickDelta() / 100f, 11, 32));

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -825,6 +825,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("yacl3.config.ait:client.showConsoleMonitorText", "Show text on console monitors?");
         provider.addTranslation("yacl3.config.ait:client.showCRTMonitorText", "Show text on CRT monitors?");
         provider.addTranslation("yacl3.config.ait:client.renderDematParticles", "Render demat particles?");
+        provider.addTranslation("yacl3.config.ait:client.powerOffDarkness", "Darkness effect when TARDIS powers off?");
         provider.addTranslation("yacl3.config.ait:client.animateConsole", "Animate console?");
         provider.addTranslation("yacl3.config.ait:client.animateDoors", "Animate doors?");
         provider.addTranslation("yacl3.config.ait:client.temperatureType", "Temperature type");


### PR DESCRIPTION
## About the PR
an option in the ait-config client that will disable or enable the darkness effect that you get in the tardis if the power is turned off

## Why / Balance
<img width="2801" height="622" alt="image" src="https://github.com/user-attachments/assets/023120d0-9d37-427a-be1d-9a0a69c42756" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: toggleable darkness effect when the tardis is powered off