### PR TITLE
fix: lifesupport subsystem flicker

### DIFF
--- a/src/main/java/dev/amble/ait/core/engine/impl/LifeSupportCircuit.java
+++ b/src/main/java/dev/amble/ait/core/engine/impl/LifeSupportCircuit.java
@@ -17,6 +17,9 @@ import dev.amble.ait.core.tardis.ServerTardis;
 import dev.amble.ait.core.tardis.util.TardisUtil;
 
 public class LifeSupportCircuit extends DurableSubSystem implements StructureHolder {
+
+    private static final int TICK_RATE = 20;
+    
     private static final MultiBlockStructure STRUCTURE = createStructure();
     private static MultiBlockStructure createStructure() {
         MultiBlockStructure made = new MultiBlockStructure();
@@ -55,13 +58,13 @@ public class LifeSupportCircuit extends DurableSubSystem implements StructureHol
         ServerTardis tardis = this.tardis().asServer();
 
         if (!this.isEnabled()) return;
-        if (ServerLifecycleHooks.get().getTicks() % 20 != 0)
+        if (ServerLifecycleHooks.get().getTicks() % TICK_RATE != 0)
             return;
 
         List<LivingEntity> entities = TardisUtil.getLivingEntitiesInInterior(tardis);
 
         for (LivingEntity entity : entities) {
-            entity.addStatusEffect(new StatusEffectInstance(StatusEffects.REGENERATION, 20, 1, true, false));
+            entity.addStatusEffect(new StatusEffectInstance(StatusEffects.REGENERATION, TICK_RATE * 2, 1, true, false));
         }
     }
 }


### PR DESCRIPTION
## About the PR
Fixes lifesupport subsystem effect flicker.

## Why / Balance
It would cause bugs with mods like JEI/REI shifting UI.

## Technical details
Increased the duration of the regeneration effect to be twice as much as the tickrate it applies at (20 ticks).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: life-support subsystem regeneration effect flicker