### PR TITLE
feat: home pos

### DIFF
--- a/src/main/java/dev/amble/ait/core/commands/HomeCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/HomeCommand.java
@@ -1,23 +1,33 @@
 package dev.amble.ait.core.commands;
 
-import static net.minecraft.server.command.CommandManager.argument;
-import static net.minecraft.server.command.CommandManager.literal;
-
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
+import dev.amble.ait.AITMod;
+import dev.amble.ait.compat.permissionapi.PermissionAPICompat;
+import dev.amble.ait.core.AITDimensions;
+import dev.amble.ait.core.commands.argument.TardisArgumentType;
+import dev.amble.ait.core.lock.LockedDimensionRegistry;
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.tardis.util.CommandUtil;
+import dev.amble.ait.core.util.WorldUtil;
+import dev.amble.ait.core.world.TardisServerWorld;
+import dev.amble.lib.data.CachedDirectedGlobalPos;
+import dev.amble.lib.data.DirectedGlobalPos;
+import net.minecraft.command.argument.BlockPosArgumentType;
+import net.minecraft.command.argument.DimensionArgumentType;
+import net.minecraft.registry.RegistryKey;
 import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
-import dev.amble.ait.AITMod;
-import dev.amble.ait.compat.permissionapi.PermissionAPICompat;
-import dev.amble.ait.core.commands.argument.TardisArgumentType;
-import dev.amble.ait.core.tardis.ServerTardis;
-import dev.amble.lib.data.CachedDirectedGlobalPos;
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
 
 public final class HomeCommand {
 
@@ -25,45 +35,101 @@ public final class HomeCommand {
     }
 
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        dispatcher.register(literal(AITMod.MOD_ID)
-                .then(literal("home")
-                        .requires(source -> PermissionAPICompat.hasPermission(source, "ait.command.home", 2))
-                        .then(literal("get")
-                                .then(argument("tardis", TardisArgumentType.tardis()).executes(HomeCommand::runGet)))
-                        .then(literal("set")
-                                .then(argument("tardis", TardisArgumentType.tardis()).executes(HomeCommand::runSet)))));
+        dispatcher.register(
+                literal(AITMod.MOD_ID)
+                        .then(literal("home")
+                                .requires(source -> PermissionAPICompat.hasPermission(source, "ait.command.home", 2))
+                                .then(literal("get")
+                                        .executes(HomeCommand::runGet)
+                                        .then(argument("tardis", TardisArgumentType.tardis())
+                                                .executes(HomeCommand::runGet)))
+                                .then(literal("set")
+                                        .executes(HomeCommand::runSet)
+                                        .then(argument("tardis", TardisArgumentType.tardis())
+                                                .executes(HomeCommand::runSet)
+                                                .then(argument("dimension", DimensionArgumentType.dimension())
+                                                .suggests(CommandUtil.NON_TARDIS_DIM_SUGGESTIONS)
+                                                        .then(argument("position", BlockPosArgumentType.blockPos())
+                                                                .executes(HomeCommand::runSet)
+                                                                .then(argument("facing", StringArgumentType.word())
+                                                                        .suggests(CommandUtil.DIRECTION)
+                                                                        .executes(HomeCommand::runSet)
+                                                                )
+                                                        )
+                                                )
+                                        )
+                                )
+                        )
+        );
     }
 
     private static int runGet(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        return sendHome(context, false);
+        ServerTardis tardis = resolveTardis(context);
+        CachedDirectedGlobalPos homePos = tardis.stats().getHome();
+
+        if (homePos == null)
+            return -1;
+
+        return printHome(context, homePos);
     }
 
     private static int runSet(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        return sendHome(context, true);
-    }
+        ServerTardis tardis = resolveTardis(context);
+        CachedDirectedGlobalPos homePos = tardis.stats().getHome();
 
