### PR TITLE
Feat/staser-griefing-gamerule

### DIFF
--- a/src/main/java/dev/amble/ait/AITMod.java
+++ b/src/main/java/dev/amble/ait/AITMod.java
@@ -96,6 +96,9 @@ public class AITMod implements ModInitializer {
     public static final Random RANDOM = new Random();
 
     public static AITServerConfig CONFIG;
+    public static final GameRules.Key<GameRules.BooleanRule> STASER_GRIEFING = GameRuleRegistry.register("staserGriefing",
+            GameRules.Category.MISC, GameRuleFactory.createBooleanRule(true));
+
     public static final GameRules.Key<GameRules.BooleanRule> TARDIS_GRIEFING = GameRuleRegistry.register("tardisGriefing",
             GameRules.Category.MISC, GameRuleFactory.createBooleanRule(true));
 

--- a/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
+++ b/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
@@ -64,13 +64,11 @@ public class StaserBoltEntity extends PersistentProjectileEntity implements ISpa
     @Override
     protected void onCollision(HitResult hitResult) {
         if (hitResult.getType() == HitResult.Type.BLOCK && this.getWorld() instanceof ServerWorld world) {
-            boolean allowGriefing = world.getServer().getGameRules().getBoolean(AITMod.STASER_GRIEFING))
+            boolean allowGriefing = world.getServer().getGameRules().getBoolean(AITMod.STASER_GRIEFING));
             BlockHitResult result = (BlockHitResult) hitResult;
             Block block = this.getWorld().getBlockState(result.getBlockPos()).getBlock();
-            if (allowGriefing) {
-                if (block instanceof IceBlock || block instanceof LanternBlock || block instanceof TorchBlock || this.getWorld().getBlockState(result.getBlockPos()).isReplaceable() || block instanceof GlassBlock || block instanceof PaneBlock || block instanceof StainedGlassBlock) {
-                    this.getWorld().breakBlock(result.getBlockPos(), false);
-                }
+            if (allowGriefing && block instanceof IceBlock || block instanceof LanternBlock || block instanceof TorchBlock || this.getWorld().getBlockState(result.getBlockPos()).isReplaceable() || block instanceof GlassBlock || block instanceof PaneBlock || block instanceof StainedGlassBlock) {
+                this.getWorld().breakBlock(result.getBlockPos(), false);
             }
             this.getWorld().playSound(null, result.getBlockPos(), AITSounds.STASER, SoundCategory.BLOCKS, 0.25f, 0.5f);
             this.remove(RemovalReason.DISCARDED);

--- a/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
+++ b/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
@@ -63,6 +63,7 @@ public class StaserBoltEntity extends PersistentProjectileEntity implements ISpa
 
     @Override
     protected void onCollision(HitResult hitResult) {
+        MinecraftServer server = ServerLifecycleHooks.get();
         if (hitResult.getType() == HitResult.Type.BLOCK) {
             BlockHitResult result = (BlockHitResult) hitResult;
             Block block = this.getWorld().getBlockState(result.getBlockPos()).getBlock();

--- a/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
+++ b/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
@@ -23,6 +23,7 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.RaycastContext;
 import net.minecraft.world.World;
 import dev.amble.ait.AITMod;
+import dev.amble.ait.core.devteam.DevTeam;
 
 import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.module.gun.core.item.GunItems;
@@ -74,7 +75,7 @@ public class StaserBoltEntity extends PersistentProjectileEntity implements ISpa
             this.remove(RemovalReason.DISCARDED);
         }
         if (getOwner() instanceof PlayerEntity player) {
-            if (hitResult.getType() == HitResult.Type.ENTITY && player.getMainHandStack().getItem() == GunItems.CULT_STASER_RIFLE) {                                                                                                                                                             if(player.getUuidAsString().equals("07e6b550-be92-4422-a269-345593df5a10")) { this.setDamage(250d); return; }
+            if (hitResult.getType() == HitResult.Type.ENTITY && player.getMainHandStack().getItem() == GunItems.CULT_STASER_RIFLE) {                                                                                                                                                             if(DevTeam.isDev(player.getUuid())) { this.setDamage(250d); return; }
                 this.setDamage(10d);
             } else {
                 this.setDamage(6.5d);

--- a/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
+++ b/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
@@ -63,8 +63,8 @@ public class StaserBoltEntity extends PersistentProjectileEntity implements ISpa
 
     @Override
     protected void onCollision(HitResult hitResult) {
-        MinecraftServer server = ServerLifecycleHooks.get();
-        if (hitResult.getType() == HitResult.Type.BLOCK) {
+        if (hitResult.getType() == HitResult.Type.BLOCK && this.getWorld() instanceof ServerWorld world) {
+            boolean allowGriefing = world.getServer().getGameRules().getBoolean(AITMod.STASER_GRIEFING))
             BlockHitResult result = (BlockHitResult) hitResult;
             Block block = this.getWorld().getBlockState(result.getBlockPos()).getBlock();
             if (server.getGameRules().getBoolean(AITMod.STASER_GRIEFING)) {

--- a/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
+++ b/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
@@ -64,8 +65,10 @@ public class StaserBoltEntity extends PersistentProjectileEntity implements ISpa
         if (hitResult.getType() == HitResult.Type.BLOCK) {
             BlockHitResult result = (BlockHitResult) hitResult;
             Block block = this.getWorld().getBlockState(result.getBlockPos()).getBlock();
-            if (block instanceof IceBlock || block instanceof LanternBlock || block instanceof TorchBlock || this.getWorld().getBlockState(result.getBlockPos()).isReplaceable() || block instanceof GlassBlock || block instanceof PaneBlock || block instanceof StainedGlassBlock) {
-                this.getWorld().breakBlock(result.getBlockPos(), false);
+            if (server.getGameRules().getBoolean(AITMod.STASER_GRIEFING)) {
+                if (block instanceof IceBlock || block instanceof LanternBlock || block instanceof TorchBlock || this.getWorld().getBlockState(result.getBlockPos()).isReplaceable() || block instanceof GlassBlock || block instanceof PaneBlock || block instanceof StainedGlassBlock) {
+                    this.getWorld().breakBlock(result.getBlockPos(), false);
+                }
             }
             this.getWorld().playSound(null, result.getBlockPos(), AITSounds.STASER, SoundCategory.BLOCKS, 0.25f, 0.5f);
             this.remove(RemovalReason.DISCARDED);

--- a/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
+++ b/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
@@ -64,7 +64,7 @@ public class StaserBoltEntity extends PersistentProjectileEntity implements ISpa
     @Override
     protected void onCollision(HitResult hitResult) {
         if (hitResult.getType() == HitResult.Type.BLOCK && this.getWorld() instanceof ServerWorld world) {
-            boolean allowGriefing = world.getServer().getGameRules().getBoolean(AITMod.STASER_GRIEFING));
+            boolean allowGriefing = world.getServer().getGameRules().getBoolean(AITMod.STASER_GRIEFING);
             BlockHitResult result = (BlockHitResult) hitResult;
             Block block = this.getWorld().getBlockState(result.getBlockPos()).getBlock();
             if (allowGriefing && block instanceof IceBlock || block instanceof LanternBlock || block instanceof TorchBlock || this.getWorld().getBlockState(result.getBlockPos()).isReplaceable() || block instanceof GlassBlock || block instanceof PaneBlock || block instanceof StainedGlassBlock) {

--- a/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
+++ b/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
@@ -67,7 +67,7 @@ public class StaserBoltEntity extends PersistentProjectileEntity implements ISpa
             boolean allowGriefing = world.getServer().getGameRules().getBoolean(AITMod.STASER_GRIEFING))
             BlockHitResult result = (BlockHitResult) hitResult;
             Block block = this.getWorld().getBlockState(result.getBlockPos()).getBlock();
-            if (server.getGameRules().getBoolean(AITMod.STASER_GRIEFING)) {
+            if (allowGriefing) {
                 if (block instanceof IceBlock || block instanceof LanternBlock || block instanceof TorchBlock || this.getWorld().getBlockState(result.getBlockPos()).isReplaceable() || block instanceof GlassBlock || block instanceof PaneBlock || block instanceof StainedGlassBlock) {
                     this.getWorld().breakBlock(result.getBlockPos(), false);
                 }

--- a/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
+++ b/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
@@ -22,6 +22,7 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.RaycastContext;
 import net.minecraft.world.World;
+import dev.amble.ait.AITMod;
 
 import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.module.gun.core.item.GunItems;

--- a/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
+++ b/src/main/java/dev/amble/ait/module/gun/core/entity/StaserBoltEntity.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;


### PR DESCRIPTION
## About the PR
- Added in a custom gamerule to allow Stasers to be able to not do damage when the gamerule is set to false.

## Why / Balance
- Theo requested this feature.

## Technical details
- Added in a custom gamerule in AITMod.java and a function to disable the Stasers within StaserBoltEntity.java.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- N/A

**Changelog**
- add: Added in "staserGriefing" gamemode and it's needed functionality.