### PR TITLE
Inform player if growth is still in progress

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
@@ -293,6 +293,12 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
         if (!tardis.door().isClosed()
                 && (!DependencyChecker.hasPortals() || !tardis.getExterior().getVariant().hasPortals()))
             TardisUtil.teleportInside(tardis, entity);
+
+        if (tardis.door().isClosed()
+                && entity instanceof PlayerEntity player
+                && tardis.isGrowth()) {
+            player.sendMessage(Text.translatable("tardis.message.growth.in_progress").formatted(Formatting.RED), true);
+        }
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1117,6 +1117,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("warning.ait.needs_subsystem", "ERROR, REQUIRES ACTIVE SUBSYSTEM: %s");
         provider.addTranslation("tardis.message.growth.hint", "Throw the Personality Matrix into the water to give it life...");
         provider.addTranslation("tardis.message.growth.no_cage", "Cage the TARDIS Coral to begin Plasmic coating process!");
+        provider.addTranslation("tardis.message.growth.in_progress", "Coral growth still in progress...");
         provider.addTranslation("message.ait.hypercubes.disabled", "Hypercubes are disabled in SERVER config.");
 
         provider.addTranslation("message.ait.control.ylandtype", "Vertical Search Mode: %s");


### PR DESCRIPTION
## About the PR
When a player attempts to enter a growth TARDIS during its initial interior reconfiguration, this PR will display an action-bar message informing the player about the ongoing progress.

## Why / Balance
For some players it can take a while for the groth interior to reconfigure.
So to prevent players from being confused as to what's going on, displaying a message when they try to enter the TARDIS (during the growth reconfiguration) will help with that.

## Technical details
A condition at the end of the exterior's collision method checks if the door is closed, a player tries to enter and if we currently have a growth TARDIS.
If so, a translatable message (in red) is displayed to the player in the action-bar.

## Media

https://github.com/user-attachments/assets/50a04707-9146-4063-93fa-6e9894abe4bc

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: action-bar message when trying to enter growth TARDIS during its initial interior reconfiguration.