### PR TITLE
sonic disguise changer

### DIFF
--- a/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/ExteriorBlockEntity.java
@@ -4,6 +4,8 @@ import static dev.amble.ait.core.tardis.handler.InteriorChangingHandler.MAX_PLAS
 
 import java.util.UUID;
 
+import dev.amble.ait.core.tardis.control.impl.SecurityControl;
+import dev.amble.ait.data.Loyalty;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.drtheo.scheduler.api.TimeUnit;
 import dev.drtheo.scheduler.api.common.Scheduler;
@@ -51,10 +53,12 @@ import dev.amble.ait.core.tardis.ServerTardis;
 import dev.amble.ait.core.tardis.Tardis;
 import dev.amble.ait.core.tardis.handler.BiomeHandler;
 import dev.amble.ait.core.tardis.handler.SonicHandler;
+import dev.amble.ait.core.tardis.handler.TardisCrashHandler;
 import dev.amble.ait.core.tardis.handler.travel.TravelHandler;
 import dev.amble.ait.core.tardis.handler.travel.TravelHandlerBase;
 import dev.amble.ait.core.tardis.util.TardisUtil;
 import dev.amble.ait.data.schema.exterior.ExteriorVariantSchema;
+import dev.amble.ait.data.schema.exterior.category.AdaptiveCategory;
 
 public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements BlockEntityTicker<ExteriorBlockEntity> {
     private UUID seatEntityUUID = null;
@@ -78,11 +82,11 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
         ItemStack hand = player.getMainHandStack();
 
         if (tardis.isGrowth()) {
-            if (tardis.interiorChangingHandler().hasCage()) {
+            if (tardis.interiorChanging().hasCage()) {
                 if (hand.getItem() == AITItems.PLASMIC_MATERIAL) {
-                    int plasmic = tardis.interiorChangingHandler().plasmicMaterialAmount();
+                    int plasmic = tardis.interiorChanging().plasmicMaterialAmount();
                     if (plasmic < MAX_PLASMIC_MATERIAL_AMOUNT) {
-                        tardis.interiorChangingHandler().addPlasmicMaterial(1);
+                        tardis.interiorChanging().addPlasmicMaterial(1);
                         world.playSound(null, pos, SoundEvents.ENTITY_MAGMA_CUBE_SQUISH, SoundCategory.BLOCKS, 1F, (float) plasmic / 8);
                         hand.decrement(1);
                     }
@@ -90,7 +94,7 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
             } else {
                 if (hand.getItem() == AITItems.CORAL_CAGE) {
                     world.playSound(null, pos, SoundEvents.BLOCK_CHAIN_HIT, SoundCategory.BLOCKS, 1F, 0.7f);
-                    tardis.interiorChangingHandler().setHasCage(true);
+                    tardis.interiorChanging().setHasCage(true);
                     hand.decrement(1);
                     return;
                 }
@@ -112,7 +116,7 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
         }
 
         if (hand.getItem() instanceof KeyItem key && !tardis.siege().isActive()
-                && !tardis.interiorChangingHandler().queued().get()) {
+                && !tardis.interiorChanging().queued().get()) {
             if (hand.isOf(AITItems.SKELETON_KEY) || key.isOf(hand, tardis)) {
                 tardis.door().interactToggleLock((ServerPlayerEntity) player);
             } else {
@@ -141,7 +145,7 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
 
         if (hand.getItem() instanceof SonicItem sonic && sonic.isOf(hand, tardis)) {
             if (!tardis.siege().isActive()
-                    && !tardis.interiorChangingHandler().queued().get()
+                    && !tardis.interiorChanging().queued().get()
                     && tardis.door().isClosed() && tardis.crash().getRepairTicks() > 0) {
                 if (sonic.isOf(hand, tardis)) {
                     handler.insertExteriorSonic(hand);
@@ -168,6 +172,28 @@ public class ExteriorBlockEntity extends AbstractLinkableBlockEntity implements 
                     phasing.cancel();
                 return;
             }
+        }
+
+        // Change disguise via sonic
+        if (player.getOffHandStack().getItem() instanceof SonicItem
+                && SonicItem.mode(player.getOffHandStack()) == SonicMode.Modes.INTERACTION
+                && tardis.getExterior().getCategory().id().equals(AdaptiveCategory.REFERENCE)
+                && tardis.door().isClosed()
+                && !tardis.siege().isActive()
+                && !tardis.interiorChanging().queued().get()
+                && tardis.crash().getState() == TardisCrashHandler.State.NORMAL
+        ) {
+            Loyalty playerLoyalty = tardis.loyalty().get(player);
+            Loyalty pilotLoyalty = Loyalty.fromLevel(Loyalty.Type.PILOT.level);
+            // Follows isomorphic security if enabled, otherwise requires at least PILOT loyalty or OP.
+            boolean isPermitted = tardis.stats().security().get() ? SecurityControl.hasMatchingKey((ServerPlayerEntity) player, tardis) : playerLoyalty.greaterOrEqual(pilotLoyalty) || player.hasPermissionLevel(2);
+
+            if (!isPermitted)
+                return;
+
+            tardis.chameleon().clearDisguise();
+            tardis.chameleon().applyDisguise();
+            return;
         }
 
         if (sneaking && !tardis.isSiegeBeingHeld() && tardis.siege().isActive()) {


### PR DESCRIPTION
## About the PR
This PR adds a way to quickly swap disguises via the sonic screwdriver:
- Set sonic screwdriver to `INTERACTION` mode.
- Put sonic screwdriver in off-hand.
- Using it now on the exterior block of a TARDIS will make it swap to a different disguise (appropriate to the biome, of course).

<ins>NOTE:</ins>
If isomorphic security is active, then it requires the respective loyalty and a linked key.
If it's not active, then it requires at least `PILOT` loyalty (or OP) with the targeted TARDIS.

## Why / Balance
Previously the `/ait debug` command allowed normal players to switch disguises of their TARDISes.
But that command has since been restricted, which means there is no convenient way anymore to switch the disguise of an adaptive exterior besides using the console monitor.

## Technical details
I added a condition check to the Exterior block-entity.

## Media
https://github.com/user-attachments/assets/00040efe-3027-423a-8c77-32ec6aa9472d

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR.

**Changelog**
:cl:
- add: Ability to change disguise of adaptive exterior via sonic screwdriver.