### PR TITLE
restore NONE for vertical search and disable falling directly instead

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/RealFlightHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/RealFlightHandler.java
@@ -95,6 +95,7 @@ public class RealFlightHandler extends KeyedTardisComponent implements TardisTic
     }
 
     public void onStartFalling(ServerWorld world, BlockState state, BlockPos pos) {
+        if (true) return;   //FIXME: remove this line after the exterior falling issues are resolved :(
         this.falling.set(true);
         TardisEvents.START_FALLING.invoker().onStartFall(tardis);
 

--- a/src/main/java/dev/amble/ait/core/util/SafePosSearch.java
+++ b/src/main/java/dev/amble/ait/core/util/SafePosSearch.java
@@ -344,7 +344,7 @@ public class SafePosSearch {
         MEDIAN {
             @Override
             public Kind next() {
-                return FLOOR; // NONE; FIXME: exterior falling issues :(
+                return NONE;
             }
         };
 


### PR DESCRIPTION
## About the PR
Restore landing (and hovering) in air, but keep falling disabled.

Since this is only changing a temporary hotfix to another temporary hotfix, I don't add a changelog.

## Why / Balance
NONE is temporarily disabled as an option due to issues with falling TARDISes.
This restores the option again and instead makes TARDISes not fall, so that the TARDIS can still be landed in the air.

## Technical details
`NONE` is restored for vertical search.
On falling, I just return instead of processing the fall.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
:nocl: