### PR TITLE
optimize server tardis world ticking

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/ServerTardis.java
+++ b/src/main/java/dev/amble/ait/core/tardis/ServerTardis.java
@@ -8,13 +8,10 @@ import java.util.function.Consumer;
 
 import com.google.gson.InstanceCreator;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
-import dev.amble.lib.util.ServerLifecycleHooks;
-import dev.drtheo.multidim.MultiDim;
 
 import net.minecraft.server.MinecraftServer;
 
 import dev.amble.ait.api.tardis.TardisComponent;
-import dev.amble.ait.core.tardis.handler.travel.TravelHandler;
 import dev.amble.ait.core.world.TardisServerWorld;
 import dev.amble.ait.data.Exclude;
 import dev.amble.ait.data.schema.desktop.TardisDesktopSchema;
@@ -101,17 +98,13 @@ public class ServerTardis extends Tardis {
         if (world == null)
             return false;
 
-        if (!MultiDim.get(ServerLifecycleHooks.get()).isWorldUnloaded(world))
-            return true;
+        return !this.travel().isLanded() || world.shouldTick() || this.shouldTickExterior();
+    }
 
-        TravelHandler travel = this.travel();
-
-        if (!travel.isLanded())
-            return true;
-
-        CachedDirectedGlobalPos pos = travel.position();
+    public boolean shouldTickExterior() {
+        CachedDirectedGlobalPos pos = this.travel().position();
         return pos.getWorld() != null && pos.getWorld()
-                .shouldTickEntity(travel.position().getPos());
+                .shouldTickEntity(pos.getPos());
     }
 
     public static Object creator() {

--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -46,6 +46,7 @@ public class TardisServerWorld extends MultiDimServerWorld {
 
     public TardisServerWorld(WorldBlueprint blueprint, MinecraftServer server, Executor workerExecutor, LevelStorage.Session session, ServerWorldProperties properties, RegistryKey<World> worldKey, DimensionOptions dimensionOptions, WorldGenerationProgressListener worldGenerationProgressListener, List<Spawner> spawners, @Nullable RandomSequencesState randomSequencesState, boolean created) {
         super(blueprint, server, workerExecutor, session, properties, worldKey, dimensionOptions, worldGenerationProgressListener, spawners, randomSequencesState, created);
+        this.setMobSpawnOptions(false, false);
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
+++ b/src/main/java/dev/amble/ait/core/world/TardisServerWorld.java
@@ -50,9 +50,13 @@ public class TardisServerWorld extends MultiDimServerWorld {
 
     @Override
     public void tick(BooleanSupplier shouldKeepTicking) {
-        if (this.tardis != null && this.tardis.shouldTick()) {
+        if (this.tardis != null && this.shouldTick()) {
             super.tick(shouldKeepTicking);
         }
+    }
+
+    public boolean shouldTick() {
+        return this.tardis != null && MultiDim.get(this.getServer()).isWorldUnloaded(this);
     }
 
     @Override


### PR DESCRIPTION
## About the PR
This PR adjusts tardis world ticking to only tick when there are chunks loaded (or players are) inside. Also, disables monster and animal spawning for the _most_ part. This should also cut some costs.

## Why / Balance
MultiDim worlds suck inherently because of the way Minecraft was coded.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- perf: improved tardis world performance