### PR TITLE
fix: food machine can be mined with iron pick and sound fix

### DIFF
--- a/src/main/java/dev/amble/ait/core/blocks/FoodMachineBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/FoodMachineBlock.java
@@ -6,6 +6,7 @@ import dev.amble.ait.core.blockentities.FoodMachineBlockEntity;
 import dev.amble.ait.core.drinks.DrinkRegistry;
 import dev.amble.ait.core.drinks.DrinkUtil;
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -51,7 +52,9 @@ public class FoodMachineBlock extends BlockWithEntity implements BlockEntityProv
     }
 
     public FoodMachineBlock(Settings settings) {
-        super(settings);
+        super(FabricBlockSettings.of()
+                .strength(3.0F, 6.0F)
+                .requiresTool());
         this.setDefaultState(this.stateManager.getDefaultState().with(ROTATION, 0));
     }
 
@@ -64,7 +67,7 @@ public class FoodMachineBlock extends BlockWithEntity implements BlockEntityProv
 
         // cycle through different modes
         if (player.isSneaking() && stack.isEmpty()) {
-            world.playSound(null, pos, AITSounds.SET_WAYPOINT, SoundCategory.BLOCKS, 1.0F, 1.0F);
+            world.playSound(null, pos, AITSounds.LOAD_WAYPOINT, SoundCategory.BLOCKS, 1.0F, 1.0F);
             switch (machine.getMode()) {
                 case FOOD_CUBES -> {
                     machine.setMode(FoodMachineBlockEntity.Mode.DRINKS);


### PR DESCRIPTION
fix: fixed the aitsound load_waypoint

## About the PR
fix bugs

## Why / Balance
the food machine couldnt be mined with an iron pick and the sound id was invalid

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- fix: food machine