### PR TITLE
Clamp destination position to safe distance from worldborder

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
@@ -198,10 +198,11 @@ public abstract class TravelHandlerBase extends KeyedTardisComponent implements 
 
         cached.init(TravelHandlerBase.server());
 
-        WorldBorder border = cached.getWorld().getWorldBorder();
         BlockPos pos = cached.getPos();
+        WorldBorder targetBorder = new WorldBorder();
+        targetBorder.setSize(cached.getWorld().getWorldBorder().getSize() - 3);
 
-        cached = border.contains(pos) ? cached : cached.pos(border.clamp(pos.getX(), pos.getY(), pos.getZ()));
+        cached = targetBorder.contains(pos) ? cached : cached.pos(targetBorder.clamp(pos.getX(), pos.getY(), pos.getZ()));
 
         // TODO what is the point of this? the only time this should be done is on landing - unless it gets optimized enough to run here. - Loqor
         //cached = WorldUtil.locateSafe(cached, this.vGroundSearch.get(), this.hGroundSearch.get());


### PR DESCRIPTION
## About the PR
Clamps the destination position to a safe distance from the worldborder.

## Why / Balance
This is to prevent the TARDIS doorway from being blocked by the worldborder and allow entry from all sides.

## Technical details
Before clamping I create a worldborder instance with a slightly smaller radius, so that the resulting position is a bit removed from the worldborder.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Travel destinations could have the TARDIS exterior doorway be facing too close to the worldborder, preventing (re-)entry.