### PR TITLE
config mat/demat sound volume & distance

### DIFF
--- a/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
+++ b/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
@@ -86,14 +86,6 @@ public class AITClientConfig {
     @EnumCycler
     @SerialEntry public TemperatureType temperatureType = TemperatureType.CELSIUS;
 
-    @AutoGen(category = CATEGORY)
-    @FloatSlider(min = 0, max = 256, step = 1f)
-    @SerialEntry public float flightSoundDistance = 16f;
-
-    @AutoGen(category = CATEGORY)
-    @FloatSlider(min = 0, max = 16, step = 0.1f)
-    @SerialEntry public float flightSoundVolume = 1f;
-
     public enum TemperatureType implements NameableEnum {
         CELSIUS,
         FAHRENHEIT,

--- a/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
+++ b/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
@@ -86,6 +86,14 @@ public class AITClientConfig {
     @EnumCycler
     @SerialEntry public TemperatureType temperatureType = TemperatureType.CELSIUS;
 
+    @AutoGen(category = CATEGORY)
+    @FloatSlider(min = 0, max = 256, step = 0.1f)
+    @SerialEntry public float flightSoundDistance = 16f;
+
+    @AutoGen(category = CATEGORY)
+    @FloatSlider(min = 0, max = 16, step = 0.1f)
+    @SerialEntry public float flightSoundVolume = 1f;
+
     public enum TemperatureType implements NameableEnum {
         CELSIUS,
         FAHRENHEIT,

--- a/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
+++ b/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
@@ -87,7 +87,7 @@ public class AITClientConfig {
     @SerialEntry public TemperatureType temperatureType = TemperatureType.CELSIUS;
 
     @AutoGen(category = CATEGORY)
-    @FloatSlider(min = 0, max = 256, step = 0.1f)
+    @FloatSlider(min = 0, max = 256, step = 1f)
     @SerialEntry public float flightSoundDistance = 16f;
 
     @AutoGen(category = CATEGORY)
@@ -104,6 +104,7 @@ public class AITClientConfig {
         TemperatureType() {
             String key1;
             key1 = this.toString().toLowerCase();
+            // FIXME wtf??
             key1 = key1.substring(0, 1).toUpperCase() + key1.substring(1);
             key1 = switch (key1) {
                 case "Celsius" -> key1 + " (°C)";

--- a/src/main/java/dev/amble/ait/client/sounds/flight/ClientFlightHandler.java
+++ b/src/main/java/dev/amble/ait/client/sounds/flight/ClientFlightHandler.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.sounds.flight;
 
+import dev.amble.ait.AITMod;
 import dev.amble.ait.client.AITModClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.sound.SoundCategory;
@@ -97,6 +98,7 @@ public class ClientFlightHandler extends SoundHandler {
         if (tardis == null)
             tardis = ClientTardisUtil.getNearestTardis(AITModClient.CONFIG.flightSoundDistance).orElse(null);
 
+        AITMod.LOGGER.info("{}@{}", tardis, AITModClient.CONFIG.flightSoundVolume);
         if (tardis == null) return;
 
         if (this.sounds == null)

--- a/src/main/java/dev/amble/ait/client/sounds/flight/ClientFlightHandler.java
+++ b/src/main/java/dev/amble/ait/client/sounds/flight/ClientFlightHandler.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.sounds.flight;
 
+import dev.amble.ait.client.AITModClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.sound.SoundCategory;
 
@@ -7,6 +8,8 @@ import dev.amble.ait.client.sounds.SoundHandler;
 import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.ait.client.util.ClientTardisUtil;
 
+// FIXME: god this is so stupid
+//   why does the client have to go through the trouble of finding every tardis in some radius
 public class ClientFlightHandler extends SoundHandler {
 
     public static double MAX_DISTANCE = 16; // distance from console before the sound stops
@@ -93,7 +96,7 @@ public class ClientFlightHandler extends SoundHandler {
         ClientTardis tardis = ClientTardisUtil.getCurrentTardis();
 
         if (tardis == null)
-            tardis = ClientTardisUtil.getNearestTardis(ClientFlightHandler.MAX_DISTANCE).orElse(null);
+            tardis = ClientTardisUtil.getNearestTardis(AITModClient.CONFIG.flightSoundDistance).orElse(null);
 
         if (tardis == null) return;
 

--- a/src/main/java/dev/amble/ait/client/sounds/flight/ClientFlightHandler.java
+++ b/src/main/java/dev/amble/ait/client/sounds/flight/ClientFlightHandler.java
@@ -12,7 +12,6 @@ import dev.amble.ait.client.util.ClientTardisUtil;
 //   why does the client have to go through the trouble of finding every tardis in some radius
 public class ClientFlightHandler extends SoundHandler {
 
-    public static double MAX_DISTANCE = 16; // distance from console before the sound stops
     public static FlightSoundPlayer FLIGHT;
     public static FlightSoundPlayer EXTERIOR;
 

--- a/src/main/java/dev/amble/ait/client/sounds/flight/ClientFlightHandler.java
+++ b/src/main/java/dev/amble/ait/client/sounds/flight/ClientFlightHandler.java
@@ -13,6 +13,8 @@ import dev.amble.ait.client.util.ClientTardisUtil;
 //   why does the client have to go through the trouble of finding every tardis in some radius
 public class ClientFlightHandler extends SoundHandler {
 
+    public static final double MAX_DISTANCE = 16;
+
     public static FlightSoundPlayer FLIGHT;
     public static FlightSoundPlayer EXTERIOR;
 
@@ -96,9 +98,8 @@ public class ClientFlightHandler extends SoundHandler {
         ClientTardis tardis = ClientTardisUtil.getCurrentTardis();
 
         if (tardis == null)
-            tardis = ClientTardisUtil.getNearestTardis(AITModClient.CONFIG.flightSoundDistance).orElse(null);
+            tardis = ClientTardisUtil.getNearestTardis(MAX_DISTANCE).orElse(null);
 
-        AITMod.LOGGER.info("{}@{}", tardis, AITModClient.CONFIG.flightSoundVolume);
         if (tardis == null) return;
 
         if (this.sounds == null)

--- a/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
+++ b/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
@@ -19,14 +19,8 @@ public class ExteriorFlightSound extends PositionedLoopingSound implements Fligh
     private boolean dirty = true;
 
     public ExteriorFlightSound(FlightSound data, SoundCategory soundCategory) {
-        super(data.sound(), soundCategory, new BlockPos(0,0,0), AITModClient.CONFIG.flightSoundVolume);
+        super(data.sound(), soundCategory, new BlockPos(0,0,0));
         this.data = data;
-        this.attenuationType = AttenuationType.NONE;
-    }
-
-    @Override
-    public boolean shouldAlwaysPlay() {
-        return true;
     }
 
     @Override
@@ -53,7 +47,7 @@ public class ExteriorFlightSound extends PositionedLoopingSound implements Fligh
 
     @Override
     public ClientTardis tardis() {
-        return ClientTardisUtil.getNearestTardis(AITModClient.CONFIG.flightSoundDistance).orElse(null);
+        return ClientTardisUtil.getNearestTardis(ClientFlightHandler.MAX_DISTANCE).orElse(null);
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
+++ b/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
@@ -24,6 +24,11 @@ public class ExteriorFlightSound extends PositionedLoopingSound implements Fligh
     }
 
     @Override
+    public boolean shouldAlwaysPlay() {
+        return true;
+    }
+
+    @Override
     public Identifier getId() {
         return data.soundId();
     }

--- a/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
+++ b/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.sounds.flight;
 
+import dev.amble.ait.client.AITModClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.sound.SoundManager;
 import net.minecraft.client.sound.WeightedSoundSet;
@@ -18,7 +19,7 @@ public class ExteriorFlightSound extends PositionedLoopingSound implements Fligh
     private boolean dirty = true;
 
     public ExteriorFlightSound(FlightSound data, SoundCategory soundCategory) {
-        super(data.sound(), soundCategory, new BlockPos(0,0,0));
+        super(data.sound(), soundCategory, new BlockPos(0,0,0), AITModClient.CONFIG.flightSoundVolume);
         this.data = data;
     }
 
@@ -46,7 +47,7 @@ public class ExteriorFlightSound extends PositionedLoopingSound implements Fligh
 
     @Override
     public ClientTardis tardis() {
-        return ClientTardisUtil.getNearestTardis(ClientFlightHandler.MAX_DISTANCE).orElse(null);
+        return ClientTardisUtil.getNearestTardis(AITModClient.CONFIG.flightSoundDistance).orElse(null);
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
+++ b/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
@@ -21,6 +21,7 @@ public class ExteriorFlightSound extends PositionedLoopingSound implements Fligh
     public ExteriorFlightSound(FlightSound data, SoundCategory soundCategory) {
         super(data.sound(), soundCategory, new BlockPos(0,0,0), AITModClient.CONFIG.flightSoundVolume);
         this.data = data;
+        this.attenuationType = AttenuationType.NONE;
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
+++ b/src/main/java/dev/amble/ait/client/sounds/flight/ExteriorFlightSound.java
@@ -1,6 +1,5 @@
 package dev.amble.ait.client.sounds.flight;
 
-import dev.amble.ait.client.AITModClient;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.sound.SoundManager;
 import net.minecraft.client.sound.WeightedSoundSet;
@@ -13,6 +12,10 @@ import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.ait.client.util.ClientTardisUtil;
 import dev.amble.ait.core.sounds.flight.FlightSound;
 
+/**
+ * Not to be confused with {@link dev.amble.ait.core.tardis.animation.v2.TardisAnimation}'s ability of playing mat/demat sounds.
+ * Yeah.
+ */
 public class ExteriorFlightSound extends PositionedLoopingSound implements FlightSoundPlayer {
     private FlightSound data;
     private int ticks = 0;

--- a/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
+++ b/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
@@ -139,6 +139,9 @@ public class ClientTardisUtil {
 
         // doesnt find nearest, only finds if within radius.
         // could be more performant though
+        //
+        // ya dont say
+        //  - Theo
         /*
         return ClientTardisManager.getInstance().find(tardis -> {
             if (!tardis.travel().position().getDimension().equals(dimension))

--- a/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
+++ b/src/main/java/dev/amble/ait/client/util/ClientTardisUtil.java
@@ -154,23 +154,25 @@ public class ClientTardisUtil {
         });
         */
 
-        AtomicReference<ClientTardis> nearestTardis = new AtomicReference<>();
-        AtomicReference<Double> nearestDistance = new AtomicReference<>(Double.MAX_VALUE);
+        double radiusSquared = Math.pow(radius, 2);
+
+        final ClientTardis[] nearestTardis = new ClientTardis[1];
+        final double[] nearestDistanceSquared = {Double.MAX_VALUE};
 
         ClientTardisManager.getInstance().forEach(tardis -> {
             if (!tardis.travel().position().getDimension().equals(dimension))
                 return;
 
             BlockPos tPos = tardis.travel().position().getPos();
-            double distance = Math.sqrt(pos.getSquaredDistance(tPos));
+            double distanceSquared = pos.getSquaredDistance(tPos);
 
-            if (distance < radius && distance < nearestDistance.get()) {
-                nearestDistance.set(distance);
-                nearestTardis.set(tardis);
+            if (radiusSquared > distanceSquared && distanceSquared < nearestDistanceSquared[0]) {
+                nearestDistanceSquared[0] = distanceSquared;
+                nearestTardis[0] = tardis;
             }
         });
 
-        return Optional.ofNullable(nearestTardis.get());
+        return Optional.ofNullable(nearestTardis[0]);
     }
 
     public static double distanceFromConsole() {

--- a/src/main/java/dev/amble/ait/config/AITServerConfig.java
+++ b/src/main/java/dev/amble/ait/config/AITServerConfig.java
@@ -89,6 +89,10 @@ public class AITServerConfig {
     @Boolean(formatter = Boolean.Formatter.YES_NO, colored = true)
     @SerialEntry public boolean disableSafeguards = false;
 
+    @AutoGen(category = CATEGORY)
+    @FloatSlider(min = 0, max = 16, step = 0.1f)
+    @SerialEntry public float crashSoundVolume = 1f;
+
     public static class StringListFactory implements ListGroup.ValueFactory<String>, ListGroup.ControllerFactory<String> {
 
         // used by the reflections

--- a/src/main/java/dev/amble/ait/config/AITServerConfig.java
+++ b/src/main/java/dev/amble/ait/config/AITServerConfig.java
@@ -93,6 +93,14 @@ public class AITServerConfig {
     @FloatSlider(min = 0, max = 16, step = 0.1f)
     @SerialEntry public float crashSoundVolume = 1f;
 
+    @AutoGen(category = CATEGORY)
+    @FloatSlider(min = 0, max = 256, step = 1f)
+    @SerialEntry public float flightSoundDistance = 16f;
+
+    @AutoGen(category = CATEGORY)
+    @FloatSlider(min = 0, max = 16, step = 0.1f)
+    @SerialEntry public float flightSoundVolume = 1f;
+
     public static class StringListFactory implements ListGroup.ValueFactory<String>, ListGroup.ControllerFactory<String> {
 
         // used by the reflections

--- a/src/main/java/dev/amble/ait/core/sounds/travel/TravelSound.java
+++ b/src/main/java/dev/amble/ait/core/sounds/travel/TravelSound.java
@@ -21,6 +21,7 @@ import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.core.tardis.handler.travel.TravelHandlerBase;
 
 // @TODO better variable names
+@Deprecated(since = "1.3.0", forRemoval = true)
 public record TravelSound(TravelHandlerBase.State target, Identifier id, Identifier soundId, int timeLeft, int maxTime, int startTime, int length, float frequency,
                           float intensity, String name) implements Identifiable, Nameable {
     public static final Codec<TravelSound> CODEC = RecordCodecBuilder.create(instance -> instance

--- a/src/main/java/dev/amble/ait/core/sounds/travel/TravelSoundRegistry.java
+++ b/src/main/java/dev/amble/ait/core/sounds/travel/TravelSoundRegistry.java
@@ -10,6 +10,7 @@ import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.core.sounds.travel.map.TravelSoundMap;
 import dev.amble.ait.core.tardis.handler.travel.TravelHandlerBase;
 
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class TravelSoundRegistry extends SimpleDatapackRegistry<TravelSound> {
     private static final TravelSoundRegistry instance = new TravelSoundRegistry();
 

--- a/src/main/java/dev/amble/ait/core/sounds/travel/map/TravelSoundMap.java
+++ b/src/main/java/dev/amble/ait/core/sounds/travel/map/TravelSoundMap.java
@@ -19,7 +19,7 @@ import dev.amble.ait.core.sounds.travel.TravelSoundRegistry;
 import dev.amble.ait.core.tardis.handler.travel.TravelHandlerBase;
 import dev.amble.ait.data.enummap.EnumMap;
 
-@Deprecated(since = "1.3.0")
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class TravelSoundMap extends EnumMap.Compliant<TravelHandlerBase.State, TravelSound> {
 
     public static Codec<TravelSoundMap> CODEC = Identifier.CODEC.listOf().flatXmap((l) -> {

--- a/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisDesktop.java
@@ -254,7 +254,7 @@ public class TardisDesktop extends TardisComponent {
 
         RegistryKey<World> worldKey = this.tardis.asServer().world().getRegistryKey();
         this.getConsolePos().forEach(consolePos -> {
-            NetworkUtil.playSound(worldKey, consolePos, soundId, category);
+            NetworkUtil.playSound(worldKey, consolePos, soundId, category, 1, 8);
         });
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/TardisExterior.java
+++ b/src/main/java/dev/amble/ait/core/tardis/TardisExterior.java
@@ -143,8 +143,8 @@ public class TardisExterior extends TardisComponent {
      * Plays a sound at the tardis position, ignoring whether it exists on the server
      * @author duzo
      */
-    public void playSound(Identifier soundId, SoundCategory category) {
+    public void playSound(Identifier soundId, SoundCategory category, float volume, float distance) {
         CachedDirectedGlobalPos pos = tardis.travel().position();
-        NetworkUtil.playSound(pos.getDimension(), pos.getPos(), soundId, category);
+        NetworkUtil.playSound(pos.getDimension(), pos.getPos(), soundId, category, volume, distance);
     }
 }

--- a/src/main/java/dev/amble/ait/core/tardis/animation/v2/TardisAnimation.java
+++ b/src/main/java/dev/amble/ait/core/tardis/animation/v2/TardisAnimation.java
@@ -98,7 +98,8 @@ public abstract class TardisAnimation implements TardisTickable, Disposable, Ide
         playSound = playSound && this.tryStart(this.rotation, new Vector3f());
 
         if (playSound) {
-            tardis.getExterior().playSound(this.getSoundIdOrDefault(), SoundCategory.BLOCKS);
+            tardis.getExterior().playSound(this.getSoundIdOrDefault(), SoundCategory.BLOCKS,
+                    AITMod.CONFIG.flightSoundVolume, AITMod.CONFIG.flightSoundDistance);
         }
 
         this.alpha.tick(server);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -378,7 +378,8 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
         this.finishRemat();
 
         this.position().getWorld().playSound(null, this.position().getPos(), AITSounds.LAND_CRASH,
-                SoundCategory.AMBIENT);
+                SoundCategory.AMBIENT, AITMod.CONFIG.crashSoundVolume, 1f);
+
         this.tardis.getDesktop().playSoundAtEveryConsole(AITSounds.ABORT_FLIGHT, SoundCategory.AMBIENT);
 
         PacketByteBuf buf = PacketByteBufs.create();

--- a/src/main/java/dev/amble/ait/core/tardis/util/NetworkUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/NetworkUtil.java
@@ -127,13 +127,12 @@ public class NetworkUtil {
     /**
      * plays a sound, ignoring whether it exists or not.
      */
-    public static void playSound(RegistryKey<World> worldKey, BlockPos pos, Identifier soundId, SoundCategory category) {
+    public static void playSound(RegistryKey<World> worldKey, BlockPos pos, Identifier soundId, SoundCategory category, float volume, float distance) {
         if (!ServerLifecycleHooks.isServer()) return;
 
         RegistryEntry<SoundEvent> soundEntry = RegistryEntry.of(SoundEvent.of(soundId));
         long seed = ServerLifecycleHooks.get().getOverworld().getRandom().nextLong();
 
-        final float distance = 8f; // default distance for exterior sounds
         ServerLifecycleHooks.get()
                 .getPlayerManager()
                 .sendToAround(
@@ -143,7 +142,7 @@ public class NetworkUtil {
                         pos.getZ(),
                         distance,
                         worldKey,
-                        new PlaySoundS2CPacket(soundEntry, category, pos.getX(), pos.getY(), pos.getZ(), 1f, 1f, seed)
+                        new PlaySoundS2CPacket(soundEntry, category, pos.getX(), pos.getY(), pos.getZ(), volume, 1f, seed)
                 );
     }
 

--- a/src/main/resources/assets/ait/lang/en_us.existing.json
+++ b/src/main/resources/assets/ait/lang/en_us.existing.json
@@ -16,6 +16,7 @@
   "yacl3.config.ait:server.riftSpawnBlacklist": "Rift spawn world blacklist",
   "yacl3.config.ait:server.riftDropBlacklist": "Rift drop world blacklist",
   "yacl3.config.ait:server.disableSafeguards": "Disable Safeguards",
+  "yacl3.config.ait:server.crashSoundVolume": "TARDIS Crash Sound Volume",
 
   "yacl3.config.ait:client.interiorHumVolume": "Interior hum volume",
   "yacl3.config.ait:client.customMenu": "Use custom main menu?",
@@ -29,6 +30,8 @@
   "yacl3.config.ait:client.animateConsole": "Animate console?",
   "yacl3.config.ait:client.animateDoors": "Animate doors?",
   "yacl3.config.ait:client.temperatureType": "Temperature type",
+  "yacl3.config.ait:client.flightSoundDistance": "Flight Sound Distance",
+  "yacl3.config.ait:client.flightSoundVolume": "Flight Sound Volume",
 
   "screen.ait.security.title": "Security"
 }


### PR DESCRIPTION
## About the PR
Commissioned by Akari (`@dakarkar` on discord).
Adds 2 config values to change volume and distance of mat/demat sounds.
Also significantly improves performance of client tardis sound handling.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- perf: improve client-side performance of TARDIS-related sounds
- add: a server-side config option to control the distance of travel sounds
- add: a server-side config option to control the volume of travel sounds