### PR TITLE
Feat/stattenheim-power

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/RemoteItem.java
+++ b/src/main/java/dev/amble/ait/core/item/RemoteItem.java
@@ -53,16 +53,20 @@ public class RemoteItem extends LinkableItem {
             return ActionResult.FAIL;
 
         if (player.isSneaking()) {
-            if (!tardis.fuel().hasPower()) {
-                tardis.fuel().enablePower();
-                player.sendMessage(Text.literal("TARDIS Powering Up..."), true);
-                tardis.getExterior().playSound(AITSounds.POWERUP, SoundCategory.BLOCKS);
-                world.playSound(null, pos, AITSounds.REMOTE, SoundCategory.BLOCKS);
-            } else {
-                tardis.fuel().disablePower();
-                player.sendMessage(Text.literal("TARDIS Powering Down..."), true);
-                tardis.getExterior().playSound(AITSounds.SHUTDOWN, SoundCategory.BLOCKS);
-                world.playSound(null, pos, AITSounds.REMOTE, SoundCategory.BLOCKS);
+            if (!tardis.travel().inFlight()) {
+                if (!tardis.fuel().hasPower()) {
+                    tardis.fuel().enablePower();
+                    player.sendMessage(Text.literal("TARDIS Powering Up..."), true);
+                    tardis.getExterior().playSound(AITSounds.POWERUP, SoundCategory.BLOCKS);
+                    world.playSound(null, pos, AITSounds.REMOTE, SoundCategory.BLOCKS);
+                } else {
+                    tardis.fuel().disablePower();
+                    player.sendMessage(Text.literal("TARDIS Powering Down..."), true);
+                    tardis.getExterior().playSound(AITSounds.SHUTDOWN, SoundCategory.BLOCKS);
+                    world.playSound(null, pos, AITSounds.REMOTE, SoundCategory.BLOCKS);
+                }
+            } else if (tardis.travel().inFlight() || !tardis.travel().isLanded()) {
+                player.sendMessage(Text.literal("TARDIS in flight. Power Switch Disabled."), true);
             }
             return ActionResult.PASS;
         }
@@ -91,11 +95,15 @@ public class RemoteItem extends LinkableItem {
 
             if (world.getBlockState(pos).isReplaceable())
                 temp = pos;
-            tardis.travel().speed(tardis.travel().maxSpeed().get());
+                if (tardis.fuel().hasPower()) {
+                    tardis.travel().speed(tardis.travel().maxSpeed().get());
 
-            TravelUtil.travelTo(tardis, CachedDirectedGlobalPos.create(serverWorld, temp, DirectionControl
-                    .getGeneralizedRotation(RotationPropertyHelper.fromYaw(player.getBodyYaw()))));
-        } else {
+                    TravelUtil.travelTo(tardis, CachedDirectedGlobalPos.create(serverWorld, temp, DirectionControl
+                            .getGeneralizedRotation(RotationPropertyHelper.fromYaw(player.getBodyYaw()))));
+                } else {
+                    player.sendMessage(Text.literal("Takeoff Failed, TARDIS powered off..."), true);
+                }
+            } else {
             world.playSound(null, pos, SoundEvents.BLOCK_NOTE_BLOCK_BIT.value(), SoundCategory.BLOCKS, 1F,
                     0.2F);
             player.sendMessage(Text.translatable("message.ait.remoteitem.warning3"), true);


### PR DESCRIPTION
## About the PR
- Added a function to the Stattenheim Remote where when you shift right click with the remote, it will toggle the power of the TARDIS.

## Why / Balance
- It was requested by Akari (one of our Trial Mods) and given the ok by Alex (Monke).

## Technical details
- Added in a check to the Stattenheim Remote to check whether or not the player is crouching during usage of the remote.
- If the player is crouching, toggle the power, display a message to update the player on the power, and play noise from the TARDIS and Remote to allow players to know their TARDIS is powered down.
- Maybe update some other part of the code to have the TARDIS play noise when it is powered on/off via any means and not just the remote?

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added toggling power via the Stattenheim Remote when shift right-clicking.