### PR TITLE
fix: breaking the engine and setting tardis power to true will no longer make the engine loop sound

### DIFF
--- a/src/main/java/dev/amble/ait/client/sounds/engine/EngineLoopSound.java
+++ b/src/main/java/dev/amble/ait/client/sounds/engine/EngineLoopSound.java
@@ -11,8 +11,6 @@ import dev.amble.ait.client.util.ClientTardisUtil;
 import dev.amble.ait.core.AITSounds;
 import net.minecraft.world.World;
 
-import java.util.UUID;
-
 public class EngineLoopSound extends PositionedLoopingSound {
     private int ticks = 0;
 

--- a/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/EngineBlockEntity.java
@@ -24,9 +24,6 @@ import dev.amble.ait.core.engine.link.IFluidSource;
 import dev.amble.ait.core.engine.link.ITardisSource;
 import dev.amble.ait.core.tardis.Tardis;
 
-import java.util.HashMap;
-import java.util.UUID;
-
 public class EngineBlockEntity extends SubSystemBlockEntity implements ITardisSource {
     public EngineBlockEntity(BlockPos pos, BlockState state) {
         super(AITBlockEntityTypes.ENGINE_BLOCK_ENTITY_TYPE, pos, state, SubSystem.Id.ENGINE);


### PR DESCRIPTION
## About the PR
engine loop sound bug, if you broke the engine and ran this command /ait data ~ FUEL power set true. the engine loop sound would still appear where the engine was last placed, i fixed this in this pr
## Why / Balance
idfk how this would effect anyone but piano and jelly wanted it fixed i think?

## Technical details
new method in engineblockentity to check if an engine exists

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- fix: breaking the engine and setting tardis power to true will no longer make the engine loop sound