### PR TITLE
fix: description.attack_eyebrows spelling again

### DIFF
--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1188,7 +1188,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("achievement.ait.title.feed_power_converter", "What are you doing, Doc?");
         provider.addTranslation("achievement.ait.description.feed_power_converter", "Use food on the power converter.");
         provider.addTranslation("achievement.ait.title.attack_eyebrows", "Attack Eyebrows");
-        provider.addTranslation("achievement.ait.description.attack_eyebrows", "Its an elevator!");
+        provider.addTranslation("achievement.ait.description.attack_eyebrows", "I'ts an elevator!");
         provider.addTranslation("achievement.ait.title.pui", "Piloting under the influence");
         provider.addTranslation("achievement.ait.description.pui", "Consume Zeiton Dust while the TARDIS is in flight.");
         provider.addTranslation("achievement.ait.title.bonding", "I think it's starting to trust you.");

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1188,7 +1188,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("achievement.ait.title.feed_power_converter", "What are you doing, Doc?");
         provider.addTranslation("achievement.ait.description.feed_power_converter", "Use food on the power converter.");
         provider.addTranslation("achievement.ait.title.attack_eyebrows", "Attack Eyebrows");
-        provider.addTranslation("achievement.ait.description.attack_eyebrows", "It`s an elevator!");
+        provider.addTranslation("achievement.ait.description.attack_eyebrows", "It's an elevator!");
         provider.addTranslation("achievement.ait.title.pui", "Piloting under the influence");
         provider.addTranslation("achievement.ait.description.pui", "Consume Zeiton Dust while the TARDIS is in flight.");
         provider.addTranslation("achievement.ait.title.bonding", "I think it's starting to trust you.");

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1188,7 +1188,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("achievement.ait.title.feed_power_converter", "What are you doing, Doc?");
         provider.addTranslation("achievement.ait.description.feed_power_converter", "Use food on the power converter.");
         provider.addTranslation("achievement.ait.title.attack_eyebrows", "Attack Eyebrows");
-        provider.addTranslation("achievement.ait.description.attack_eyebrows", "I'ts an elevator!");
+        provider.addTranslation("achievement.ait.description.attack_eyebrows", "It`s an elevator!");
         provider.addTranslation("achievement.ait.title.pui", "Piloting under the influence");
         provider.addTranslation("achievement.ait.description.pui", "Consume Zeiton Dust while the TARDIS is in flight.");
         provider.addTranslation("achievement.ait.title.bonding", "I think it's starting to trust you.");


### PR DESCRIPTION
## About the PR
Fix spelling of spelling fix.

## Why / Balance
The spelling was not fully fixed.

## Technical details
I added an apostrophe.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: description.attack_eyebrows spelling, for real this time