### PR TITLE
fix: engine can only be placed in tardis dimension

### DIFF
--- a/src/main/java/dev/amble/ait/core/blocks/EngineBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/EngineBlock.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.core.blocks;
 
+import dev.amble.ait.core.world.TardisServerWorld;
 import net.minecraft.world.WorldView;
 import org.jetbrains.annotations.Nullable;
 
@@ -64,11 +65,7 @@ public class EngineBlock extends SubSystemBlock implements BlockEntityProvider {
 
     @Override
     public boolean canPlaceAt(BlockState state, WorldView world, BlockPos pos) {
-        if (world instanceof World world1 && (world1.getRegistryKey().equals(World.OVERWORLD) ||
-                world1.getRegistryKey().equals(World.NETHER) || world1.getRegistryKey().equals(World.END))) {
-            return false;
-        }
-        return super.canPlaceAt(state, world, pos);
+        return world instanceof World world1 && TardisServerWorld.isTardisDimension(world1);
     }
 
     @Override


### PR DESCRIPTION
## About the PR
fixed a bug where the engine could be placed in the overworld and would crash the game and the minecraft server

## Why / Balance
fix crashes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


:cl:
- fix: fixed a bug where you could place an engine in a non tardis dimension and it would crash the game