-    private static int sendHome(CommandContext<ServerCommandSource> context, boolean update) throws CommandSyntaxException {
-        ServerTardis tardis = TardisArgumentType.getTardis(context, "tardis");
-        CachedDirectedGlobalPos homePos = tardis.travel().home();
+        if (CommandUtil.hasArgument(context, "position")) {
+            ServerWorld world = DimensionArgumentType.getDimensionArgument(context, "dimension");
+            RegistryKey<World> key = world.getRegistryKey();
+            BlockPos manualPos = BlockPosArgumentType.getBlockPos(context, "position");
+            byte rotation;
 
-        if (update) {
+            if (TardisServerWorld.isTardisDimension(world)
+                    || key.getValue().equals(AITDimensions.TIME_VORTEX_WORLD.getValue())
+                    || key.getValue().toString().equals("ait:tardis_dimension_type"))
+                return -1;
+
+            if (!LockedDimensionRegistry.getInstance().isUnlocked(tardis, world)) {
+                context.getSource().sendError(Text.translatable("command.ait.home.dimension_locked",
+                        WorldUtil.worldText(world.getRegistryKey(), false)));
+                return -1;
+            }
+
+            if (CommandUtil.hasArgument(context, "facing")) {
+                rotation = WorldUtil.stringName2Rot(StringArgumentType.getString(context, "facing"));
+            }else {
+                rotation = WorldUtil.tardis2Rot(tardis);
+            }
+
+            homePos = CachedDirectedGlobalPos.create(world, manualPos, rotation);
+            tardis.stats().setHome(homePos);
+        } else {
             CachedDirectedGlobalPos current = tardis.travel().position();
 
             if (current == null)
                 return -1;
 
-            tardis.travel().setHome(current);
-            homePos = tardis.travel().home();
+            tardis.stats().setHome(current);
         }
 
-        if (homePos == null)
-            return -1;
+        return printHome(context, homePos);
+    }
 
+    private static int printHome(CommandContext<ServerCommandSource> context, CachedDirectedGlobalPos homePos) {
         BlockPos blockPos = homePos.getPos();
+        String facing = WorldUtil.rot2StringName(homePos.getRotation());
+        String arrow = DirectedGlobalPos.rotationForArrow(homePos.getRotation());
         Identifier dimension = homePos.getDimension().getValue();
 
         context.getSource().sendMessage(Text.literal(
-                blockPos.getX() + " " + blockPos.getY() + " " + blockPos.getZ() + " " + dimension));
+                blockPos.getX() + " " + blockPos.getY() + " " + blockPos.getZ() + " (" + facing + " " + arrow + ") " + dimension));
         return Command.SINGLE_SUCCESS;
     }
+
+    private static ServerTardis resolveTardis(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        if (CommandUtil.hasArgument(context, "tardis"))
+            return TardisArgumentType.getTardis(context, "tardis");
+
+        throw TardisArgumentType.INVALID_UUID.create();
+    }
+
 }

--- a/src/main/java/dev/amble/ait/core/commands/TravelDebugCommand.java
+++ b/src/main/java/dev/amble/ait/core/commands/TravelDebugCommand.java
@@ -26,8 +26,11 @@ public class TravelDebugCommand {
                 .requires(source -> PermissionAPICompat.hasPermission(source, "ait.command.travel", 2))
                 .then(argument("tardis", TardisArgumentType.tardis())
                         .then(literal("demat").executes(TravelDebugCommand::demat))
-                        .then(literal("destination").then(argument("dimension", DimensionArgumentType.dimension()).then(
-                                argument("pos", BlockPosArgumentType.blockPos()).executes(TravelDebugCommand::setPos))))
+                        .then(literal("destination")
+                                .then(literal("home").executes(TravelDebugCommand::setHome))
+                                .then(argument("dimension", DimensionArgumentType.dimension())
+                                        .then(argument("pos", BlockPosArgumentType.blockPos())
+                                                .executes(TravelDebugCommand::setPos))))
                         .then(literal("remat").executes(TravelDebugCommand::remat)))));
     }
 
