### PR TITLE
fix drink client crash

### DIFF
--- a/src/main/java/dev/amble/ait/core/drinks/DrinkUtil.java
+++ b/src/main/java/dev/amble/ait/core/drinks/DrinkUtil.java
@@ -48,6 +48,10 @@ public class DrinkUtil {
 
     public static List<StatusEffectInstance> getDrinkEffects(NbtCompound nbt) {
         ArrayList<StatusEffectInstance> list = Lists.newArrayList();
+        Drink drink = DrinkUtil.getDrink(nbt);
+
+        if (drink == null) return list;
+
         list.addAll(DrinkUtil.getDrink(nbt).getEffects());
         DrinkUtil.getCustomDrinkEffects(nbt, list);
         return list;

--- a/src/main/java/dev/amble/ait/core/drinks/DrinkUtil.java
+++ b/src/main/java/dev/amble/ait/core/drinks/DrinkUtil.java
@@ -85,7 +85,7 @@ public class DrinkUtil {
             return nbtCompound.getInt(CUSTOM_DRINK_COLOR_KEY);
         }
         Drink drink = DrinkUtil.getDrink(stack);
-        return Objects.equals(drink, EMPTY) ? DEFAULT_COLOR : DrinkUtil.getColor(drink, DrinkUtil.getDrinkEffects(stack));
+        return drink == null || Objects.equals(drink, EMPTY) ? DEFAULT_COLOR : DrinkUtil.getColor(drink, DrinkUtil.getDrinkEffects(stack));
     }
 
     public static int getColor(Drink drink, Collection<StatusEffectInstance> effects) {

--- a/src/main/java/dev/amble/ait/core/item/DrinkItem.java
+++ b/src/main/java/dev/amble/ait/core/item/DrinkItem.java
@@ -79,7 +79,7 @@ public class DrinkItem extends Item {
                 return new ItemStack(AITItems.MUG);
             }
             if (playerEntity != null) {
-                playerEntity.getInventory().insertStack(new ItemStack(AITItems.MUG));
+                playerEntity.getInventory().insertStack(this.getDefaultStack());
             }
         }
         user.emitGameEvent(GameEvent.DRINK);

--- a/src/main/java/dev/amble/ait/core/item/DrinkItem.java
+++ b/src/main/java/dev/amble/ait/core/item/DrinkItem.java
@@ -76,7 +76,7 @@ public class DrinkItem extends Item {
         }
         if (playerEntity == null || !playerEntity.getAbilities().creativeMode) {
             if (stack.isEmpty()) {
-                return new ItemStack(AITItems.MUG);
+                return this.getDefaultStack();
             }
             if (playerEntity != null) {
                 playerEntity.getInventory().insertStack(this.getDefaultStack());


### PR DESCRIPTION
## About the PR
This PR fixes the drink client crash.

## Technical details
_Someone_ forgot a null check for the drink, resulting in the rendering code trying to get a color of a non existent drink.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: drinks no longer crash people
- fix: you cant drink air anymore