### PR TITLE
Fix structure search cost of telepathic circuits

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/TelepathicControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/TelepathicControl.java
@@ -306,7 +306,7 @@ public class TelepathicControl extends Control {
             BlockPos newPos = pos != null ? pos.getFirst() : null;
             if (newPos != null) {
                 tardis.travel().forceDestination(cached -> cached.pos(newPos.withY(75)));
-                tardis.removeFuel(500 * tardis.travel().getHammerUses());
+                tardis.removeFuel(500 * tardis.travel().instability());
                 player.sendMessage(Text.translatable("tardis.message.control.telepathic.success"), true);
             } else {
                 player.sendMessage(Text.translatable("tardis.message.control.telepathic.failed"), true);


### PR DESCRIPTION
## About the PR
Fixes the cost when searching for structures in the Nether or the End via the Telepathic Circuits.

When the mallet was not used yet, then searching for structures in the Nether or the End via the telepathic circuits is for free, while it is not for free when searching them in the Overworld.

## Why / Balance
There should be no difference in cost between searches in the Nether/End and Overworld.

## Technical details
I replaced the hammer uses factor of the cost with the instability factor.
Just like it is done in the structure search for the Overworld.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Structure searches via the Telepathic Circuits for the Nether and the End did not cost any Artron (when the console had not been hit yet with the mallet).