### PR TITLE
Feat: Add engine overdrive arming mechanism

### DIFF
--- a/src/main/java/dev/amble/ait/api/tardis/TardisEvents.java
+++ b/src/main/java/dev/amble/ait/api/tardis/TardisEvents.java
@@ -288,9 +288,9 @@ public final class TardisEvents {
                 }
             });
     public static final Event<UseControl> USE_CONTROL = EventFactory.createArrayBacked(UseControl.class,
-            callbacks -> control -> {
+            callbacks -> (control, tardis, player, world, console, leftClick) -> {
                 for (UseControl callback : callbacks) {
-                    callback.onUse(control);
+                    callback.onUse(control, tardis, player, world, console, leftClick);
                 }
             });
 
@@ -550,7 +550,7 @@ public final class TardisEvents {
          * @param control
          *            the control that was used
          */
-        void onUse(Control control);
+        void onUse(Control control, Tardis tardis, ServerPlayerEntity player, ServerWorld world, BlockPos console, boolean leftClick);
     }
 
 

--- a/src/main/java/dev/amble/ait/api/tardis/TardisEvents.java
+++ b/src/main/java/dev/amble/ait/api/tardis/TardisEvents.java
@@ -2,6 +2,7 @@ package dev.amble.ait.api.tardis;
 
 import java.util.Optional;
 
+import dev.amble.ait.core.tardis.control.Control;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedBlockPos;
 import net.fabricmc.fabric.api.event.Event;
@@ -286,6 +287,12 @@ public final class TardisEvents {
                     callback.onPhase(system);
                 }
             });
+    public static final Event<UseControl> USE_CONTROL = EventFactory.createArrayBacked(UseControl.class,
+            callbacks -> control -> {
+                for (UseControl callback : callbacks) {
+                    callback.onUse(control);
+                }
+            });
 
     /**
      * Called when a TARDIS successfully ( passed all checks ) starts to take off,
@@ -533,6 +540,17 @@ public final class TardisEvents {
     @FunctionalInterface
     public interface OnEnginesPhase {
         void onPhase(EngineSystem system);
+    }
+
+    @FunctionalInterface
+    public interface UseControl {
+        /**
+         * Called when a console control is used.
+         *
+         * @param control
+         *            the control that was used
+         */
+        void onUse(Control control);
     }
 
 

--- a/src/main/java/dev/amble/ait/core/blockentities/control/ControlBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/control/ControlBlockEntity.java
@@ -105,7 +105,7 @@ public abstract class ControlBlockEntity extends InteriorLinkableBlockEntity {
             return false;
 
         if (this.control.shouldHaveDelay(tardis) && !this.onDelay)
-            this.createDelay(this.control.getDelayLength());
+            this.createDelay(this.control.getDelayLength(tardis));
 
         Control.Result result = this.control.handleRun(tardis, user, user.getServerWorld(), this.pos, isMine);
         this.getWorld().playSound(null, pos, this.control.getSound(this.getConsoleType(), result), SoundCategory.BLOCKS, 0.7f, 1f);

--- a/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
@@ -470,7 +470,7 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
             this.dataTracker.set(ON_DELAY, true);
 
             Scheduler.get().runTaskLater(() -> this.dataTracker.set(ON_DELAY, false),
-                    TaskStage.END_SERVER_TICK, TimeUnit.TICKS, this.control.getDelayLength());
+                    TaskStage.END_SERVER_TICK, TimeUnit.TICKS, this.control.getDelayLength(tardis));
         }
 
         Control.Result result = this.control.handleRun(tardis, (ServerPlayerEntity) player, (ServerWorld) world, this.getConsoleBlockPos(), leftClick);

--- a/src/main/java/dev/amble/ait/core/tardis/control/Control.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/Control.java
@@ -108,7 +108,7 @@ public class Control implements Identifiable {
         return "Control{" + "id='" + id + '\'' + '}';
     }
 
-    public long getDelayLength() {
+    public long getDelayLength(Tardis tardis) {
         return 5;
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/control/Control.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/Control.java
@@ -41,7 +41,7 @@ public class Control implements Identifiable {
             throw ControlSequencedException.INSTANCE;
         }
 
-        TardisEvents.USE_CONTROL.invoker().onUse(this);
+        TardisEvents.USE_CONTROL.invoker().onUse(this, tardis, player, world, console, leftClick);
 
         return Result.FAILURE;
     }

--- a/src/main/java/dev/amble/ait/core/tardis/control/Control.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/Control.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.core.tardis.control;
 
+import dev.amble.ait.api.tardis.TardisEvents;
 import dev.amble.lib.api.Identifiable;
 
 import net.minecraft.particle.ParticleTypes;
@@ -39,6 +40,8 @@ public class Control implements Identifiable {
             this.addToControlSequence(tardis, player, console);
             throw ControlSequencedException.INSTANCE;
         }
+
+        TardisEvents.USE_CONTROL.invoker().onUse(this);
 
         return Result.FAILURE;
     }

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/ElectricalDischargeControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/ElectricalDischargeControl.java
@@ -83,7 +83,7 @@ public class ElectricalDischargeControl extends Control {
     }
 
     @Override
