### PR TITLE
Fix celsius showing fahrenheit degrees

### DIFF
--- a/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
+++ b/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
@@ -12,6 +12,7 @@ import dev.isxander.yacl3.platform.YACLPlatform;
 import net.minecraft.text.Text;
 
 import dev.amble.ait.AITMod;
+import org.apache.commons.lang3.StringUtils;
 
 public class AITClientConfig {
 
@@ -94,13 +95,12 @@ public class AITClientConfig {
         private final String key;
 
         TemperatureType() {
-            String unitCapitalized = this.toString().charAt(0) + this.toString().substring(1).toLowerCase();
             String unitSymbol = switch (this) {
                 case CELSIUS -> "°C";
                 case FAHRENHEIT -> "°F";
                 case KELVIN -> "K";
             };
-            this.key = String.format("%s (%s)", unitCapitalized, unitSymbol);
+            this.key = String.format("%s (%s)", StringUtils.capitalize(this.toString().toLowerCase()), unitSymbol);
         }
 
         @Override

--- a/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
+++ b/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
@@ -94,17 +94,13 @@ public class AITClientConfig {
         private final String key;
 
         TemperatureType() {
-            String key1;
-            key1 = this.toString().toLowerCase();
-            // FIXME wtf??
-            key1 = key1.substring(0, 1).toUpperCase() + key1.substring(1);
-            key1 = switch (key1) {
-                case "Celsius" -> key1 + " (°C)";
-                case "Fahrenheit" -> key1 + " (°F)";
-                case "Kelvin" -> key1 + " (K)";
-                default -> key1;
+            String unitCapitalized = this.toString().charAt(0) + this.toString().substring(1).toLowerCase();
+            String unitSymbol = switch (this) {
+                case CELSIUS -> "°C";
+                case FAHRENHEIT -> "°F";
+                case KELVIN -> "K";
             };
-            this.key = key1;
+            this.key = String.format("%s (%s)", unitCapitalized, unitSymbol);
         }
 
         @Override

--- a/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
+++ b/src/main/java/dev/amble/ait/client/config/AITClientConfig.java
@@ -95,12 +95,7 @@ public class AITClientConfig {
         private final String key;
 
         TemperatureType() {
-            String unitSymbol = switch (this) {
-                case CELSIUS -> "°C";
-                case FAHRENHEIT -> "°F";
-                case KELVIN -> "K";
-            };
-            this.key = String.format("%s (%s)", StringUtils.capitalize(this.toString().toLowerCase()), unitSymbol);
+            this.key = "yacl3.config.ait:client.temperatureType.unit." + this.toString().toLowerCase();
         }
 
         @Override

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -829,6 +829,9 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("yacl3.config.ait:client.animateConsole", "Animate console?");
         provider.addTranslation("yacl3.config.ait:client.animateDoors", "Animate doors?");
         provider.addTranslation("yacl3.config.ait:client.temperatureType", "Temperature type");
+        provider.addTranslation("yacl3.config.ait:client.temperatureType.unit.celsius", "Celsius (°C)");
+        provider.addTranslation("yacl3.config.ait:client.temperatureType.unit.fahrenheit", "Fahrenheit (°F)");
+        provider.addTranslation("yacl3.config.ait:client.temperatureType.unit.kelvin", "Kelvin (K)");
 
         provider.addTranslation("text.autoconfig.aitconfig.category.client", "Client");
         provider.addTranslation("text.autoconfig.aitconfig.option.CLIENT.SHOW_EXPERIMENTAL_WARNING", "Show Experimental Warning");

--- a/src/main/java/dev/amble/ait/module/planet/client/SpaceSuitOverlay.java
+++ b/src/main/java/dev/amble/ait/module/planet/client/SpaceSuitOverlay.java
@@ -57,9 +57,9 @@ public class SpaceSuitOverlay implements HudRenderCallback {
 
     public String getTemperatureType(AITClientConfig config, Planet planet) {
         return switch(config.temperatureType) {
-            case CELSIUS -> ("" + planet.fahrenheit()).substring(0, 5) + "°C";
-            case FAHRENHEIT -> ("" + planet.fahrenheit()).substring(0, 5) + "°F";
-            case KELVIN -> planet.kelvin() + "K";
+            case CELSIUS -> ("" + planet.celsius()).substring(0, 5) + " °C";
+            case FAHRENHEIT -> ("" + planet.fahrenheit()).substring(0, 5) + " °F";
+            case KELVIN -> planet.kelvin() + " K";
         };
     }
 }

--- a/src/main/java/dev/amble/ait/module/planet/core/space/planet/Planet.java
+++ b/src/main/java/dev/amble/ait/module/planet/core/space/planet/Planet.java
@@ -75,8 +75,8 @@ public record Planet(Identifier dimension, float gravity, boolean hasOxygen, boo
         return this.dimension();
     }
 
-    // Use Celcius since it's more accurate in terms of water temperature
-    public float celcius() {
+    // Use Celsius since it's more accurate in terms of water temperature
+    public float celsius() {
         return this.temperature() - 273.15f;
     }
 
@@ -85,13 +85,13 @@ public record Planet(Identifier dimension, float gravity, boolean hasOxygen, boo
         return this.temperature();
     }
 
-    // Celcius -> Fahrenheit conversion isn't always the most accurate but oh well cope harder I guess
+    // Celsius -> Fahrenheit conversion isn't always the most accurate but oh well cope harder I guess
     public float fahrenheit() {
-        return celcius() * 1.8f + 32f;
+        return celsius() * 1.8f + 32f;
     }
 
     public boolean isFreezing() {
-        return this.celcius() <= 0;
+        return this.celsius() <= 0;
     }
 
     public boolean zeroGravity() {

--- a/src/main/resources/assets/ait/lang/uk_ua.existing.json
+++ b/src/main/resources/assets/ait/lang/uk_ua.existing.json
@@ -13,7 +13,7 @@
   "text.config.aitconfig.option.DISABLE_LOYALTY_SLEEPING_ACTIONBAR": "Вимкнути панель дій довіри під час сну",
   "text.config.aitconfig.option.TEMPERATURE_TYPE": "Тип температури",
   "text.config.aitconfig.option.ENABLE_TARDIS_BOTI": "Ввімкнути TARDIS BOTI (Більше всередині)",
-  "text.config.aitconfig.enum.temperatureType.celcius": "Цельсій (°C)",
+  "text.config.aitconfig.enum.temperatureType.celsius": "Цельсій (°C)",
   "text.config.aitconfig.enum.temperatureType.fahrenheit": "Фаренгейт (°F)",
   "text.config.aitconfig.enum.temperatureType.kelvin": "Кельвін (K)",
   "gamerule.tardisGriefing": "Сумування TARDIS",


### PR DESCRIPTION
## About the PR
Makes the space suit display Celsius degrees when Celsius setting is chosen instead of displaying Fahrenheit degrees.
Also fixes some Celsius spelling and improves the temperature config enum code.

## Why / Balance
Because Celsius is not Fahrenheit.

## Technical details
Changed a call to `celsius()` instead of `fahrenheit()` where Celsius was called for (pun intended).

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Celsius was showing Fahrenheit degrees