### PR TITLE
feat: /ait list command search queries

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/StatsHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/StatsHandler.java
@@ -24,7 +24,6 @@ import dev.amble.ait.AITMod;
 import dev.amble.ait.api.tardis.KeyedTardisComponent;
 import dev.amble.ait.core.sounds.flight.FlightSound;
 import dev.amble.ait.core.sounds.flight.FlightSoundRegistry;
-import dev.amble.ait.core.sounds.travel.map.TravelSoundMap;
 import dev.amble.ait.core.tardis.handler.travel.AnimatedTravelHandler;
 import dev.amble.ait.core.tardis.vortex.reference.VortexReference;
 import dev.amble.ait.core.tardis.vortex.reference.VortexReferenceRegistry;
@@ -65,7 +64,6 @@ public class StatsHandler extends KeyedTardisComponent {
     private static final DoubleProperty TARDIS_Y_SCALE = new DoubleProperty("tardis_y_scale", 1);
     private static final DoubleProperty TARDIS_Z_SCALE = new DoubleProperty("tardis_z_scale", 1);
 
-
     private final Value<String> tardisName = NAME.create(this);
     private final Value<String> playerCreatorName = PLAYER_CREATOR_NAME.create(this);
     private final Value<Long> dateCreated = DATE.create(this);
@@ -82,8 +80,6 @@ public class StatsHandler extends KeyedTardisComponent {
     private final DoubleValue tardisYScale = TARDIS_Y_SCALE.create(this);
     private final DoubleValue tardisZScale = TARDIS_Z_SCALE.create(this);
 
-    @Exclude
-    private Lazy<TravelSoundMap> travelFxCache;
     @Exclude
     private Lazy<FlightSound> flightFxCache;
     @Exclude

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1458,6 +1458,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("command.ait.data.set", "Set value %s to '%s'");
         provider.addTranslation("command.ait.data.fail",
                 "Can't get value of a property named %s, because component %s is not keyed!");
+        provider.addTranslation("command.ait.list.pattern.error", "Bad pattern '%s'!");
 
         // Rift Chunk Tracking
         provider.addTranslation("riftchunk.ait.tracking", "Rift Tracking");


### PR DESCRIPTION
## About the PR
Adds /ait list command search queries.

## Why / Balance
Because the moderators requested it.

## Technical details
It splits the search-query argument by a colon and parses the second part as regex.
- `id:` searches by id
- `name:` searches by TARDIS' name
- `owner:` searches by TARDIS' owner's name

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: /ait list command is now more useful. Read the wiki for more details.