### PR TITLE
Prevent landing in locked dimensions via crashing or engine overload

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -68,6 +68,10 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
             TravelHandler travel = tardis.travel();
 
+            // Destination world locked, diverting TARDIS back to previous location.
+            if (!LockedDimensionRegistry.getInstance().isUnlocked(tardis, travel.destination().getWorld()))
+                travel.forceDestination(travel.previousPosition());
+
             return (TardisUtil.isInteriorEmpty(tardis) && !travel.leaveBehind().get()) || travel.autopilot() || travel.speed() == 0
                     ? TardisEvents.Interaction.SUCCESS : TardisEvents.Interaction.PASS;
         });


### PR DESCRIPTION
## About the PR
This PR prevents the ability to land in locked dimensions by way of crashing or using the engine overload.

*Feel free to block this, so that people can get around the lock by being creative.
This is just in case the dimension lock is supposed to be non-cirumventable.*

## Why / Balance
Because locked means locked.
*Unless we want to allow players to find creative ways to circumvent it.*

## Technical details
I added a check in the TravelHandler's `FINISH_FLIGHT` event that looks at the destination's dimension and, if so, resets the destination to the previous location.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Landing in locked worlds was possible via crashing or using engine overload