### PR TITLE
Fix the experimental warning being shown for release versions

### DIFF
--- a/src/main/java/dev/amble/ait/AITMod.java
+++ b/src/main/java/dev/amble/ait/AITMod.java
@@ -115,14 +115,14 @@ public class AITMod implements ModInitializer {
     public static final String BRANCH;
 
     static {
-        // ait-1.x.x.xxx-1.20.1-xxxx-xxxx
+        // ait-1.x.xx-BRANCH+mc.1.20.1
         String version = FabricLoader.getInstance().getModContainer(MOD_ID).get().getMetadata().getVersion().getFriendlyString();
-        // get the last part of the version string after the -
-        BRANCH = version.substring(version.lastIndexOf("-") + 1);
+        // get the part of the version string between the - and +
+        BRANCH = version.substring(version.lastIndexOf("-") + 1, version.lastIndexOf("+"));
     }
 
     public static boolean isUnsafeBranch() {
-        return !BRANCH.equals("release");
+        return !BRANCH.contains("release");
     }
 
     public void registerParticles() {


### PR DESCRIPTION
## About the PR
Do not show the experimental release warning (the red writing at the top in the main menu) for release versions.

## Why / Balance
It's only supposed to be shown for non-release versions (testbuilds, betas, etc.).

## Technical details
Previously, the mod tested if the branch part of the string *equals* `"release"`, but the release version string ends with `"release+mc.1.20.1"` which is not equal to `"release"`.
To fix this I did two things:
- determine the branch name not just by looking at everything after the first "-", but also stop before the first "+".  
So for `"ait-1.2.12-release+mc.1.20.1"` it would return `"release"`.
- Change the check from an `equals` to a `contains`, to make it more robust if other changes happen to the string in the future.  
Because I assume if the version string contains `"release"` anywhere, then it's a release version.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: the experimental warning was shown for release versions