### PR TITLE
Feat: Evict players who fall into void without a key when leave-behind is on

### DIFF
--- a/src/main/java/dev/amble/ait/mixin/server/ServerPlayerMixin.java
+++ b/src/main/java/dev/amble/ait/mixin/server/ServerPlayerMixin.java
@@ -1,15 +1,15 @@
 package dev.amble.ait.mixin.server;
 
+import dev.amble.ait.core.entities.FlightTardisEntity;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.tardis.control.impl.SecurityControl;
+import dev.amble.ait.core.tardis.util.TardisUtil;
+import dev.amble.ait.core.world.TardisServerWorld;
+import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import net.minecraft.server.network.ServerPlayerEntity;
-
-import dev.amble.ait.core.entities.FlightTardisEntity;
-import dev.amble.ait.core.tardis.util.TardisUtil;
-import dev.amble.ait.core.world.TardisServerWorld;
 
 @Mixin(ServerPlayerEntity.class)
 public class ServerPlayerMixin {
@@ -19,8 +19,15 @@ public class ServerPlayerMixin {
         ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
 
         // if player is in tardis and y is less than -100 save them
+        // if leave-behind is on, and they do not have a key + enough loyalty, then evict them instead
         if (player.getY() <= -100 && player.getServerWorld() instanceof TardisServerWorld tardisWorld) {
-            TardisUtil.teleportInside(tardisWorld.getTardis(), player);
+            ServerTardis serverTardis = tardisWorld.getTardis();
+
+            if (!SecurityControl.hasMatchingKey(player, serverTardis) && serverTardis.travel().leaveBehind().get())
+                TardisUtil.teleportOutside(serverTardis, player);
+            else
+                TardisUtil.teleportInside(serverTardis, player);
+
             player.fallDistance = 0;
         }
     }


### PR DESCRIPTION
## About the PR
When leave-behind is enabled and a player falls into the TARDIS void, then without a key (and valid loyalty level) they will be spawned outside the TARDIS instead of at the interior door.

## Why / Balance
This was a a suggested idea on Discord by `ihudhudi` here:
https://discord.com/channels/1213989169878274068/1420864949474951189/1420864949474951189

## Technical details
Added an additional check to the existing ServerPlayerMixin to check for a matching key and the leave-behind setting.

## Media
<img width="1598" height="104" alt="image" src="https://github.com/user-attachments/assets/91d97287-21cd-4f9a-80b9-8063cc677c6b" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- add: When leave-behind is on, then players falling into the TARDIS void without a key (and valid loyalty level) will be evicted from the TARDIS.