### PR TITLE
Prevent TARDIS in TARDIS landing via Hail Mary protocol

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/KeyItem.java
+++ b/src/main/java/dev/amble/ait/core/item/KeyItem.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import dev.amble.ait.core.util.WorldUtil;
 import dev.amble.ait.core.world.TardisServerWorld;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import org.jetbrains.annotations.Nullable;
@@ -149,8 +150,8 @@ public class KeyItem extends LinkableItem {
             return;
 
         World world = player.getWorld();
-        // fail silently if in tardis dim
-        if (TardisServerWorld.isTardisDimension(world))
+        // fail silently if destination world is blacklisted
+        if (!WorldUtil.getTravelWorlds().contains((ServerWorld) world))
             return;
 
         BlockPos pos = player.getBlockPos();

--- a/src/main/java/dev/amble/ait/core/item/KeyItem.java
+++ b/src/main/java/dev/amble/ait/core/item/KeyItem.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import dev.amble.ait.core.world.TardisServerWorld;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import org.jetbrains.annotations.Nullable;
 
@@ -148,6 +149,10 @@ public class KeyItem extends LinkableItem {
             return;
 
         World world = player.getWorld();
+        // fail silently if in tardis dim
+        if (TardisServerWorld.isTardisDimension(world))
+            return;
+
         BlockPos pos = player.getBlockPos();
 
         CachedDirectedGlobalPos globalPos = CachedDirectedGlobalPos.create((ServerWorld) world, pos,


### PR DESCRIPTION
## About the PR
When Hail Mary protocol is active and the conditions for it trigger when the player is inside a TARDIS, then it currently makes the player's TARDIS land inside the TARDIS ((be that itself or another).

This PR fixes that.

## Why / Balance
TARDISes are (currently) not meant to travel into TARDISes.

## Technical details
I added a simple `isTardisDimension` check for when the Hail Mary protocol fires, similar to how it's already done with the `TARDIS` mode of the sonice screwdriver.

## Media
<img width="674" height="440" alt="image" src="https://github.com/user-attachments/assets/4e478ad8-8f83-4261-8df2-20cb8ad00f6f" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- fix: TARDIS in TARDIS landing was still possible via Hail Mary protocol.