### PR TITLE
fix bookshelf exterior BOTI

### DIFF
--- a/src/main/java/dev/amble/ait/client/models/exteriors/BookshelfExteriorModel.java
+++ b/src/main/java/dev/amble/ait/client/models/exteriors/BookshelfExteriorModel.java
@@ -6,6 +6,7 @@ import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.Entity;
+import net.minecraft.util.math.RotationAxis;
 
 import dev.amble.ait.api.tardis.link.v2.Linkable;
 import dev.amble.ait.client.AITModClient;
@@ -205,7 +206,8 @@ public class BookshelfExteriorModel extends SimpleExteriorModel {
       if (isBOTI) {
           matrices.push();
             matrices.scale(1F, 1F, 1F);
-           matrices.translate(0.04, -1.26f, -0.36);
+           matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180f));
+           matrices.translate(0.04f, -1.28f, -0.10f);
            this.bookshelf.getChild("left_door").render(matrices, vertices, light, overlay, red, green, blue, pAlpha);
            this.bookshelf.getChild("right_door").render(matrices, vertices, light, overlay, red, green, blue, pAlpha);
             matrices.pop();


### PR DESCRIPTION
## About the PR
Fixes the bookshelf BOTI for the exterior.

## Why / Balance
Because it was rotated so that opening the left door showed the BOTI's right door opening and vice versa.

## Technical details
I rotated it by 180 degrees and moved it into the right place to fit snugly with the exterior doors.

## Media
https://github.com/user-attachments/assets/76f37be5-9585-446e-b4c1-b6130b3a97b6

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- fix: Bookshelf exterior BOTI showed the doors rotated by 180 degrees and floating.