### PR TITLE
fix waterlogged not being removed from all doors

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/DoorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/DoorBlockEntity.java
@@ -61,7 +61,7 @@ public class DoorBlockEntity extends InteriorLinkableBlockEntity {
 
         Tardis tardis = door.tardis().get();
 
-        if (tardis.areShieldsActive() || world.getServer().getTicks() % 20 != 0)
+        if (world.getServer().getTicks() % 20 != 0)
             return;
 
         CachedDirectedGlobalPos globalExteriorPos = tardis.travel().position();
@@ -75,12 +75,15 @@ public class DoorBlockEntity extends InteriorLinkableBlockEntity {
         if (exteriorWorld == null)
             return;
 
+        if (!tardis.door().isOpen() || tardis.areShieldsActive()) {
+            world.setBlockState(pos, blockState.with(Properties.WATERLOGGED, false),
+                Block.NOTIFY_ALL | Block.REDRAW_ON_MAIN_THREAD);
+            return;
+        }
+
         if (blockState.get(Properties.WATERLOGGED) && world.getRandom().nextBoolean()) {
             serverWorld.getPlayers().forEach(player -> tardis.loyalty().subLevel(player, 2));
         }
-
-        if (!tardis.door().isOpen())
-            return;
 
         ChunkPos exteriorChunkPos = new ChunkPos(exteriorPos);
         Chunk exteriorChunk = exteriorWorld.getChunk(exteriorChunkPos.x, exteriorChunkPos.z, ChunkStatus.EMPTY, false);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -4,8 +4,6 @@ import dev.amble.lib.data.DirectedBlockPos;
 import net.fabricmc.fabric.api.util.TriState;
 import org.jetbrains.annotations.Nullable;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
 import net.minecraft.particle.ParticleEffect;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -13,7 +11,6 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
-import net.minecraft.state.property.Properties;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
@@ -24,8 +21,6 @@ import dev.amble.ait.api.tardis.TardisTickable;
 import dev.amble.ait.core.AITDimensions;
 import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.core.blockentities.DoorBlockEntity;
-import dev.amble.ait.core.blocks.DoorBlock;
-import dev.amble.ait.core.tardis.Tardis;
 import dev.amble.ait.core.tardis.handler.travel.TravelHandlerBase;
 import dev.amble.ait.core.tardis.util.TardisUtil;
 import dev.amble.ait.data.Exclude;
@@ -242,17 +237,6 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
         this.setDoorState(DoorState.CLOSED);
     }
 
-    public static void removeWaterlogged(Tardis tardis) {
-        BlockPos pos = tardis.getDesktop().getDoorPos().getPos();
-        ServerWorld world = tardis.asServer().world();
-        BlockState blockState = world.getBlockState(pos);
-
-        if (!(blockState.getBlock() instanceof DoorBlock)) return;
-
-        world.setBlockState(pos, blockState.with(Properties.WATERLOGGED, false),
-                Block.NOTIFY_ALL | Block.REDRAW_ON_MAIN_THREAD);
-    }
-
     private void setDoorState(DoorState newState) {
         if (this.locked() && newState != DoorState.CLOSED)
             return;
@@ -266,7 +250,6 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
                 TardisEvents.DOOR_OPEN.invoker().onOpen(tardis());
 
             if (newState == DoorState.CLOSED) {
-                removeWaterlogged(this.tardis);
                 TardisEvents.DOOR_CLOSE.invoker().onClose(tardis());
             }
         }

--- a/src/main/java/dev/amble/ait/core/tardis/handler/ShieldHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/ShieldHandler.java
@@ -56,7 +56,6 @@ public class ShieldHandler extends KeyedTardisComponent implements TardisTickabl
 
     public void enable() {
         this.shielded().set(true);
-        DoorHandler.removeWaterlogged(this.tardis);
         TardisEvents.TOGGLE_SHIELDS.invoker().onShields(this.tardis, true, this.visuallyShielded().get());
     }
 


### PR DESCRIPTION
## About the PR
It removes the waterlogged status from *all* interior doors instead of just from the last placed/interacted door.

## Why / Balance
In #1738 I only removed the state from the last placed/interacted door, which will leave all other doors waterlogged and continue to reduce loyalty, even when the doors were closed or the shields activated.
But in that case *all* the doors should no longer be waterlogged.

## Technical details
I moved the removal logic for the waterlogged status from the door handler to the doors themselves.
This way we don't need to save the positions for all the doors and can just let each door handle their own waterlogged status based on whether it is closed or the shields are active.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: When an interior door was closed or the shields activated, only the last placed/interacted door would no longer be waterlogged, all the others would remain waterlogged (and continue to reduce loyalty).