### PR TITLE
fix: tardises can now properly grow in any dimension properly even if they're locked

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -3,7 +3,6 @@ package dev.amble.ait.core.tardis.handler;
 import java.util.ArrayList;
 import java.util.List;
 
-import dev.amble.ait.core.advancement.TardisCriterions;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.data.DirectedBlockPos;
 import dev.amble.lib.data.DirectedGlobalPos;
@@ -38,8 +37,11 @@ import dev.amble.ait.api.tardis.TardisEvents;
 import dev.amble.ait.api.tardis.TardisTickable;
 import dev.amble.ait.core.AITDamageTypes;
 import dev.amble.ait.core.AITItems;
+import dev.amble.ait.core.advancement.TardisCriterions;
 import dev.amble.ait.core.blockentities.ConsoleBlockEntity;
 import dev.amble.ait.core.engine.SubSystem;
+import dev.amble.ait.core.lock.LockedDimension;
+import dev.amble.ait.core.lock.LockedDimensionRegistry;
 import dev.amble.ait.core.tardis.handler.travel.TravelHandler;
 import dev.amble.ait.core.tardis.manager.ServerTardisManager;
 import dev.amble.ait.core.tardis.util.TardisUtil;
@@ -233,6 +235,11 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
                         TravelHandler travel = tardis.travel();
 
                         travel.autopilot(true);
+                        // To fix landing error when you grow a TARDIS in a different dimension. - Loqor
+                        LockedDimension worldID = LockedDimensionRegistry.getInstance().get(travel.position().getDimension().getRegistry());
+                        if (worldID != null) {
+                            tardis.stats().unlock(worldID);
+                        }
                         travel.forceDemat();
                         this.replaceAllConsolesWithGrowth();
                     } else {


### PR DESCRIPTION
## About the PR
Made the TARDIS auto-unlock a dimension if its grown there.

## Why / Balance
To 1. fix issues when growing TARDIS' in other dimensions if locked, and 2. to balance and help players wanting to start in other dimensions.

## Technical details
Simply just test for the world and if its lockable and then, unlock it. easy as.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: TARDIS' can now grow and reland in other locked dimensions!