### PR TITLE
fix console generator breaking in creative mode

### DIFF
--- a/.github/workflows/publish-devbuilds.yml
+++ b/.github/workflows/publish-devbuilds.yml
@@ -11,6 +11,7 @@ on:
       - gradlew
       - gradlew.bat
       - versioning.gradle
+      - .github/workflows/publish-devbuilds.yml
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,7 +31,7 @@ jobs:
     - name: Build
       run: ./gradlew build
     - name: Publish artifacts
-      uses: DrTheodor/discord-webhook-upload-action@v2.0
+      uses: drtheodor/discord-webhook-upload-action@v0.1
       with:
         url: ${{ secrets.DEV_BUILDS }}
         username: george washington
@@ -39,3 +40,5 @@ jobs:
         message_commit: '> :sparkles: [${commitMessage}](<${commitUrl}>) by [${authorName}](<${authorUrl}>)'
         message_header: |
           <:new1:1253371736510959636><:new2:1253371805734015006> New `Adventures in Time` dev build `#${{ github.run_number }}`:
+
+        file: 'build/libs/*'

--- a/.github/workflows/publish-devbuilds.yml
+++ b/.github/workflows/publish-devbuilds.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Build
       run: ./gradlew build
     - name: Publish artifacts
-      uses: drtheodor/discord-webhook-upload-action@v0.1
+      uses: drtheodor/discord-webhook-upload-action@v0.2
       with:
         url: ${{ secrets.DEV_BUILDS }}
         username: george washington

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ exp4j_version = 0.4.8
 multidim_version = 2.1.4
 scheduler_version = 1.1.0
 queue_version = 1.1.0-1.20
-amblekit_version=1.1.12
+amblekit_version=1.1.13
 yacl_version = 3.6.1+1.20.1-fabric
 
 # Compat

--- a/src/main/java/dev/amble/ait/core/blocks/ConsoleGeneratorBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/ConsoleGeneratorBlock.java
@@ -2,6 +2,8 @@ package dev.amble.ait.core.blocks;
 
 import dev.amble.ait.core.world.TardisServerWorld;
 import dev.amble.lib.api.ICantBreak;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.BlockEntityProvider;
@@ -108,6 +110,8 @@ public class ConsoleGeneratorBlock extends FluidLinkBlock implements BlockEntity
         }
 
         if (world.getBlockEntity(pos) instanceof ConsoleGeneratorBlockEntity be) {
+            world.playSound(null, pos, SoundEvents.BLOCK_SCULK_CHARGE, SoundCategory.BLOCKS, 0.5f, 1.0f);
+
             if (player.isSneaking())
                 be.changeConsole(previousVariant(be.getConsoleVariant()));
             else

--- a/src/main/java/dev/amble/ait/core/blocks/ConsoleGeneratorBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/ConsoleGeneratorBlock.java
@@ -1,15 +1,17 @@
 package dev.amble.ait.core.blocks;
 
-import dev.amble.ait.core.world.TardisServerWorld;
+import static dev.amble.ait.core.blockentities.ConsoleBlockEntity.previousConsole;
+import static dev.amble.ait.core.blockentities.ConsoleBlockEntity.previousVariant;
+
 import dev.amble.lib.api.ICantBreak;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.BlockEntityProvider;
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
@@ -21,9 +23,7 @@ import dev.amble.ait.AITMod;
 import dev.amble.ait.core.blockentities.ConsoleGeneratorBlockEntity;
 import dev.amble.ait.core.engine.link.block.FluidLinkBlock;
 import dev.amble.ait.core.engine.link.block.FluidLinkBlockEntity;
-
-import static dev.amble.ait.core.blockentities.ConsoleBlockEntity.previousConsole;
-import static dev.amble.ait.core.blockentities.ConsoleBlockEntity.previousVariant;
+import dev.amble.ait.core.world.TardisServerWorld;
 
 public class ConsoleGeneratorBlock extends FluidLinkBlock implements BlockEntityProvider, ICantBreak {
 

--- a/src/main/java/dev/amble/ait/core/blocks/ConsoleGeneratorBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/ConsoleGeneratorBlock.java
@@ -1,5 +1,7 @@
 package dev.amble.ait.core.blocks;
 
+import dev.amble.ait.core.world.TardisServerWorld;
+import dev.amble.lib.api.ICantBreak;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.BlockEntityProvider;
@@ -18,7 +20,10 @@ import dev.amble.ait.core.blockentities.ConsoleGeneratorBlockEntity;
 import dev.amble.ait.core.engine.link.block.FluidLinkBlock;
 import dev.amble.ait.core.engine.link.block.FluidLinkBlockEntity;
 
-public class ConsoleGeneratorBlock extends FluidLinkBlock implements BlockEntityProvider {
+import static dev.amble.ait.core.blockentities.ConsoleBlockEntity.previousConsole;
+import static dev.amble.ait.core.blockentities.ConsoleBlockEntity.previousVariant;
+
+public class ConsoleGeneratorBlock extends FluidLinkBlock implements BlockEntityProvider, ICantBreak {
 
     public ConsoleGeneratorBlock(Settings settings) {
         super(settings);
@@ -84,9 +89,29 @@ public class ConsoleGeneratorBlock extends FluidLinkBlock implements BlockEntity
         }
     }
 
+    // Triggers instead of onTryBreak when punching in survival mode.
     @Override
     public void onBlockBreakStart(BlockState state, World world, BlockPos pos, PlayerEntity player) {
         if (world.getBlockEntity(pos) instanceof ConsoleGeneratorBlockEntity be)
             be.useOn(world, player.isSneaking(), true, player);
+    }
+
+    // Triggers instead of onBlockBreakStart when punching in creative mode.
+    @Override
+    public void onTryBreak(World world, BlockPos pos, BlockState state, PlayerEntity player) {
+        if (player == null)
+            return;
+
+        if (!TardisServerWorld.isTardisDimension(world) || !player.getMainHandStack().isEmpty()) {
+            world.breakBlock(pos, true);
+            return;
+        }
+
+        if (world.getBlockEntity(pos) instanceof ConsoleGeneratorBlockEntity be) {
+            if (player.isSneaking())
+                be.changeConsole(previousVariant(be.getConsoleVariant()));
+            else
+                be.changeConsole(previousConsole(be.getConsoleSchema()));
+        }
     }
 }


### PR DESCRIPTION
## About the PR
Makes punching (left-clicking) the console generator in creative mode not break it but browse to the previous console.
Breaking the console generator in creative mode (while inside the TARDIS) now only happens when punching it while holding any item in the main hand.
And then it will drop the console generator item, just like when breaking it outside of the TARDIS.

## Why / Balance
To make it consistent with the behavior in survival.
This also prevents accidental breaking while in creative mode.

## Technical details
This PR relies on https://github.com/amblelabs/modkit/pull/35 and uses that to detect whether the player who attempted to break the console generator is sneaking or not.
This information is used to enable the browsing to the *previous* console/variant while in creative mode (see `onTryBreak`).
(Browsing to the *next* console/variant is still handled by `ConsoleGeneratorBlockEntity` and thus doesn't need to be handled by the `onTryBreak`.)

## Media
NOTE: In the videos the sound for browsing to the previous console while in creative mode is missing. This has already been fixed but I didn't record new videos.

https://github.com/user-attachments/assets/7e6f9254-000d-40ec-aed8-b0a19bf2bf22

https://github.com/user-attachments/assets/eeaeb1cf-4ae8-4b3c-8897-5d1d75ddd9a0

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- fix: left-clicking breaks the console generator when in creative instead of browsing to the previous console/variant