### PR TITLE
feat: overload mode breaks bricks now

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -182,6 +182,7 @@ public class OverloadSonicMode extends SonicMode {
         } else if(state.isOf(Blocks.BRICKS)){
             breakBlock(world, pos, user, state, blockHit);
         }
+        playFx(world, pos);
     }
 
     private void playSparkEffect(ServerWorld world, PlayerEntity player) {

--- a/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/OverloadSonicMode.java
@@ -179,10 +179,9 @@ public class OverloadSonicMode extends SonicMode {
                 world.setBlockState(blockPos2, AbstractFireBlock.getState(world, blockPos2), Block.NOTIFY_ALL);
                 world.emitGameEvent(user, GameEvent.BLOCK_PLACE, pos);
             }
+        } else if(state.isOf(Blocks.BRICKS)){
+            breakBlock(world, pos, user, state, blockHit);
         }
-
-
-        playFx(world, pos);
     }
 
     private void playSparkEffect(ServerWorld world, PlayerEntity player) {


### PR DESCRIPTION
## About the PR
I added a feature to the overload mode so that it will break bricks

## Why / Balance
https://discord.com/channels/1213989169878274068/1213989171241426954/1402985541766615082

## Technical details
fuck off and die

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl:
- feat: overload mode breaks bricks