### PR TITLE
Feat: sonic lever and button interaction

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/InteractionSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/InteractionSonicMode.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.core.item.sonic;
 
+import dev.amble.ait.core.AITTags;
 import net.minecraft.block.*;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -47,6 +48,8 @@ public class InteractionSonicMode extends SonicMode {
     private void interactBlock(BlockPos pos, ServerWorld world, LivingEntity user, int ticks, BlockHitResult blockHit) {
         BlockState state = world.getBlockState(pos);
         Block block = state.getBlock();
+
+        if (!state.isIn(AITTags.Blocks.SONIC_INTERACTABLE)) return;
 
         if (block == Blocks.IRON_DOOR && state.contains(Properties.OPEN)) {
             boolean isOpen = state.get(Properties.OPEN);

--- a/src/main/java/dev/amble/ait/core/item/sonic/InteractionSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/InteractionSonicMode.java
@@ -2,6 +2,7 @@ package dev.amble.ait.core.item.sonic;
 
 import net.minecraft.block.*;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.state.property.Properties;
@@ -36,14 +37,14 @@ public class InteractionSonicMode extends SonicMode {
     }
 
     private void process(ServerWorld world, LivingEntity user, int ticks) {
-        HitResult hitResult = SonicMode.getHitResult(user);
+        HitResult hitResult = SonicMode.getHitResultForOutline(user);
 
         if (hitResult instanceof BlockHitResult blockHit) {
-            this.interactBlock(blockHit.getBlockPos(), world, user, ticks);
+            this.interactBlock(blockHit.getBlockPos(), world, user, ticks, blockHit);
         }
     }
 
-    private void interactBlock(BlockPos pos, ServerWorld world, LivingEntity user, int ticks) {
+    private void interactBlock(BlockPos pos, ServerWorld world, LivingEntity user, int ticks, BlockHitResult blockHit) {
         BlockState state = world.getBlockState(pos);
         Block block = state.getBlock();
 
@@ -76,6 +77,11 @@ public class InteractionSonicMode extends SonicMode {
         if (block instanceof DaylightDetectorBlock && state.contains(Properties.INVERTED)) {
             world.setBlockState(pos, state.cycle(Properties.INVERTED), 3);
             world.emitGameEvent(user, GameEvent.BLOCK_CHANGE, pos);
+            return;
+        }
+
+        if (user instanceof PlayerEntity player && block instanceof ButtonBlock button) {
+            button.onUse(state, world, pos, player, player.getActiveHand(), blockHit);
             return;
         }
     }

--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -52,7 +52,7 @@ public class OverloadSonicMode extends SonicMode {
     }
 
     private void process(ServerWorld world, LivingEntity user, int ticks) {
-        HitResult hitResult = SonicMode.getHitResult(user);
+        HitResult hitResult = SonicMode.getHitResultForOutline(user);
 
         if (hitResult instanceof BlockHitResult blockHit) {
             this.overloadBlock(blockHit.getBlockPos(), world, user, ticks, blockHit);
@@ -156,6 +156,12 @@ public class OverloadSonicMode extends SonicMode {
         }
         else if (block instanceof RedstoneWireBlock || block instanceof AbstractRedstoneGateBlock) {
             forceRedstonePower(world, pos, state, 5 * 20);
+        }
+        else if (block instanceof LeverBlock lever) {
+            lever.togglePower(state, world, pos);
+        }
+        else if (block instanceof ButtonBlock button) {
+            button.onUse(state, world, pos, (PlayerEntity) user, user.getActiveHand(), blockHit);
         }
         else if (block instanceof GlassBlock || block instanceof StainedGlassPaneBlock) {
             breakBlock(world, pos, user, state, blockHit);

--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -160,9 +160,6 @@ public class OverloadSonicMode extends SonicMode {
         else if (block instanceof LeverBlock lever) {
             lever.togglePower(state, world, pos);
         }
-        else if (block instanceof ButtonBlock button) {
-            button.onUse(state, world, pos, (PlayerEntity) user, user.getActiveHand(), blockHit);
-        }
         else if (block instanceof GlassBlock || block instanceof StainedGlassPaneBlock) {
             breakBlock(world, pos, user, state, blockHit);
         }

--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -148,7 +148,7 @@ public class OverloadSonicMode extends SonicMode {
             return;
         }
 
-        if (block instanceof DaylightDetectorBlock || block instanceof ButtonBlock) {
+        if (block instanceof DaylightDetectorBlock) {
             activateBlock(world, pos, user, state, blockHit);
         }
         else if (block instanceof RedstoneLampBlock) {

--- a/src/main/java/dev/amble/ait/core/item/sonic/SonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/SonicMode.java
@@ -20,6 +20,8 @@ import dev.amble.ait.data.schema.sonic.SonicSchema;
 
 public abstract class SonicMode implements Ordered {
 
+    private static final int MAX_DISTANCE = 16;
+
     public static class Modes {
         public static final SonicMode[] VALUES = new SonicMode[4];
         private static int lastIndex = 0;
@@ -117,7 +119,7 @@ public abstract class SonicMode implements Ordered {
     }
 
     public static HitResult getHitResultForOutline(LivingEntity user) {
-        return getHitResultForOutline(user, 16);
+        return getHitResultForOutline(user, MAX_DISTANCE);
     }
     public static HitResult getHitResultForOutline(LivingEntity user, double distance) {
         BlockHitResult hitResult = null;
@@ -132,7 +134,7 @@ public abstract class SonicMode implements Ordered {
         return hitResult;
     }
     public static HitResult getHitResult(LivingEntity user) {
-        return getHitResult(user, 16);
+        return getHitResult(user, MAX_DISTANCE);
     }
     public static HitResult getHitResult(LivingEntity user, double distance) {
         return ProjectileUtil.getCollision(user, entity -> !entity.isSpectator() && entity.canHit(), distance);

--- a/src/main/java/dev/amble/ait/core/item/sonic/SonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/SonicMode.java
@@ -9,7 +9,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.RaycastContext;
 import net.minecraft.world.World;
 
 import dev.amble.ait.data.enummap.Ordered;
@@ -113,6 +116,21 @@ public abstract class SonicMode implements Ordered {
         return 1;
     }
 
+    public static HitResult getHitResultForOutline(LivingEntity user) {
+        return getHitResultForOutline(user, 16);
+    }
+    public static HitResult getHitResultForOutline(LivingEntity user, double distance) {
+        BlockHitResult hitResult = null;
+
+        if (user instanceof PlayerEntity player) {
+            Vec3d eyePos = player.getCameraPosVec(1.0F);
+            Vec3d rotation = player.getRotationVec(1.0F);
+            Vec3d end = eyePos.add(rotation.multiply(distance));
+            hitResult = player.getWorld().raycast(new RaycastContext(eyePos, end, RaycastContext.ShapeType.OUTLINE, RaycastContext.FluidHandling.NONE, player));
+        }
+
+        return hitResult;
+    }
     public static HitResult getHitResult(LivingEntity user) {
         return getHitResult(user, 16);
     }

--- a/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
+++ b/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
@@ -54,6 +54,7 @@ public class AITBlockTagProvider extends AmbleBlockTagProvider {
                 .add(Blocks.BRICKS, Blocks.BRICK_WALL, Blocks.REDSTONE_TORCH, Blocks.DEEPSLATE_BRICKS)
                 .add(Blocks.BARREL)
                 .add(Blocks.REDSTONE_WIRE, Blocks.COMPARATOR, Blocks.REPEATER)
+                .add(Blocks.LEVER, Blocks.STONE_BUTTON)
                 .add(Blocks.BELL, Blocks.JUKEBOX, Blocks.TRAPPED_CHEST)
                 .add(Blocks.DAYLIGHT_DETECTOR)
                 .add(Blocks.OBSIDIAN);

--- a/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
+++ b/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
@@ -54,6 +54,7 @@ public class AITBlockTagProvider extends AmbleBlockTagProvider {
                 .add(Blocks.BRICKS, Blocks.BRICK_WALL, Blocks.REDSTONE_TORCH, Blocks.DEEPSLATE_BRICKS)
                 .add(Blocks.BARREL)
                 .add(Blocks.REDSTONE_WIRE, Blocks.COMPARATOR, Blocks.REPEATER, Blocks.LEVER)
+                .forceAddTag(BlockTags.BUTTONS)
                 .add(Blocks.BELL, Blocks.JUKEBOX, Blocks.TRAPPED_CHEST)
                 .add(Blocks.DAYLIGHT_DETECTOR)
                 .add(Blocks.OBSIDIAN);

--- a/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
+++ b/src/main/java/dev/amble/ait/datagen/datagen_providers/AITBlockTagProvider.java
@@ -53,8 +53,7 @@ public class AITBlockTagProvider extends AmbleBlockTagProvider {
                 .add(Blocks.BLACK_CONCRETE,Blocks.CYAN_CONCRETE,Blocks.BLUE_CONCRETE,Blocks.BROWN_CONCRETE,Blocks.GRAY_CONCRETE,Blocks.GREEN_CONCRETE,Blocks.MAGENTA_CONCRETE,Blocks.ORANGE_CONCRETE,Blocks.PINK_CONCRETE,Blocks.RED_CONCRETE,Blocks.WHITE_CONCRETE,Blocks.PURPLE_CONCRETE,Blocks.LIGHT_GRAY_CONCRETE,Blocks.LIGHT_BLUE_CONCRETE,Blocks.LIME_CONCRETE)
                 .add(Blocks.BRICKS, Blocks.BRICK_WALL, Blocks.REDSTONE_TORCH, Blocks.DEEPSLATE_BRICKS)
                 .add(Blocks.BARREL)
-                .add(Blocks.REDSTONE_WIRE, Blocks.COMPARATOR, Blocks.REPEATER)
-                .add(Blocks.LEVER, Blocks.STONE_BUTTON)
+                .add(Blocks.REDSTONE_WIRE, Blocks.COMPARATOR, Blocks.REPEATER, Blocks.LEVER)
                 .add(Blocks.BELL, Blocks.JUKEBOX, Blocks.TRAPPED_CHEST)
                 .add(Blocks.DAYLIGHT_DETECTOR)
                 .add(Blocks.OBSIDIAN);


### PR DESCRIPTION
## About the PR
This PR adds the ability to toggle a lever via the sonic's _overload_ mode
and the ability to press a stone button via the sonic's _interaction_ mode.

## Why / Balance
It was asked for in here: https://discord.com/channels/1213989169878274068/1402420014350598255
And Saturn was already researching it.

## Technical details
The existing `getHitResult` was insufficient, because it relied on `ProjectileUtil.getCollision`, which only does a raycast that detects blocks it *collides* with.
Since levers and buttons don't have collision, that wouldn't work to detect them.

So I had to add a new method to `SonicMode` called `getHitResultForOutline` that creates a raycast that detects the *outline* of a block instead.

## Media

https://github.com/user-attachments/assets/2a8c30f7-f5d3-4899-bcce-f765fbf9c4d1

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- add: Sonic Overload mode can now toggle levers and Sonic Interaction mode can press stone buttons