### PR TITLE
fix crashing still allowing to land in locked dimensions

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -78,8 +78,8 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
             // Destination world locked, diverting TARDIS back to previous world (but preserving the destination coordinates).
             if (!LockedDimensionRegistry.getInstance().isUnlocked(tardis, travel.destination().getWorld())) {
-                CachedDirectedGlobalPos newCoordsButPreviousWorld = travel.destination().world(travel.previousPosition().getWorld());
-                travel.forceDestination(newCoordsButPreviousWorld);
+                CachedDirectedGlobalPos destinationCoordsButPreviousWorld = travel.destination().world(travel.previousPosition().getWorld());
+                travel.forceDestination(destinationCoordsButPreviousWorld);
             }
 
             return (TardisUtil.isInteriorEmpty(tardis) && !travel.leaveBehind().get()) || travel.autopilot() || travel.speed() == 0
@@ -456,7 +456,11 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
             return Optional.of(this.queueFor(State.LANDED));
         }
 
-        final CachedDirectedGlobalPos finalPos = result.value().orElse(initialPos);
+        // If the destination world is locked, crash in previous world.
+        boolean isDestinationUnlocked = LockedDimensionRegistry.getInstance().isUnlocked(this.tardis, this.destination().getWorld());
+        final CachedDirectedGlobalPos finalPos = isDestinationUnlocked
+                ? result.value().orElse(initialPos)
+                : this.tardis.travel().destination().world(this.tardis.travel().previousPosition().getWorld());
 
         this.setState(State.MAT);
         this.waiting = true;


### PR DESCRIPTION
## About the PR
I completely forgot about the crashing part in #1836 
So this PR fixes that, i.e. crashing will now definitely not allow landing in locked dimensions.

## Why / Balance
I previously only fixed it for landings with Ghost Monument disabled.
This will ensure that crashing only happens into unlocked dimensions.

## Technical details
Crashing will revert the destination world to the previous world before landing.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
I'm not adding a changelog here, because the changelog from #1836 already covers this PR.
(Unless there's a good reason to add it of course. Let me know!)