### PR TITLE
Fix exterior variant portal

### DIFF
--- a/src/main/java/dev/amble/ait/data/datapack/DatapackExterior.java
+++ b/src/main/java/dev/amble/ait/data/datapack/DatapackExterior.java
@@ -60,7 +60,7 @@ public class DatapackExterior extends ExteriorVariantSchema implements AnimatedD
                     Codec.BOOL.optionalFieldOf("has_transparent_doors", false).forGetter(DatapackExterior::hasTransparentDoors),
                     Identifier.CODEC.optionalFieldOf("model").forGetter(DatapackExterior::model),
                     Identifier.CODEC.optionalFieldOf("door").forGetter(DatapackExterior::getDoorId),
-                    PortalOffsets.CODEC.optionalFieldOf("portal_info", new PortalOffsets(1, 2)).forGetter(DatapackExterior::getPortalOffsets),
+                    PortalOffsets.CODEC.optionalFieldOf("portal_info").forGetter(DatapackExterior::portalOffsets),
                     BedrockAnimationReference.CODEC.optionalFieldOf("left_animation").forGetter(DatapackExterior::getLeftAnimation),
                     BedrockAnimationReference.CODEC.optionalFieldOf("right_animation").forGetter(DatapackExterior::getRightAnimation),
                     Vec3d.CODEC.optionalFieldOf("scale", new Vec3d(1, 1, 1)).forGetter(DatapackExterior::getScale),
@@ -72,7 +72,7 @@ public class DatapackExterior extends ExteriorVariantSchema implements AnimatedD
     protected final TravelAnimationMap animations;
 
     public DatapackExterior(Identifier id, Identifier category, Identifier parent, Identifier texture,
-                            Identifier emission, Optional<Loyalty> loyalty, BiomeOverrides overrides, Vec3d seatTranslations, boolean hasTransparentDoors, Optional<Identifier> model, Optional<Identifier> door, PortalOffsets offsets, Optional<BedrockAnimationReference> leftAnimation, Optional<BedrockAnimationReference> rightAnimation, Vec3d scale, TravelAnimationMap animations) {
+                            Identifier emission, Optional<Loyalty> loyalty, BiomeOverrides overrides, Vec3d seatTranslations, boolean hasTransparentDoors, Optional<Identifier> model, Optional<Identifier> door, Optional<PortalOffsets> offsets, Optional<BedrockAnimationReference> leftAnimation, Optional<BedrockAnimationReference> rightAnimation, Vec3d scale, TravelAnimationMap animations) {
         super(category, id, loyalty);
         this.parent = parent;
         this.texture = texture;
@@ -83,7 +83,7 @@ public class DatapackExterior extends ExteriorVariantSchema implements AnimatedD
         this.overrides = overrides;
         this.model = model.orElse(null);
         this.doorId = door.orElse(null);
-        this.portalOffsets = offsets;
+        this.portalOffsets = offsets.orElse(null);
         this.leftAnimation = leftAnimation.orElse(null);
         this.rightAnimation = rightAnimation.orElse(null);
         this.scale = scale;
@@ -197,6 +197,10 @@ public class DatapackExterior extends ExteriorVariantSchema implements AnimatedD
      */
     public Optional<Identifier> model() {
         return Optional.ofNullable(this.model);
+    }
+
+    public Optional<PortalOffsets> portalOffsets() {
+        return Optional.ofNullable(this.portalOffsets);
     }
 
     public PortalOffsets getPortalOffsets() {


### PR DESCRIPTION
## About the PR
This PR closes #1823.

## Technical details
Apparently, a default value was assigned to the value, making it not try to get the parent's portal offset.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: portal rendering should be fixed now