### PR TITLE
Fix/painting-drop

### DIFF
--- a/src/main/java/dev/amble/ait/core/entities/BOTIPaintingEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/BOTIPaintingEntity.java
@@ -31,7 +31,7 @@ public abstract class BOTIPaintingEntity extends AbstractDecorationEntity implem
     public static Optional<BOTIPaintingEntity> placePainting(EntityType<? extends BOTIPaintingEntity> entityType, World world, BlockPos pos, Direction facing) {
         BOTIPaintingEntity paintingEntity = entityType.create(world);
 
-        assert paintingEntity != null;
+        if (paintingEntity == null) return Optional.empty();
         paintingEntity.setPosition(pos.getX(), pos.getY(), pos.getZ());
         paintingEntity.setFacing(facing);
 


### PR DESCRIPTION
## About the PR
- Made Paintings actually drop their respective items when broken.

## Why / Balance
- This is how paintings are supposed to work in game.
- This was requested by players to be fixed.

## Technical details
- Made BOTIPaintingEntity abstract
- General clean-up after previous change to make sure the code functions as intended

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Fixed the BOTI paintings not dropping items when broken in survival.