### PR TITLE
Allow the use of default cave interior without breaking growth checks

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/Tardis.java
+++ b/src/main/java/dev/amble/ait/core/tardis/Tardis.java
@@ -182,7 +182,7 @@ public abstract class Tardis extends Initializable<TardisComponent.InitContext> 
 
     // FIXME: this needs to be changed.
     public boolean isGrowth() {
-        return hasGrowthExterior() || hasGrowthDesktop();
+        return hasGrowthExterior();
     }
 
     public boolean hasGrowthExterior() {


### PR DESCRIPTION
## About the PR
This PR makes the already available growth desktop to be used without borking your TARDIS.

## Why / Balance
It's a pretty nice interior and people have tried to use it only to bork their TARDIS.

## Technical details
"Is TARDIS in growth?" check checks whether the exterior is a TARDIS coral OR the interior is the cave interior. This PR removes the second condition.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: TARDIS' no longer break when using the default cave interior