### PR TITLE
Fix falling TARDIS destroying siege cubes

### DIFF
--- a/src/main/java/dev/amble/ait/core/entities/FallingTardisEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/FallingTardisEntity.java
@@ -130,8 +130,8 @@ public class FallingTardisEntity extends LinkableDummyEntity implements ISpaceIm
                     SoundEvents.ITEM_ELYTRA_FLYING, SoundCategory.BLOCKS, 0.25F, 1.0F));
 
         Planet planet = PlanetRegistry.getInstance().get(this.getWorld());
-        boolean canFall = this.tardis().get().travel().antigravs().get() || planet != null && planet.zeroGravity();
-        if (canFall) {
+        boolean cannotFall = this.tardis().get().travel().antigravs().get() || planet != null && planet.zeroGravity();
+        if (cannotFall) {
             this.stopFalling(true);
             return;
         }
@@ -140,6 +140,14 @@ public class FallingTardisEntity extends LinkableDummyEntity implements ISpaceIm
 
         if (blockPos == null)
             return;
+
+        // If it falls on top of an exterior whose collision shape is smaller than the exterior's blockspace itself,
+        // (which is the case for a siege cube exterior), then make it stop 2 blocks above, so the door won't be blocked when un-sieged.
+        if (this.getWorld().getBlockEntity(blockPos) instanceof ExteriorBlockEntity) {
+            this.setPosition(blockPos.toCenterPos().add(0, 2, 0));
+            this.stopFalling(false);
+            return;
+        }
 
         tardis.travel().forcePosition(cached -> cached.pos(blockPos).world(this.getWorld().getRegistryKey()));
 


### PR DESCRIPTION
## About the PR
Prevents falling TARDIS exteriors from destroying siege cube exteriors when landing on them.

The falling TARDIS' exterior will stop at the same height above the siege cube as when it would be falling onto a police box.
This ensures that when the siege mode is deactivated, the door is not blocked by the other TARDIS's exterior being too far clipped into it.

## Why / Balance
Because a siege cube should not be squished by another TARDIS falling on top of it.

## Technical details
Once the falling TARDIS reaches into the blockspace of the siege cube, it will detect that there is another TARDIS exterior in that blockspace.
It will then reset its position to 2 blocks above it and stop falling.
Since this happens within a tick, this reset is barely noticeable.

## Media
https://github.com/user-attachments/assets/d607d71b-8fa1-4f76-aaf8-e3d993ceea6e

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- fix: Falling TARDISes destroy Siege Cube exteriors