### PR TITLE
Rift Tags

### DIFF
--- a/src/main/java/dev/amble/ait/core/AITTags.java
+++ b/src/main/java/dev/amble/ait/core/AITTags.java
@@ -29,11 +29,14 @@ public class AITTags {
 
         public static final TagKey<Item> NO_BOP = createTag("no_bop");
         public static final TagKey<Item> KEY = createTag("key");
-        public static final TagKey<Item> GOAT_HORN = createTag("goat_horn");
+        // public static final TagKey<Item> GOAT_HORN = createTag("goat_horn");
         public static final TagKey<Item> LINK = createTag("link"); // TODO use the tag instead of the item instanceof
         public static final TagKey<Item> IS_TARDIS_FUEL = createTag("is_tardis_fuel");
         public static final TagKey<Item> REPAIRS_SUBSYSTEM = createTag("repairs_subsystem");
         public static final TagKey<Item> INSERTABLE_DISCS = createTag("insertable_discs");
+
+        public static final TagKey<Item> RIFT_SUCCESS_EXTRA_ITEM = createTag("rift_success_extra_item");
+        public static final TagKey<Item> RIFT_FAIL_ITEM = createTag("rift_fail_item");
 
         private static TagKey<Item> createTag(String name) {
             return TagKey.of(RegistryKeys.ITEM, AITMod.id(name));

--- a/src/main/java/dev/amble/ait/core/entities/RiftEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/RiftEntity.java
@@ -1,12 +1,14 @@
 package dev.amble.ait.core.entities;
 
 
+import dev.amble.ait.core.util.TagsUtil;
 import dev.amble.lib.util.TeleportUtil;
 
 import net.minecraft.block.*;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.SpawnReason;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket;
@@ -86,10 +88,22 @@ public class RiftEntity extends DummyAmbientEntity implements ISpaceImmune {
 
             player.damage(this.getWorld().getDamageSources().hotFloor(), 7);
             if (gotFragment) {
+
+                Item randomItem = TagsUtil.getRandomItemFromTag(
+                        this.getWorld(),
+                        AITTags.Items.RIFT_SUCCESS_EXTRA_ITEM
+                );
+
                 StackUtil.spawn(this.getWorld(), this.getBlockPos(), new ItemStack(AITItems.CORAL_FRAGMENT));
+                StackUtil.spawn(this.getWorld(), this.getBlockPos(), new ItemStack(randomItem));
                 this.getWorld().playSound(null, player.getBlockPos(), AITSounds.RIFT_SUCCESS, SoundCategory.AMBIENT, 1f, 1f);
             } else {
-                StackUtil.spawn(this.getWorld(), this.getBlockPos(), new ItemStack(Items.PAPER));
+                Item randomItem = TagsUtil.getRandomItemFromTag(
+                        this.getWorld(),
+                        AITTags.Items.RIFT_FAIL_ITEM
+                );
+
+                StackUtil.spawn(this.getWorld(), this.getBlockPos(), new ItemStack(randomItem));
                 this.getWorld().playSound(null, this.getBlockPos(), AITSounds.RIFT_FAIL, SoundCategory.AMBIENT, 1f, 1f);
                 spreadTardisCoral(this.getWorld(), this.getBlockPos());
             }

--- a/src/main/java/dev/amble/ait/core/item/SiegeTardisItem.java
+++ b/src/main/java/dev/amble/ait/core/item/SiegeTardisItem.java
@@ -66,7 +66,7 @@ public class SiegeTardisItem extends LinkableItem {
     @Override
     public ActionResult useOnBlock(ItemUsageContext context) {
         if (context.getHand() != Hand.MAIN_HAND || context.getPlayer() == null)
-            return ActionResult.PASS; // bc i cba
+            return ActionResult.PASS;
 
         context.getPlayer().getInventory().setStack(context.getPlayer().getInventory().selectedSlot, Items.AIR.getDefaultStack());
 

--- a/src/main/java/dev/amble/ait/core/util/TagsUtil.java
+++ b/src/main/java/dev/amble/ait/core/util/TagsUtil.java
@@ -1,0 +1,46 @@
+package dev.amble.ait.core.util;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.RegistryWrapper;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.registry.entry.RegistryEntryList;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+
+import java.util.Optional;
+
+public class TagsUtil {
+    public static Item getRandomItemFromTag(World world, TagKey<Item> tag) {
+        RegistryWrapper.Impl<Item> itemLookup = world.getRegistryManager().getWrapperOrThrow(RegistryKeys.ITEM);
+        Optional<RegistryEntryList.Named<Item>> optionalList = itemLookup.getOptional(tag);
+
+        if (optionalList.isEmpty()) {
+            return Items.AIR;
+        }
+
+        RegistryEntryList.Named<Item> list = optionalList.get();
+        RegistryEntry<Item> randomEntry = list.get(world.random.nextInt(list.size()));
+
+        return randomEntry.value();
+    }
+
+    public static Block getRandomBlockFromTag(World world, TagKey<Block> tag) {
+        RegistryWrapper.Impl<Block> blockLookup = world.getRegistryManager().getWrapperOrThrow(RegistryKeys.BLOCK);
+        Optional<RegistryEntryList.Named<Block>> optionalList = blockLookup.getOptional(tag);
+
+        if (optionalList.isEmpty()) {
+            return Blocks.AIR;
+        }
+
+        RegistryEntryList.Named<Block> list = optionalList.get();
+        RegistryEntry<Block> randomEntry = list.get(world.random.nextInt(list.size()));
+
+        return randomEntry.value();
+    }
+
+}

--- a/src/main/java/dev/amble/ait/datagen/datagen_providers/AITItemTagProvider.java
+++ b/src/main/java/dev/amble/ait/datagen/datagen_providers/AITItemTagProvider.java
@@ -3,6 +3,7 @@ package dev.amble.ait.datagen.datagen_providers;
 
 import java.util.concurrent.CompletableFuture;
 
+import dev.amble.ait.module.planet.core.PlanetItems;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
 import org.jetbrains.annotations.Nullable;
@@ -62,6 +63,15 @@ public class AITItemTagProvider extends FabricTagProvider<Item> {
         getOrCreateTagBuilder(AITTags.Items.IS_TARDIS_FUEL).forceAddTag(ItemTags.LOGS_THAT_BURN);
         getOrCreateTagBuilder(AITTags.Items.IS_TARDIS_FUEL).forceAddTag(ItemTags.COALS);
         getOrCreateTagBuilder(AITTags.Items.IS_TARDIS_FUEL).add(Items.LAVA_BUCKET);
+
+        // Rifts
+
+        getOrCreateTagBuilder(AITTags.Items.RIFT_SUCCESS_EXTRA_ITEM).add(AITItems.ZEITON_SHARD);
+        getOrCreateTagBuilder(AITTags.Items.RIFT_FAIL_ITEM).add(Items.PAPER);
+
+        //Linkable
+
+        getOrCreateTagBuilder(AITTags.Items.LINK).add(AITItems.SONIC_SCREWDRIVER, AITItems.CLASSIC_KEY, AITItems.GOLD_KEY, AITItems.IRON_KEY, AITItems.REMOTE_ITEM,AITItems.NETHERITE_KEY, PlanetItems.HANDLES);
 
         ModuleRegistry.instance().iterator().forEachRemaining(module -> {
             module.getDataGenerator().ifPresent(generator -> {


### PR DESCRIPTION
## About the PR
Made so when a rift drops an item it chooses randomly from tags - I have tested it so it doesn't need testing

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed rift drops from just being a specific item to randomly choosing from tags "rift_success_extra_item" & "rift_fail_item"