-    public long getDelayLength() {
+    public long getDelayLength(Tardis tardis) {
         return 800;
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/EngineOverloadControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/EngineOverloadControl.java
@@ -76,21 +76,14 @@ public class EngineOverloadControl extends Control {
         runDumpingArtronSequence(player, () -> {
             world.playSound(null, player.getBlockPos(), AITSounds.ENGINE_OVERLOAD, SoundCategory.BLOCKS, 1.0F, 1.0F);
             world.getServer().execute(() -> {
-                tardis.travel().decreaseFlightTime(999999999);
                 tardis.travel().handbrake(false);
-                tardis.setRefueling(false);
-                tardis.setFuelCount(0);
 
-                if (!isInFlight) {
+                if (!isInFlight)
                     tardis.travel().finishDemat();
-                    tardis.setFuelCount(0);
-                    tardis.travel().decreaseFlightTime(999999999);
-                    tardis.setRefueling(false);
-                } else {
-                    tardis.travel().decreaseFlightTime(999999999);
-                    tardis.setFuelCount(0);
-                    tardis.setRefueling(false);
-                }
+
+                tardis.setFuelCount(0);
+                tardis.travel().decreaseFlightTime(999999999);
+                tardis.setRefueling(false);
 
                 Scheduler.get().runTaskLater(() -> triggerExplosion(world, console, tardis, 4), TaskStage.END_SERVER_TICK, TimeUnit.SECONDS, 0);
             });

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/EngineOverloadControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/EngineOverloadControl.java
@@ -34,7 +34,7 @@ public class EngineOverloadControl extends Control {
     private static boolean isArmed = false;
 
     static {
-        TardisEvents.USE_CONTROL.register(control -> {
+        TardisEvents.USE_CONTROL.register((control, tardis, player, world, console, leftClick) -> {
             if (!(control instanceof EngineOverloadControl)) {
                 disarm();
             }

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/EngineOverloadControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/EngineOverloadControl.java
@@ -2,13 +2,12 @@ package dev.amble.ait.core.tardis.control.impl;
 
 import java.util.Random;
 
-import dev.amble.ait.api.tardis.TardisEvents;
+import dev.amble.ait.core.tardis.handler.travel.TravelHandler;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.drtheo.scheduler.api.TimeUnit;
 import dev.drtheo.scheduler.api.common.Scheduler;
 import dev.drtheo.scheduler.api.common.TaskStage;
 
-import dev.drtheo.scheduler.api.task.Task;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
@@ -29,17 +28,6 @@ public class EngineOverloadControl extends Control {
 
     private static final Random RANDOM = new Random();
     private static final String[] SPINNER = {"/", "-", "\\", "|"};
-    private static final long CONFIRMATION_TIME = 20 * 5;   //in ticks
-    private static Task confirmationTimer;
-    private static boolean isArmed = false;
-
-    static {
-        TardisEvents.USE_CONTROL.register((control, tardis, player, world, console, leftClick) -> {
-            if (!(control instanceof EngineOverloadControl)) {
-                disarm();
-            }
-        });
-    }
 
     public EngineOverloadControl() {
         super(AITMod.id("engine_overload"));
@@ -60,12 +48,12 @@ public class EngineOverloadControl extends Control {
         }
 
 
-        if (!isArmed) {
+        if (!TravelHandler.isEngineOverloadArmed(tardis.getUuid())) {
             player.sendMessage(Text.translatable("tardis.message.control.engine_overdrive.primed").formatted(Formatting.RED), true);
-            arm();
+            TravelHandler.armEngineOverload(tardis.getUuid(), world);
             return Result.SUCCESS_ALT;
         }
-        disarm();
+        TravelHandler.disarmEngineOverload(tardis.getUuid());
 
         boolean isInFlight = tardis.travel().getState() == TravelHandlerBase.State.FLIGHT;
 
@@ -90,18 +78,6 @@ public class EngineOverloadControl extends Control {
         });
 
         return Result.SUCCESS;
-    }
-
-    private static void arm() {
-        isArmed = true;
-        confirmationTimer = Scheduler.get().runTaskLater(() -> isArmed = false,
-                TaskStage.END_SERVER_TICK, TimeUnit.TICKS, CONFIRMATION_TIME);
-    }
-
-    private static void disarm() {
-        isArmed = false;
-        if (confirmationTimer != null)
-            confirmationTimer.cancel();
     }
 
     private void triggerExplosion(ServerWorld world, BlockPos console, Tardis tardis, int stage) {
@@ -179,8 +155,8 @@ public class EngineOverloadControl extends Control {
     }
 
     @Override
-    public long getDelayLength() {
-        if (isArmed)
+    public long getDelayLength(Tardis tardis) {
+        if (TravelHandler.isEngineOverloadArmed(tardis.getUuid()))
             return 360000;
 
         return 5;

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/EngineOverloadControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/EngineOverloadControl.java
@@ -54,7 +54,7 @@ public class EngineOverloadControl extends Control {
 
 
         if (tardis.fuel().getCurrentFuel() < 25000) {
-            player.sendMessage(Text.literal("§cERROR, TARDIS REQUIRES AT LEAST 25K ARTRON TO EXECUTE THIS ACTION."), true);
+            player.sendMessage(Text.translatable("tardis.message.control.engine_overdrive.insufficient_fuel").formatted(Formatting.RED), true);
             world.playSound(null, player.getBlockPos(), AITSounds.CLOISTER, SoundCategory.BLOCKS, 1.0F, 1.0F);
             return Result.FAILURE;
         }
@@ -136,9 +136,7 @@ public class EngineOverloadControl extends Control {
             Scheduler.get().runTaskLater(() -> {
                 String frame = SPINNER[delay % SPINNER.length];
 
-                // FIXME: use translations
-                // FIXME: use `#formatted`
-                player.sendMessage(Text.literal("§6DUMPING ARTRON " + frame), true);
+                player.sendMessage(Text.translatable("tardis.message.control.engine_overdrive.dumping_artron").append(" " + frame).formatted(Formatting.GOLD), true);
             }, TaskStage.END_SERVER_TICK, TimeUnit.SECONDS, delay);
         }
 
@@ -149,9 +147,8 @@ public class EngineOverloadControl extends Control {
         for (int i = 0; i < 6; i++) {
             int delay = i + 1;
             Scheduler.get().runTaskLater(() -> {
-                // FIXME: use `#formatted`
-                String flashColor = (delay % 2 == 0) ? "§c" : "§f";
-                player.sendMessage(Text.literal(flashColor + "ARTRON DUMPED, ENGINES OVERLOADED, TRIGGERING EMERGENCY ARTRON RELEASE"), true);
+                Formatting flashColor = (delay % 2 == 0) ? Formatting.RED : Formatting.WHITE;
+                player.sendMessage(Text.translatable("tardis.message.control.engine_overdrive.engines_overloaded").formatted(flashColor), true);
             }, TaskStage.END_SERVER_TICK, TimeUnit.SECONDS, delay);
         }
 

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/PowerControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/PowerControl.java
@@ -49,7 +49,7 @@ public class PowerControl extends Control {
     }
 
     @Override
-    public long getDelayLength() {
+    public long getDelayLength(Tardis tardis) {
         return 200;
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/RandomiserControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/RandomiserControl.java
@@ -39,7 +39,7 @@ public class RandomiserControl extends Control {
     }
 
     @Override
-    public long getDelayLength() {
+    public long getDelayLength(Tardis tardis) {
         return 40;
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/SecurityControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/SecurityControl.java
@@ -90,7 +90,7 @@ public class SecurityControl extends Control {
     }
 
     @Override
-    public long getDelayLength() {
+    public long getDelayLength(Tardis tardis) {
         return 50;
     }
 }

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/SiegeModeControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/SiegeModeControl.java
@@ -49,7 +49,7 @@ public class SiegeModeControl extends Control {
     }
 
     @Override
-    public long getDelayLength() {
+    public long getDelayLength(Tardis tardis) {
         return 200;
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/TelepathicControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/TelepathicControl.java
@@ -291,7 +291,7 @@ public class TelepathicControl extends Control {
     }
 
     @Override
-    public long getDelayLength() {
+    public long getDelayLength(Tardis tardis) {
         return 120;
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -1,13 +1,17 @@
 package dev.amble.ait.core.tardis.handler.travel;
 
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Optional;
+import java.util.UUID;
 
+import dev.amble.ait.core.tardis.control.impl.EngineOverloadControl;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.drtheo.queue.api.ActionQueue;
 import dev.drtheo.scheduler.api.TimeUnit;
 import dev.drtheo.scheduler.api.common.Scheduler;
 import dev.drtheo.scheduler.api.common.TaskStage;
+import dev.drtheo.scheduler.api.task.Task;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
@@ -49,6 +53,10 @@ import dev.amble.ait.core.world.RiftChunkManager;
 import dev.amble.ait.data.Exclude;
 
 public final class TravelHandler extends AnimatedTravelHandler implements CrashableTardisTravel {
+
+    private static final HashMap<UUID, Boolean> ENGINE_OVERLOAD_ARMED = new HashMap<>();
+    private static final HashMap<UUID, Task<?>> ENGINE_OVERLOAD_CONFIRMATION_TIMER = new HashMap<>();
+    private static final long CONFIRMATION_TIME = 20 * 5;   //in ticks
 
     @Exclude
     private boolean travelCooldown;
@@ -108,6 +116,12 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
                 tardis.travel().setCrashing(false);
         });
 
+        TardisEvents.USE_CONTROL.register((control, tardis, player, world, console, leftClick) -> {
+            if (!(control instanceof EngineOverloadControl)) {
+                disarmEngineOverload(tardis.getUuid());
+            }
+        });
+
         if (EnvType.CLIENT == FabricLoader.getInstance().getEnvironmentType()) initializeClient();
     }
 
@@ -123,6 +137,26 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
                 });
             });
         });
+    }
+
+    public static void armEngineOverload(UUID tardisID, ServerWorld serverWorld) {
+        ENGINE_OVERLOAD_ARMED.put(tardisID, true);
+        ENGINE_OVERLOAD_CONFIRMATION_TIMER.put(
+                tardisID,
+                Scheduler.get().runTaskLater(() -> ENGINE_OVERLOAD_ARMED.put(tardisID, false), TaskStage.endWorldTick(serverWorld), TimeUnit.TICKS, CONFIRMATION_TIME)
+        );
+    }
+
+    public static void disarmEngineOverload(UUID tardisID) {
+        ENGINE_OVERLOAD_ARMED.remove(tardisID);
+        Task<?> confirmationTimer = ENGINE_OVERLOAD_CONFIRMATION_TIMER.get(tardisID);
+
+        if (confirmationTimer != null)
+            confirmationTimer.cancel();
+    }
+
+    public static boolean isEngineOverloadArmed(UUID tardisID) {
+        return ENGINE_OVERLOAD_ARMED.getOrDefault(tardisID, false);
     }
 
     public TravelHandler() {

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1118,6 +1118,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("tardis.message.control.telepathic.success", "Destination Found");
         provider.addTranslation("tardis.message.control.telepathic.failed", "Destination Not Found");
         provider.addTranslation("tardis.message.control.telepathic.choosing", "The TARDIS is choosing...");
+        provider.addTranslation("tardis.message.control.engine_overdrive.primed", "Dump Artron? Press again to confirm.");
         provider.addTranslation("tardis.message.interiorchange.success", "%s has grown to %d");
         provider.addTranslation("tardis.message.landingpad.adjust", "Adjusting to landing pad..");
         provider.addTranslation("tardis.message.self_destruct.warning", "SELF DESTRUCT INITIATED | ABORT SHIP");

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1119,6 +1119,9 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("tardis.message.control.telepathic.failed", "Destination Not Found");
         provider.addTranslation("tardis.message.control.telepathic.choosing", "The TARDIS is choosing...");
         provider.addTranslation("tardis.message.control.engine_overdrive.primed", "Dump Artron? Press again to confirm.");
+        provider.addTranslation("tardis.message.control.engine_overdrive.insufficient_fuel", "ERROR, TARDIS REQUIRES AT LEAST 25K ARTRON TO EXECUTE THIS ACTION.");
+        provider.addTranslation("tardis.message.control.engine_overdrive.dumping_artron", "DUMPING ARTRON");
+        provider.addTranslation("tardis.message.control.engine_overdrive.engines_overloaded", "ARTRON DUMPED, ENGINES OVERLOADED, TRIGGERING EMERGENCY ARTRON RELEASE");
         provider.addTranslation("tardis.message.interiorchange.success", "%s has grown to %d");
         provider.addTranslation("tardis.message.landingpad.adjust", "Adjusting to landing pad..");
         provider.addTranslation("tardis.message.self_destruct.warning", "SELF DESTRUCT INITIATED | ABORT SHIP");


### PR DESCRIPTION
## About the PR
This PR adds an arming mechanism to the engine overdrive.
                                                               
First press arms it.
Pressing again within 5 seconds executes overdrive.
Pressing any other control or waiting 5 seconds disarms it.
The 5 minute cooldown only starts after overdrive was executed.

## Why / Balance
To prevent accidental activation.

## Technical details
I added two static functions to the engine overdrive control that arm and disarm it:
`arm()` sets a boolean to true and starts a confirmation-timer that will disarm the overdrive after 5 seconds (20 * 5 ticks).
`disarm()` sets the same boolean to false and cancels the confirmation-timer.

When the control is first pressed, overdrive will be armed and return.
If the control is pressed again within the confirmation-time, overdrive is disarmed (just to reset the state) and the dumping of Artron is allowed to commence.

To cancel the event whenever another control is pressed (after arming overdrive):
I added an event that fires when a control is used.
The engine overdrive control registers to this event and if any other control is used it disarms overdrive.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- add: arming mechanism for engine overdrive