@@ -44,6 +47,13 @@ public class TravelDebugCommand {
         BlockPos pos = BlockPosArgumentType.getBlockPos(context, "pos");
 
         tardis.travel().forceDestination(cached -> cached.world(world).pos(pos));
+        return Command.SINGLE_SUCCESS;
+    }
+
+    private static int setHome(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        Tardis tardis = TardisArgumentType.getTardis(context, "tardis");
+
+        tardis.travel().forceDestination(cached -> tardis.stats().getHome());
         return Command.SINGLE_SUCCESS;
     }
 

--- a/src/main/java/dev/amble/ait/core/tardis/control/impl/TelepathicControl.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/impl/TelepathicControl.java
@@ -150,7 +150,7 @@ public class TelepathicControl extends Control {
                 return Result.FAILURE;
             }
 
-            tardis.travel().setHome(currentPos);
+            tardis.stats().setHome(currentPos);
 
             player.sendMessage(Text.translatable("tardis.message.control.telepathic.home_updated"), true);
 

--- a/src/main/java/dev/amble/ait/core/tardis/handler/StatsHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/StatsHandler.java
@@ -10,6 +10,7 @@ import java.util.*;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.register.unlockable.Unlockable;
 import dev.amble.lib.util.ServerLifecycleHooks;
 import org.joml.Vector3f;
