### PR TITLE
fix dropped items in interior being teleported instantly

### DIFF
--- a/src/main/java/dev/amble/ait/mixin/server/ItemEntityMixin.java
+++ b/src/main/java/dev/amble/ait/mixin/server/ItemEntityMixin.java
@@ -22,8 +22,8 @@ public abstract class ItemEntityMixin {
         if (world.isClient())
             return;
 
-        // if entity is in tardis and y is less than -100 save them
-        if (entity.getY() < -entity.getWorld().getBottomY() && world instanceof TardisServerWorld tardisWorld
+        // if entity is in tardis and y is less than the TARDIS' bottom coordinate (currently -64), teleport it to the door
+        if (entity.getY() < entity.getWorld().getBottomY() && world instanceof TardisServerWorld tardisWorld
                 && !tardisWorld.getTardis().interiorChanging().regenerating().get())
             TardisUtil.teleportInside(tardisWorld.getTardis(), entity);
     }


### PR DESCRIPTION
## About the PR
When items are dropped inside the TARDIS, they instantly get teleported to the door.

## Why / Balance
They should only get teleported to the door if they fall below the bottom Y of the dimension.

## Technical details
I simply removed a negative sign that was probably carry-over from the `ServerPlayerMixin`, where the Y coordinate for teleporting players was `-100`.
But in the `ItemEntityMixin` it references `entity.getWorld().getBottomY()`, which is *already* negative (-64 to be precise).
So having a negative sign in front of that would check against `64`, which is *not* the bottom Y of the dimension, but way above the console room.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Dropped items in interior were being teleported instantly