### PR TITLE
feat: add an off option to the hum swticher that will technically disable the tardis hum sound (intentionally empty)

### DIFF
--- a/src/main/java/dev/amble/ait/registry/impl/HumRegistry.java
+++ b/src/main/java/dev/amble/ait/registry/impl/HumRegistry.java
@@ -12,6 +12,7 @@ import dev.amble.ait.client.sounds.ClientSoundManager;
 import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.data.hum.DatapackHum;
 import dev.amble.ait.data.hum.Hum;
+import net.minecraft.sound.SoundEvents;
 
 public class HumRegistry extends SimpleDatapackRegistry<Hum> {
     private static final HumRegistry instance = new HumRegistry();
@@ -26,6 +27,7 @@ public class HumRegistry extends SimpleDatapackRegistry<Hum> {
 
     public static Hum CORAL;
     public static Hum CHRISTMAS;
+    public static Hum OFF;
 
     @Override
     public void onCommonInit() {
@@ -38,6 +40,7 @@ public class HumRegistry extends SimpleDatapackRegistry<Hum> {
     protected void defaults() {
         CORAL = register(Hum.create(AITMod.MOD_ID, "coral", AITSounds.CORAL_HUM));
         CHRISTMAS = register(Hum.create(AITMod.MOD_ID, "christmas", AITSounds.CHRISTMAS_HUM));
+        OFF = register(Hum.create(AITMod.MOD_ID, "off", SoundEvents.INTENTIONALLY_EMPTY));
     }
 
     @Override


### PR DESCRIPTION
## About the PR

feat: add an off option to the hum swticher that will technically disable the tardis hum sound (intentionally empty)

## Why / Balance
https://discord.com/channels/1213989169878274068/1418313509275570369

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**

:cl:
- add: off option to hum switcher