@@ -63,6 +64,7 @@ public class StatsHandler extends KeyedTardisComponent {
     private static final DoubleProperty TARDIS_X_SCALE = new DoubleProperty("tardis_x_scale", 1);
     private static final DoubleProperty TARDIS_Y_SCALE = new DoubleProperty("tardis_y_scale", 1);
     private static final DoubleProperty TARDIS_Z_SCALE = new DoubleProperty("tardis_z_scale", 1);
+    private static final Property<CachedDirectedGlobalPos> HOME = new Property<>(Property.CDIRECTED_GLOBAL_POS, "home", (CachedDirectedGlobalPos) null);
 
     private final Value<String> tardisName = NAME.create(this);
     private final Value<String> playerCreatorName = PLAYER_CREATOR_NAME.create(this);
@@ -79,6 +81,7 @@ public class StatsHandler extends KeyedTardisComponent {
     private final DoubleValue tardisXScale = TARDIS_X_SCALE.create(this);
     private final DoubleValue tardisYScale = TARDIS_Y_SCALE.create(this);
     private final DoubleValue tardisZScale = TARDIS_Z_SCALE.create(this);
+    private final Value<CachedDirectedGlobalPos> home = HOME.create(this);
 
     @Exclude
     private Lazy<FlightSound> flightFxCache;
@@ -96,6 +99,7 @@ public class StatsHandler extends KeyedTardisComponent {
         this.setXScale(1.0f);
         this.setYScale(1.0f);
         this.setZScale(1.0f);
+        this.setHome(this.tardis().travel().position());
     }
 
     @Override
@@ -115,6 +119,9 @@ public class StatsHandler extends KeyedTardisComponent {
         tardisXScale.of(this, TARDIS_X_SCALE);
         tardisYScale.of(this, TARDIS_Y_SCALE);
         tardisZScale.of(this, TARDIS_Z_SCALE);
+        home.of(this, HOME);
+        if (home.get() == null)
+            this.setHome(this.tardis().travel().position());
         vortexId.addListener((id) -> {
             if (this.vortexFxCache != null)
                 this.vortexFxCache.invalidate();
@@ -174,6 +181,18 @@ public class StatsHandler extends KeyedTardisComponent {
     }
     public BoolValue receiveCalls() {
         return this.receiveCalls;
+    }
+
+    public CachedDirectedGlobalPos getHome() {
+        return this.home.get();
+    }
+
+    public void setHome(CachedDirectedGlobalPos cached) {
+        if (cached == null)
+            return;
+
+        cached.init(ServerLifecycleHooks.get());
+        this.home.set(cached);
     }
 
     public String getPlayerCreatorName() {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -545,9 +545,6 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
 
         if (this.previousPosition.get() == null)
             this.previousPosition.set(cached);
-
-        if (this.home.get() == null)
-            this.setHome(cached);
     }
 
     public boolean isLanded() {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
@@ -38,8 +38,6 @@ public abstract class TravelHandlerBase extends KeyedTardisComponent implements 
             Property.CDIRECTED_GLOBAL_POS, "destination", (CachedDirectedGlobalPos) null);
     private static final Property<CachedDirectedGlobalPos> PREVIOUS_POSITION = new Property<>(
             Property.CDIRECTED_GLOBAL_POS, "previous_position", (CachedDirectedGlobalPos) null);
-    private static final Property<CachedDirectedGlobalPos> HOME = new Property<>(
-            Property.CDIRECTED_GLOBAL_POS, "home", (CachedDirectedGlobalPos) null);
 
     private static final BoolProperty CRASHING = new BoolProperty("crashing", false);
     private static final BoolProperty ANTIGRAVS = new BoolProperty("antigravs", false);
@@ -55,7 +53,6 @@ public abstract class TravelHandlerBase extends KeyedTardisComponent implements 
     protected final Value<CachedDirectedGlobalPos> position = POSITION.create(this);
     protected final Value<CachedDirectedGlobalPos> destination = DESTINATION.create(this);
     protected final Value<CachedDirectedGlobalPos> previousPosition = PREVIOUS_POSITION.create(this);
-    protected final Value<CachedDirectedGlobalPos> home = HOME.create(this);
 
     private final BoolValue leaveBehind = LEAVE_BEHIND.create(this);
     protected final BoolValue crashing = CRASHING.create(this);
@@ -81,7 +78,6 @@ public abstract class TravelHandlerBase extends KeyedTardisComponent implements 
         position.of(this, POSITION);
         destination.of(this, DESTINATION);
         previousPosition.of(this, PREVIOUS_POSITION);
-        home.of(this, HOME);
         leaveBehind.of(this, LEAVE_BEHIND);
 
         speed.of(this, SPEED);
@@ -105,13 +101,9 @@ public abstract class TravelHandlerBase extends KeyedTardisComponent implements 
         @SuppressWarnings("resource")
         MinecraftServer current = TravelHandlerBase.server();
 
-        if (this.home.get() == null && this.position.get() != null)
-            this.setHome(this.position.get());
-
         this.position.ifPresent(cached -> cached.init(current), false);
         this.destination.ifPresent(cached -> cached.init(current), false);
         this.previousPosition.ifPresent(cached -> cached.init(current), false);
-        this.home.ifPresent(cached -> cached.init(current), false);
     }
 
     @Override
@@ -237,18 +229,6 @@ public abstract class TravelHandlerBase extends KeyedTardisComponent implements 
 
     public CachedDirectedGlobalPos previousPosition() {
         return previousPosition.get();
-    }
-
-    public CachedDirectedGlobalPos home() {
-        return this.home.get();
-    }
-
-    public void setHome(CachedDirectedGlobalPos cached) {
-        if (cached == null)
-            return;
-
-        cached.init(TravelHandlerBase.server());
-        this.home.set(cached);
     }
 
     public BoolValue horizontalSearch() {

--- a/src/main/java/dev/amble/ait/core/tardis/util/CommandUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/util/CommandUtil.java
@@ -1,0 +1,58 @@
+package dev.amble.ait.core.tardis.util;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.context.ParsedCommandNode;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import dev.amble.ait.core.AITDimensions;
+import dev.amble.ait.core.world.TardisServerWorld;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.World;
+
+public class CommandUtil {
+
+    public static final SuggestionProvider<ServerCommandSource> NON_TARDIS_DIM_SUGGESTIONS =
+            (CommandContext<ServerCommandSource> ctx, SuggestionsBuilder builder) -> {
+                MinecraftServer server = ctx.getSource().getServer();
+
+                for (RegistryKey<World> key : server.getWorldRegistryKeys()) {
+                    ServerWorld world = server.getWorld(key);
+                    if (world == null)
+                        continue;
+
+                    if (!TardisServerWorld.isTardisDimension(world)
+                            && !key.getValue().equals(AITDimensions.TIME_VORTEX_WORLD.getValue())
+                            && !key.getValue().toString().equals("ait:tardis_dimension_type")) {
+                        builder.suggest(key.getValue().toString());
+                    }
+                }
+                return builder.buildFuture();
+            };
+
+    public static final SuggestionProvider<ServerCommandSource> DIRECTION = (ctx, b) -> {
+        String[] opts = {
+                "north",
+                "north_east",
+                "east",
+                "south_east",
+                "south",
+                "south_west",
+                "west",
+                "north_west"
+        };
+        for (String o : opts) b.suggest(o);
+        return b.buildFuture();
+    };
+
+    public static boolean hasArgument(CommandContext<ServerCommandSource> context, String name) {
+        for (ParsedCommandNode<ServerCommandSource> node : context.getNodes()) {
+            if (node.getNode().getName().equals(name))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/dev/amble/ait/core/util/WorldUtil.java
+++ b/src/main/java/dev/amble/ait/core/util/WorldUtil.java
@@ -4,8 +4,10 @@ import dev.amble.ait.AITMod;
 import dev.amble.ait.api.AITWorldOptions;
 import dev.amble.ait.client.util.ClientTardisUtil;
 import dev.amble.ait.core.AITDimensions;
+import dev.amble.ait.core.tardis.ServerTardis;
 import dev.amble.ait.core.world.TardisServerWorld;
 import dev.amble.ait.mixin.server.EnderDragonFightAccessor;
+import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.amble.lib.util.ServerLifecycleHooks;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -228,6 +230,40 @@ public class WorldUtil {
         };
 
         return Text.translatable(key);
+    }
+
+    public static byte tardis2Rot(ServerTardis tardis) {
+        if (tardis == null)
+            return 0;
+        CachedDirectedGlobalPos position = tardis.travel().position();
+        return position == null ? 0 : position.getRotation();
+    }
+
+    public static byte stringName2Rot(String name) {
+        String s = name == null ? "" : name.toLowerCase();
+        return switch (s) {
+            case "north_east" -> 2;     // group 1..3
+            case "east" -> 4;           // group 4
+            case "south_east" -> 6;     // group 5..7
+            case "south" -> 8;          // group 8
+            case "south_west" -> 10;    // group 9..11
+            case "west" -> 12;          // group 12
+            case "north_west" -> 14;    // group 13..15
+            default -> 0;               // group 0 (north)
+        };
+    }
+
+    public static String rot2StringName(int rotation) {
+        return switch (rotation) {
+            case 1, 2, 3 -> "north_east";
+            case 4 -> "east";
+            case 5, 6, 7 -> "south_east";
+            case 8 -> "south";
+            case 9, 10, 11 -> "south_west";
+            case 12 -> "west";
+            case 13, 14, 15 -> "north_west";
+            default -> "north";
+        };
     }
 
     public static void onBreakHalfInCreative(World world, BlockPos pos, BlockState state, PlayerEntity player) {

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1486,6 +1486,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("command.ait.list.tardises", "TARDISes");
         provider.addTranslation("command.ait.list.pattern.error", "Bad pattern '%s'!");
         provider.addTranslation("command.ait.this.not_found", "Not in TARDIS interior, or no linked item.");
+        provider.addTranslation("command.ait.home.dimension_locked", "Cannot set home in a dimension locked for this TARDIS.");
 
         // Rift Chunk Tracking
         provider.addTranslation("riftchunk.ait.tracking", "Rift Tracking");
@@ -1666,6 +1667,8 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("tardis.message.interiorchange.warning",
                 "Interior reconfiguration started! Please leave the interior.");
         provider.addTranslation("command.ait.realworld.responses", "Spawned a real world TARDIS at: ");
+        provider.addTranslation("command.ait.home.dimension_locked",
+                "Impossible de définir la base dans une dimension verrouillée pour cette TARDIS.");
 
         return provider;
     }
@@ -1768,6 +1771,8 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("tardis.message.interiorchange.warning",
                 "Interior reconfiguration started! Please leave the interior.");
         provider.addTranslation("command.ait.realworld.responses", "Spawned a real world TARDIS at: ");
+        provider.addTranslation("command.ait.home.dimension_locked",
+                "No se puede establecer el hogar en una dimensión bloqueada para esta TARDIS.");
 
         return provider;
     }
@@ -1870,6 +1875,8 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("tardis.message.interiorchange.warning",
                 "Interior reconfiguration started! Please leave the interior.");
         provider.addTranslation("command.ait.realworld.responses", "Spawned a real world TARDIS at:");
+        provider.addTranslation("command.ait.home.dimension_locked",
+                "Heimatposition kann nicht in einer für diese TARDIS gesperrten Dimension festgelegt werden.");
 
         return provider;
     }
@@ -1880,6 +1887,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("tardis.message.control.telepathic.home_updated", "Local de origem da TARDIS alterado.");
         provider.addTranslation("tardis.message.control.telepathic.home_denied", "A TARDIS recusa-se a mudar sua casa para você. Nível de lealdade PILOT necessário.");
         provider.addTranslation("tardis.message.control.telepathic.home_denied_nether", "A TARDIS rejeita o Nether como casa. Nível de lealdade OWNER necessário.");
+        provider.addTranslation("command.ait.home.dimension_locked", "Não é possível definir a casa em uma dimensão bloqueada para esta TARDIS.");
         return provider;
     }
 


### PR DESCRIPTION
## About the PR

- The TARDIS now remembers its grown-spot location as its "home".
- It can be changed by right-clicking with a coral fragment on the telepathic circuits.

## Why / Balance

- This PR only implements the home pos (and reset mechanic) as a tool for other potentially useful gameplay mechanics.
- Like turtles, TARDISes are sentimental; in case of danger or uncertainty, they can return to a familiar place.
- TARDISes dislike the Nether dimension. That is why more loyalty is required to set the home pos in the Nether.
- This could be used in #1381: a TARDIS mats to the home pos for a set amount of time (or waits for an event) before returning to the previous pos if a major danger is present (as in the special “Wild Blue Yonder”). A Dalek raid could be one case.
- If loyalty is low and a mood roll occurs, #949 could trigger the TARDIS to return to the home pos and refuse to leave for some time.
- A Ghost Monument (#673) with no logged player with a key could just return to the home pos.
- As a way to recover lost TARDISes, a TARDIS with no player interaction for a very long time could return to the home pos and power down.
- As a last resort, if a TARDIS exterior ceases to exist for any reason, make it appear at the home pos.
- The home pos is chosen by the player, either where they grow their TARDIS, or later by resetting it via the telepathic circuits. It would be reasonable to implement breaking/removal of any blocks that would prevent the TARDIS from materialising there.

## Technical details

- Added a `home` variable of type `CachedDirectedGlobalPos` in `TravelHandlerBase`, initializing it when a TARDIS is grown, placed, or loaded without a prior home pos.
- Telepathic circuits accept a coral fragment (when not in flight) to reset the home pos to the current location, requiring PILOT loyalty level, or OWNER for the Nether.
- Registered the `/ait home` command to get a TARDIS’s current home pos (coords and dimension) or to set the current pos as the home pos.
- Updated language providers for acceptance and denial messages when changing the TARDIS home pos via telepathic circuits.

## Media

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

N/A

**Changelog**
🆑

- Add: TARDIS remembers a "home" pos, either its grown spot or the current location for existing ones. Can be reset to the current location using a coral fragment on the telepathic circuits (requires PILOT loyalty level, or OWNER for the Nether).