### PR TITLE
fix exterior selection screen

### DIFF
--- a/src/main/java/dev/amble/ait/client/screens/MonitorScreen.java
+++ b/src/main/java/dev/amble/ait/client/screens/MonitorScreen.java
@@ -101,9 +101,6 @@ public class MonitorScreen extends ConsoleScreen {
     }
 
     public ClientExteriorVariantSchema getCurrentVariant() {
-        if (Objects.equals(currentVariant, ClientExteriorVariantRegistry.CORAL_GROWTH))
-            changeCategory(true);
-
         if (currentVariant == null)
             if (!this.tardis().getExterior().getCategory().equals(getCategory())) {
                 setCurrentVariant(this.getCategory().getDefaultVariant());

--- a/src/main/java/dev/amble/ait/client/screens/MonitorScreen.java
+++ b/src/main/java/dev/amble/ait/client/screens/MonitorScreen.java
@@ -195,8 +195,8 @@ public class MonitorScreen extends ConsoleScreen {
         else
             setCategory(previousCategory());
 
-        if ((this.category instanceof ExclusiveCategory && !ExclusiveCategory.isUnlocked(player.getUuid()))
-                || this.category instanceof GrowthCategory)
+        if ((CategoryRegistry.EXCLUSIVE.equals(this.category) && !ExclusiveCategory.isUnlocked(player.getUuid()))
+                || CategoryRegistry.CORAL_GROWTH.equals(this.category))
             changeCategory(direction);
     }
 


### PR DESCRIPTION
## About the PR
Exclusives are now only shown if unlocked for a player UUID.
And the Coral Growth exterior is back to being skipped again.

(I'm not going to mention the crystal growth bulletpoint in the changelog, as that was a regression introduced after the latest release, so it wouldn't be a fix since then).

## Why / Balance
The coral growth exterior shouldn't appear at all and the exclusives should be exclusive.

## Technical details
Checking via `instanceof` didn't seem to work, so I instead did an `.equals` check against the respective categories.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Exclusive exteriors are now exclusive again