### PR TITLE
add fail notification for '/ait this' command

### DIFF
--- a/src/main/java/dev/amble/ait/core/commands/ThisTardisCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/ThisTardisCommand.java
@@ -36,8 +36,15 @@ public class ThisTardisCommand {
             try {
                 UUID id = LinkableItem.getTardisIdStatic(stack);
 
-                player.sendMessage(Text.translatable("message.ait.id").append(TextUtil.forTardis(id)));
-            } catch (IllegalArgumentException ignored) { }
+                if (id == null || id.toString().isEmpty()) {
+                    // Since an IllegalArgumentException is automatically thrown when the held item is not linkable,
+                    // we want to show the same error message when a held linkable item is not linked.
+                    throw new IllegalArgumentException();
+                } else
+                    player.sendMessage(Text.translatable("message.ait.id").append(TextUtil.forTardis(id)));
+            } catch (IllegalArgumentException ignored) {
+                player.sendMessage(Text.translatable("command.ait.this.not_found"));
+            }
         }
 
         return Command.SINGLE_SUCCESS;

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1469,6 +1469,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
                 "Can't get value of a property named %s, because component %s is not keyed!");
         provider.addTranslation("command.ait.list.tardises", "TARDISes");
         provider.addTranslation("command.ait.list.pattern.error", "Bad pattern '%s'!");
+        provider.addTranslation("command.ait.this.not_found", "Not in TARDIS interior, or no linked item.");
 
         // Rift Chunk Tracking
         provider.addTranslation("riftchunk.ait.tracking", "Rift Tracking");


### PR DESCRIPTION
## About the PR
Adds a fail message for the `this` command.
When the player is ...
... not in a TARDIS
... and doesn't hold a linkable item or the linkable item is not linked
then an informative message is displayed.

## Why / Balance
Previously it just didn't output anything under the mentioned conditions.
For better UX an informative message makes sense.

## Technical details
There's not much to it, I added a message (via a translatable string).

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- add: Fail notification for `/ait this` command