### PR TITLE
Fix siege cubes remaining in player inventory on death via keepinventory

### DIFF
--- a/src/main/java/dev/amble/ait/mixin/server/ServerPlayerMixin.java
+++ b/src/main/java/dev/amble/ait/mixin/server/ServerPlayerMixin.java
@@ -1,5 +1,11 @@
 package dev.amble.ait.mixin.server;
 
+import dev.amble.ait.core.AITItems;
+import dev.amble.ait.core.item.SiegeTardisItem;
+import dev.amble.ait.core.tardis.manager.ServerTardisManager;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -10,6 +16,8 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import dev.amble.ait.core.entities.FlightTardisEntity;
 import dev.amble.ait.core.tardis.util.TardisUtil;
 import dev.amble.ait.core.world.TardisServerWorld;
+
+import java.util.Objects;
 
 @Mixin(ServerPlayerEntity.class)
 public class ServerPlayerMixin {
@@ -30,5 +38,27 @@ public class ServerPlayerMixin {
         ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
         if (player.hasVehicle() && player.getVehicle() instanceof FlightTardisEntity)
             ci.cancel();
+    }
+
+    @Inject(method = "onDeath", at = @At("HEAD"))
+    public void ait$onDeath(DamageSource damageSource, CallbackInfo ci) {
+        ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
+
+        ServerTardisManager.getInstance().forEach(tardis -> {
+            if (!tardis.siege().isActive())
+                return;
+
+            if (!Objects.equals(tardis.siege().getHeldPlayerUUID(), player.getUuid()))
+                return;
+
+            for (ItemStack itemStack : player.getInventory().main) {
+                if (itemStack.isOf(AITItems.SIEGE_ITEM)) {
+                    if (tardis.getUuid().equals(SiegeTardisItem.getTardisIdStatic(itemStack))) {
+                        player.getInventory().setStack(player.getInventory().getSlotWithStack(itemStack), Items.AIR.getDefaultStack());
+                    }
+                }
+            }
+            SiegeTardisItem.placeTardis(tardis, SiegeTardisItem.fromEntity(player));
+        });
     }
 }


### PR DESCRIPTION
## About the PR
Prevents siege cubes from staying in a player's inventory on death when the gamerule `keepinventory` is true.

Originally reported by `amokdev` on Discord here: https://discord.com/channels/1213989169878274068/1421125485362020525/1421134182800818206

## Why / Balance
So that a player, who set their spawn point inside a TARDIS, cannot take the siege cube inside of that TARDIS by dying with the siege cube in their inventory (while keepinventory is true).

## Technical details
I hooked into the `onDeath()` method of the `ServerPlayer` and then check for siege cube items.
If one is found, I remove it and place the TARDIS exterior at the position of the player.

That code is basically just copied over from how it is done when a player is disconnecting from the server with a siege cube in their inventory (see `ServerPlayConnectionEvents.DISCONNECT` event)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] It does not require an ingame showcase.

**Changelog**
:cl:
- fix: Siege cubes remained in a player's inventory on death when the gamerule "keepinventory" was true