### PR TITLE
Gradle build config: Make multidim, scheduler and queue libraries transitive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,12 +85,15 @@ dependencies {
     // TODO: move these 3 to modkit so we don't have to re-export so many dependencies
     include(modApi("dev.drtheo:multidim:${project.multidim_version}")) {
         exclude(group: "net.fabricmc.fabric-api")
+        transitive = true
     }
     include(modApi("dev.drtheo:scheduler:${project.scheduler_version}")) {
         exclude(group: "net.fabricmc.fabric-api")
+        transitive = true
     }
     include(modApi("dev.drtheo:queue:${project.queue_version}")) {
         exclude(group: "net.fabricmc.fabric-api")
+        transitive = true
     }
 
     modApi("com.github.amblelabs:modkit:v${project.amblekit_version}") {


### PR DESCRIPTION
## About the PR
Make multidim, scheduler and queue libraries transitive.

## Why / Balance
If a mod uses AIT as a dependency (like e.g. ait-extras), then these requried libraries will automatically be available as well without having to be explicitly included.

## Technical details
Normally `modApi` is transitive, but when used within an `include` then the non-transitivity of that wins.
In order to make it transitive again I simply added a `transitive = true` to each include block.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- chore: make multidim, scheduler and queue libraries transitive