### PR TITLE
Fix duping of waypoint cartridges via console port

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/waypoint/LoadWaypointControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/waypoint/LoadWaypointControl.java
@@ -25,9 +25,13 @@ public class LoadWaypointControl extends Control {
     public Result runServer(Tardis tardis, ServerPlayerEntity player, ServerWorld world, BlockPos console, boolean leftClick) {
         super.runServer(tardis, player, world, console, leftClick);
 
+        if (!tardis.waypoint().hasCartridge()) {
+            player.sendMessage(Text.translatable("control.ait.load_waypoint.no_cartridge"), true);
+            TardisDesktop.playSoundAtConsole(world, console, SoundEvents.BLOCK_NOTE_BLOCK_BIT.value(), SoundCategory.PLAYERS, 6f, 0.1f);
+            return Result.SUCCESS;
+        }
+
         WaypointHandler waypoints = tardis.waypoint();
-
-
 
         if (waypoints.loadWaypoint()) {
             TardisDesktop.playSoundAtConsole(world, console, AITSounds.NAV_NOTIFICATION, SoundCategory.PLAYERS, 6f, 1);
@@ -35,9 +39,6 @@ public class LoadWaypointControl extends Control {
             player.sendMessage(Text.translatable("control.ait.load_waypoint.error"), true);
             TardisDesktop.playSoundAtConsole(world, console, SoundEvents.BLOCK_NOTE_BLOCK_BIT.value(), SoundCategory.PLAYERS, 6f, 0.1f);
         }
-
-
-        //waypoints.spawnItem(console);
 
         return Result.SUCCESS;
     }

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/waypoint/SaveWaypointControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/waypoint/SaveWaypointControl.java
@@ -6,6 +6,8 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.Text;
 import net.minecraft.util.math.BlockPos;
 
 import dev.amble.ait.AITMod;
@@ -24,6 +26,14 @@ public class SaveWaypointControl extends Control {
 
     @Override
     public Result runServer(Tardis tardis, ServerPlayerEntity player, ServerWorld world, BlockPos console, boolean leftClick) {
+        super.runServer(tardis, player, world, console, leftClick);
+
+        if (!tardis.waypoint().hasCartridge()) {
+            player.sendMessage(Text.translatable("control.ait.load_waypoint.no_cartridge"), true);
+            TardisDesktop.playSoundAtConsole(world, console, SoundEvents.BLOCK_NOTE_BLOCK_BIT.value(), SoundCategory.PLAYERS, 6f, 0.1f);
+            return Result.SUCCESS;
+        }
+
         CachedDirectedGlobalPos cached = tardis.travel().position();
         if (cached.getWorld() instanceof TardisServerWorld) {
             cached = CachedDirectedGlobalPos.create(TardisServerWorld.OVERWORLD, cached.getPos(), cached.getRotation());

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -794,6 +794,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("control.ait.save_waypoint", "Save Waypoint");
         provider.addTranslation("control.ait.load_waypoint", "Load Waypoint");
         provider.addTranslation("control.ait.load_waypoint.error", "Cartridge contains no waypoint");
+        provider.addTranslation("control.ait.load_waypoint.no_cartridge", "No cartridge in port");
         provider.addTranslation("control.ait.increment", "Increment");
         provider.addTranslation("control.ait.x", "X");
         provider.addTranslation("control.ait.y", "Y");


### PR DESCRIPTION
## About the PR
Putting a cartridge into the console port *after* pressing the save waypoint button would automatically eject a written waypoint cartridge while leaving in the empt one, effectively allowing cartridge duping.

This PR fixes this, as well as displaying an info message to the player when there is no cartridge in the port.


## Why / Balance
Because we don't want any item duping to happen.

## Technical details
I added a check for a cartridge to be in the port (for both the save and load buttons).
If there isn't one in the port, it returns and displays a message.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Waypoint cartridges could be duped when saving a waypoint before putting a cartridge in.