### PR TITLE
Feat: Show message during hostile presence alarm

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/ServerAlarmHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/ServerAlarmHandler.java
@@ -130,7 +130,7 @@ public class ServerAlarmHandler extends KeyedTardisComponent implements TardisTi
                 if (entity instanceof TntEntity || (entity instanceof HostileEntity && !entity.hasCustomName())
                         || entity instanceof ServerPlayerEntity player
                         && tardis.loyalty().get(player).level() == Loyalty.Type.REJECT.level) {
-                    tardis.alarm().enable();
+                    tardis.alarm().enable(AlarmType.HOSTILE_PRESENCE);
                 }
             }
 
@@ -308,6 +308,7 @@ public class ServerAlarmHandler extends KeyedTardisComponent implements TardisTi
 
     public enum AlarmType implements Alarm {
         CRASHING,
+        HOSTILE_PRESENCE,
         HAIL_MARY("tardis.message.protocol_813.travel");
 
         private final String translation;

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1422,6 +1422,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
 
         // Alarms
         provider.addTranslation("tardis.message.alarm.crashing", "System Alert: TARDIS is experiencing a critical failure.");
+        provider.addTranslation("tardis.message.alarm.hostile_presence", "System Alert: Hostile presence detected.");
 
         // Security Settings Menu
         provider.addTranslation("screen.ait.sonic.button", "> Sonic Settings");


### PR DESCRIPTION
## About the PR
This PR adds an action bar message during a hostile presence alarm, specifying the alarm type to the player.

## Why / Balance
Otherwise it could be confusing why the alarm continues to turn itself back on.

## Technical details
I added a new alarm type "HOSTILE_PRESENCE" and its respective translatable.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Display message on action bar (in addition to alarm) to inform about hostile presence.