### PR TITLE
fix overload not breaking all glass and glass panes

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -160,7 +160,7 @@ public class OverloadSonicMode extends SonicMode {
         else if (block instanceof LeverBlock lever) {
             lever.togglePower(state, world, pos);
         }
-        else if (block instanceof GlassBlock || block instanceof StainedGlassPaneBlock) {
+        else if (block instanceof AbstractGlassBlock || block instanceof PaneBlock) {
             breakBlock(world, pos, user, state, blockHit);
         }
         else if (canLight(ticks) && block instanceof TntBlock) {


### PR DESCRIPTION
## About the PR
This PR fixes the sonic overload mode not breaking all glass.

## Why / Balance
Because it should break all glass equally.

## Technical details
Replaced the condition checks to more generic glass/glass-pane classes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: overload did not break all glass and glass panes