### PR TITLE
fix: fail mat playing at old pos instead of destination

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -357,7 +357,7 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
     }
 
     private void failRemat() {
-        // Play failure sound at the current position
+        // Play failure sound at the destination position where materialization was attempted
         this.destination().getWorld().playSound(null, this.destination().getPos(), AITSounds.FAIL_MAT, SoundCategory.BLOCKS,
                 2f, 1f);
 


### PR DESCRIPTION
closes #1928