### PR TITLE
Fix explosion (and fire) gamerules

### DIFF
--- a/src/main/java/dev/amble/ait/core/blocks/PeanutBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/PeanutBlock.java
@@ -1,10 +1,12 @@
 package dev.amble.ait.core.blocks;
 
+import dev.amble.ait.core.tardis.util.TardisUtil;
 import net.minecraft.block.Block;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public class PeanutBlock extends Block {
+    private static final float EXPLOSION_POWER = 100;
 
     public PeanutBlock(Settings settings) {
         super(settings.strength(-1.0f, 3600000.0f).emissiveLighting((state, world, pos) -> true).luminance(value -> 128)
@@ -12,10 +14,10 @@ public class PeanutBlock extends Block {
     }
 
     public void explode(World world, BlockPos pos) {
-        world.createExplosion(null, world.getDamageSources().outOfWorld(), null, pos.toCenterPos(), 100, true,
+        world.createExplosion(null, world.getDamageSources().outOfWorld(), TardisUtil.EXPLOSION_BEHAVIOR, pos.toCenterPos(), EXPLOSION_POWER, TardisUtil.doCreateFire(world),
                 World.ExplosionSourceType.MOB);
-        world.createExplosion(null, null, null, pos.toCenterPos(), 100, true, World.ExplosionSourceType.BLOCK);
-        world.createExplosion(null, world.getDamageSources().outOfWorld(), null, pos.toCenterPos(), 100, true,
+        world.createExplosion(null, null, TardisUtil.EXPLOSION_BEHAVIOR, pos.toCenterPos(), EXPLOSION_POWER, TardisUtil.doCreateFire(world), World.ExplosionSourceType.BLOCK);
+        world.createExplosion(null, world.getDamageSources().outOfWorld(), TardisUtil.EXPLOSION_BEHAVIOR, pos.toCenterPos(), EXPLOSION_POWER, TardisUtil.doCreateFire(world),
                 World.ExplosionSourceType.TNT);
     }
 }

--- a/src/main/java/dev/amble/ait/core/entities/FallingTardisEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/FallingTardisEntity.java
@@ -2,7 +2,7 @@ package dev.amble.ait.core.entities;
 
 import java.util.function.Predicate;
 
-import dev.amble.lib.util.ServerLifecycleHooks;
+import dev.amble.ait.core.tardis.util.TardisUtil;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -20,7 +20,6 @@ import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket;
 import net.minecraft.predicate.entity.EntityPredicates;
 import net.minecraft.registry.RegistryKeys;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
@@ -30,12 +29,8 @@ import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
-import net.minecraft.world.explosion.Explosion;
-import net.minecraft.world.explosion.ExplosionBehavior;
 
-import dev.amble.ait.AITMod;
 import dev.amble.ait.client.tardis.ClientTardis;
 import dev.amble.ait.core.AITBlocks;
 import dev.amble.ait.core.AITDamageTypes;
@@ -178,16 +173,7 @@ public class FallingTardisEntity extends LinkableDummyEntity implements ISpaceIm
         });
 
         if (isCrashing) {
-            this.getWorld().createExplosion(this, null, new ExplosionBehavior() {
-                        @Override
-                        public boolean canDestroyBlock(Explosion explosion, BlockView world, BlockPos pos, BlockState state, float power) {
-                            MinecraftServer server = ServerLifecycleHooks.get();
-                            if (server == null) return false;
-                            if (!server.getGameRules().getBoolean(AITMod.TARDIS_GRIEFING)) return false;
-
-                            return super.canDestroyBlock(explosion, world, pos, state, power);
-                        }
-                    }, this.getPos(), 10, true,
+            this.getWorld().createExplosion(this, null, TardisUtil.EXPLOSION_BEHAVIOR, this.getPos(), 10, TardisUtil.doCreateFire(this.getWorld()),
                     World.ExplosionSourceType.TNT);
 
             travel.setCrashing(false);

--- a/src/main/java/dev/amble/ait/core/item/HammerItem.java
+++ b/src/main/java/dev/amble/ait/core/item/HammerItem.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.core.item;
 
+import dev.amble.ait.core.tardis.util.TardisUtil;
 import org.joml.Vector3f;
 
 import net.minecraft.block.BlockState;
@@ -44,13 +45,9 @@ public class HammerItem extends SwordItem {
 
     @Override
     public ActionResult useOnBlock(ItemUsageContext context) {
-
-
         BlockPos pos = context.getBlockPos();
         PlayerEntity player = context.getPlayer();
         ItemStack stack = context.getStack();
-
-
 
         if (!(context.getWorld() instanceof ServerWorld world))
             return ActionResult.SUCCESS;
@@ -102,7 +99,7 @@ public class HammerItem extends SwordItem {
                                     1),
                             pos.getX() + 0.5f, pos.getY() + 1.25, pos.getZ() + 0.5f, 5 * hammerUses, 0, 0, 0, 0.1f * hammerUses);
 
-                    world.createExplosion(null, world.getDamageSources().outOfWorld(), null, pos.toCenterPos(), 5, true,
+                    world.createExplosion(null, world.getDamageSources().outOfWorld(), TardisUtil.EXPLOSION_BEHAVIOR, pos.toCenterPos(), 5, TardisUtil.doCreateFire(world),
                             World.ExplosionSourceType.MOB);
 
                     tardis.loyalty().subLevel((ServerPlayerEntity) player, 50); // safe cast since its on server already

--- a/src/main/java/dev/amble/ait/core/tardis/handler/SelfDestructHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/SelfDestructHandler.java
@@ -58,7 +58,7 @@ public class SelfDestructHandler extends KeyedTardisComponent implements TardisT
         AITMod.LOGGER.warn("Tardis {} has self destructed, expect lag.", tardis.getUuid());
         world.getServer().executeSync(() -> ServerTardisManager.getInstance().remove(world.getServer(), tardis.asServer()));
 
-        world.createExplosion(null, pos.getX(), pos.getY(), pos.getZ(), 50, true,
+        world.createExplosion(null, null, TardisUtil.EXPLOSION_BEHAVIOR, pos.getX(), pos.getY(), pos.getZ(), 50, TardisUtil.doCreateFire(world),
                 World.ExplosionSourceType.MOB);
         world.spawnParticles(ParticleTypes.EXPLOSION_EMITTER, pos.getX(), pos.getY(), pos.getZ(), 10, 1, 1, 1, 1);
         world.spawnParticles(ParticleTypes.CLOUD, pos.getX(), pos.getY(), pos.getZ(), 100, 1, 1, 1, 1);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/CrashableTardisTravel.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/CrashableTardisTravel.java
@@ -67,8 +67,6 @@ public sealed interface CrashableTardisTravel permits TravelHandler {
         ServerWorld world = tardis.asServer().world();
 
         tardis.getDesktop().getConsolePos().forEach(console -> {
-            TardisDesktop.playSoundAtConsole(world, console, SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 3f, 1f);
-
             startCrashEffects(tardis, console);
         });
 
@@ -111,11 +109,6 @@ public sealed interface CrashableTardisTravel permits TravelHandler {
 
     default void startCrashEffects(Tardis tardis, BlockPos console) {
         ServerWorld world = tardis.asServer().world();
-
-        if (!world.getGameRules().getBoolean(AITMod.TARDIS_FIRE_GRIEFING))
-            return;
-
-        world.playSound(null, console, SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 3.0f, 1.0f);
-        world.playSound(null, console, SoundEvents.ENTITY_WITHER_HURT, SoundCategory.BLOCKS, 3.0f, 1.0f);
+        TardisDesktop.playSoundAtConsole(world, console, SoundEvents.ENTITY_GENERIC_EXPLODE, SoundCategory.BLOCKS, 3f, 1f);
     }
 }

--- a/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/TardisUtil.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedBlockPos;
+import dev.amble.lib.util.ServerLifecycleHooks;
 import dev.amble.lib.util.TeleportUtil;
 import dev.drtheo.scheduler.api.TimeUnit;
 import dev.drtheo.scheduler.api.common.Scheduler;
@@ -12,6 +13,11 @@ import dev.drtheo.scheduler.api.common.TaskStage;
 import it.unimi.dsi.fastutil.longs.LongBidirectionalIterator;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.util.TriState;
+import net.minecraft.block.BlockState;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.explosion.Explosion;
+import net.minecraft.world.explosion.ExplosionBehavior;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.entity.Entity;
@@ -63,6 +69,20 @@ public class TardisUtil {
     public static final Identifier FLYING_SPEED = AITMod.id("flying_speed");
     public static final Identifier TOGGLE_ANTIGRAVS = AITMod.id("toggle_antigravs");
     public static final Identifier FIND_PLAYER = AITMod.id("find_player");
+    public static final ExplosionBehavior EXPLOSION_BEHAVIOR = new ExplosionBehavior() {
+        @Override
+        public boolean canDestroyBlock(Explosion explosion, BlockView world, BlockPos pos, BlockState state, float power) {
+            MinecraftServer server = ServerLifecycleHooks.get();
+            if (server == null) return false;
+            if (!server.getGameRules().getBoolean(AITMod.TARDIS_GRIEFING)) return false;
+
+            return super.canDestroyBlock(explosion, world, pos, state, power);
+        }
+    };
+
+    public static boolean doCreateFire(World world) {
+        return world.getGameRules().getBoolean(AITMod.TARDIS_FIRE_GRIEFING);
+    }
 
     public static void init() {
         ServerPlayNetworking.registerGlobalReceiver(SNAP, (server, player, handler, buf, responseSender) -> {


### PR DESCRIPTION
## About the PR
Fixes the gamerules `tardisGriefing` and `tardisFireGriefing`.
If `tardisGriefing` is set to `true`, then explosions will destroy blocks, otherwise not.
If `tardisFireGriefing` is set to `true`, then explosions will also create fire (only if `tardisGriefing` is also true), otherwise not.

## Why / Balance
The gamerules were only doing something effective for a crashing TARDIS that was falling.
No other explosions (of *any* fires) were controlled by them.

## Technical details
I extracted the `ExplosionBehavior` from `FallingTardisEntity` and put it in `TardisUtil` so it can be used from one central location.
Then I added this ExplosionBEhavior to all other explosions.
Additionally I added a `doCreateFire` method to `TardisUtil` that checks the gamerule `tardisFireGriefing` and added a call to it to all the explosions as well.

<ins>**NOTE:**</ins>
I didn't touch the explosions of the "avoid debris" flight event (in [`SequenceRegistry`](https://github.com/amblelabs/ait/blob/main/src/main/java/dev/amble/ait/registry/impl/SequenceRegistry.java)), because those explosions only act as a damage-source to hurt the player (i.e. they are *never* meant to destroy blocks, regardless of gamerule).

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Gamerules did not control all explosions (and their fire creation)