### PR TITLE
fix: boti smearing

### DIFF
--- a/src/main/java/dev/amble/ait/client/boti/BOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/BOTI.java
@@ -17,8 +17,6 @@ import dev.amble.ait.core.blockentities.DoorBlockEntity;
 import dev.amble.ait.core.blockentities.ExteriorBlockEntity;
 import dev.amble.ait.core.entities.BOTIPaintingEntity;
 import dev.amble.ait.core.entities.RiftEntity;
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.opengl.GL30;
 
 public class BOTI {
     public static final Queue<RiftEntity> RIFT_RENDERING_QUEUE = new LinkedList<>();
@@ -36,22 +34,10 @@ public class BOTI {
         GlStateManager._glBlitFrameBuffer(0, 0, src.textureWidth, src.textureHeight, 0, 0, dest.textureWidth, dest.textureHeight, GlConst.GL_DEPTH_BUFFER_BIT | GlConst.GL_COLOR_BUFFER_BIT, GlConst.GL_NEAREST);
     }
 
-    public static void copyColor(Framebuffer source, Framebuffer dest) {
-        GL30.glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, source.fbo);
-        GL30.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, dest.fbo);
-
-        // Enable depth test during blit so it only copies where depth allows
-        GL11.glEnable(GL11.GL_DEPTH_TEST);
-        GL11.glDepthFunc(GL11.GL_LEQUAL);
-
-        GL30.glBlitFramebuffer(
-                0, 0, source.textureWidth, source.textureHeight,
-                0, 0, dest.textureWidth, dest.textureHeight,
-                GL11.GL_COLOR_BUFFER_BIT,
-                GL11.GL_NEAREST
-        );
-
-        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0);
+    public static void copyColor(Framebuffer src, Framebuffer dest) {
+        GlStateManager._glBindFramebuffer(GlConst.GL_READ_FRAMEBUFFER, src.fbo);
+        GlStateManager._glBindFramebuffer(GlConst.GL_DRAW_FRAMEBUFFER, dest.fbo);
+        GlStateManager._glBlitFrameBuffer(0, 0, src.textureWidth, src.textureHeight, 0, 0, dest.textureWidth, dest.textureHeight, GlConst.GL_COLOR_BUFFER_BIT, GlConst.GL_NEAREST);
     }
 
     public static void copyDepth(Framebuffer src, Framebuffer dest) {

--- a/src/main/java/dev/amble/ait/client/boti/PaintingBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/PaintingBOTI.java
@@ -13,6 +13,7 @@ import net.minecraft.util.Identifier;
 import dev.amble.ait.client.AITModClient;
 import dev.amble.ait.client.models.decoration.PaintingFrameModel;
 import dev.amble.ait.client.renderers.AITRenderLayers;
+import org.lwjgl.opengl.GL30;
 
 public class PaintingBOTI extends BOTI {
     public static void renderBOTIPainting(MatrixStack stack, PaintingFrameModel frame,
@@ -43,16 +44,7 @@ public class PaintingBOTI extends BOTI {
         // Ensure viewport matches framebuffer dimensions on Apple
         GL11.glViewport(0, 0, BOTI_HANDLER.afbo.textureWidth, BOTI_HANDLER.afbo.textureHeight);
 
-        // Before copying color back, ensure depth is in sync
-        BOTI_HANDLER.afbo.endWrite();
-
-// Copy depth from BOTI back to main so the blit knows where to draw
-        BOTI.copyDepth(BOTI_HANDLER.afbo, client.getFramebuffer());
-
-        client.getFramebuffer().beginWrite(false); // false = don't clear!
-
-// Now copy color - it will respect the depth buffer
-        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
+        GL11.glClearColor(0.0F, 0.0F, 0.0F, 0.0F);
         GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
         BOTI_HANDLER.afbo.endWrite();
 
@@ -112,7 +104,30 @@ public class PaintingBOTI extends BOTI {
         // End write BEFORE copying back
         BOTI_HANDLER.afbo.endWrite();
 
-        client.getFramebuffer().beginWrite(true);
+// NEW: Copy stencil buffer to main framebuffer
+        GL30.glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, BOTI_HANDLER.afbo.fbo);
+        GL30.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, client.getFramebuffer().fbo);
+        GL30.glBlitFramebuffer(
+                0, 0, BOTI_HANDLER.afbo.textureWidth, BOTI_HANDLER.afbo.textureHeight,
+                0, 0, client.getFramebuffer().textureWidth, client.getFramebuffer().textureHeight,
+                GL30.GL_STENCIL_BUFFER_BIT, // Only copy stencil
+                GL30.GL_NEAREST
+        );
+
+        client.getFramebuffer().beginWrite(false); // Don't clear!
+
+// Enable stencil test for the color copy
+        GL11.glEnable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xFF);
+        GL11.glStencilMask(0x00); // Don't write to stencil
+
+        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
+
+// Clean up stencil
+        GL11.glDisable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilMask(0xFF);
+
+        client.getFramebuffer().beginWrite(false);
 
         BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 

--- a/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
@@ -28,6 +28,7 @@ import dev.amble.ait.core.tardis.handler.travel.TravelHandlerBase;
 import dev.amble.ait.data.schema.exterior.ClientExteriorVariantSchema;
 import dev.amble.ait.data.schema.exterior.ExteriorVariantSchema;
 import dev.amble.ait.registry.impl.CategoryRegistry;
+import org.lwjgl.opengl.GL30;
 
 public class TardisDoorBOTI extends BOTI {
     public static void renderInteriorDoorBoti(ClientTardis tardis, DoorBlockEntity door, ClientExteriorVariantSchema variant, MatrixStack stack, Identifier frameTex, AnimatedModel frame, ModelPart mask, int light, float tickDelta) {
@@ -55,16 +56,7 @@ public class TardisDoorBOTI extends BOTI {
         // Ensure viewport matches framebuffer dimensions on Apple
         GL11.glViewport(0, 0, BOTI_HANDLER.afbo.textureWidth, BOTI_HANDLER.afbo.textureHeight);
 
-        // Before copying color back, ensure depth is in sync
-        BOTI_HANDLER.afbo.endWrite();
-
-// Copy depth from BOTI back to main so the blit knows where to draw
-        BOTI.copyDepth(BOTI_HANDLER.afbo, client.getFramebuffer());
-
-        client.getFramebuffer().beginWrite(false); // false = don't clear!
-
-// Now copy color - it will respect the depth buffer
-        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
+        GL11.glClearColor(0.0F, 0.0F, 0.0F, 0.0F);
         GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
         BOTI_HANDLER.afbo.endWrite();
 
@@ -192,7 +184,22 @@ public class TardisDoorBOTI extends BOTI {
         // End write BEFORE copying back
         BOTI_HANDLER.afbo.endWrite();
 
-        client.getFramebuffer().beginWrite(true);
+// NEW: Copy stencil buffer to main framebuffer
+        GL30.glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, BOTI_HANDLER.afbo.fbo);
+        GL30.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, client.getFramebuffer().fbo);
+        GL30.glBlitFramebuffer(
+                0, 0, BOTI_HANDLER.afbo.textureWidth, BOTI_HANDLER.afbo.textureHeight,
+                0, 0, client.getFramebuffer().textureWidth, client.getFramebuffer().textureHeight,
+                GL30.GL_STENCIL_BUFFER_BIT, // Only copy stencil
+                GL30.GL_NEAREST
+        );
+
+        client.getFramebuffer().beginWrite(false); // Don't clear!
+
+// Enable stencil test for the color copy
+        GL11.glEnable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xFF);
+        GL11.glStencilMask(0x00); // Don't write to stencil
 
         BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 

--- a/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
@@ -27,6 +27,7 @@ import dev.amble.ait.core.tardis.handler.StatsHandler;
 import dev.amble.ait.data.schema.exterior.ClientExteriorVariantSchema;
 import dev.amble.ait.data.schema.exterior.ExteriorVariantSchema;
 import dev.amble.ait.registry.impl.exterior.ClientExteriorVariantRegistry;
+import org.lwjgl.opengl.GL30;
 
 public class TardisExteriorBOTI extends BOTI {
     public void renderExteriorBoti(ExteriorBlockEntity exterior, ClientExteriorVariantSchema variant, MatrixStack stack, Identifier frameTex, ExteriorModel frame, ModelPart mask, int light) {
@@ -56,16 +57,7 @@ public class TardisExteriorBOTI extends BOTI {
         // Ensure viewport matches framebuffer dimensions on Apple
         GL11.glViewport(0, 0, BOTI_HANDLER.afbo.textureWidth, BOTI_HANDLER.afbo.textureHeight);
 
-        // Before copying color back, ensure depth is in sync
-        BOTI_HANDLER.afbo.endWrite();
-
-// Copy depth from BOTI back to main so the blit knows where to draw
-        BOTI.copyDepth(BOTI_HANDLER.afbo, client.getFramebuffer());
-
-        client.getFramebuffer().beginWrite(false); // false = don't clear!
-
-// Now copy color - it will respect the depth buffer
-        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
+        GL11.glClearColor(0.0F, 0.0F, 0.0F, 0.0F);
         GL11.glClear(GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
         BOTI_HANDLER.afbo.endWrite();
 
@@ -209,7 +201,22 @@ public class TardisExteriorBOTI extends BOTI {
         // End write BEFORE copying back
         BOTI_HANDLER.afbo.endWrite();
 
-        client.getFramebuffer().beginWrite(true);
+// NEW: Copy stencil buffer to main framebuffer
+        GL30.glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, BOTI_HANDLER.afbo.fbo);
+        GL30.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, client.getFramebuffer().fbo);
+        GL30.glBlitFramebuffer(
+                0, 0, BOTI_HANDLER.afbo.textureWidth, BOTI_HANDLER.afbo.textureHeight,
+                0, 0, client.getFramebuffer().textureWidth, client.getFramebuffer().textureHeight,
+                GL30.GL_STENCIL_BUFFER_BIT, // Only copy stencil
+                GL30.GL_NEAREST
+        );
+
+        client.getFramebuffer().beginWrite(false); // Don't clear!
+
+// Enable stencil test for the color copy
+        GL11.glEnable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xFF);
+        GL11.glStencilMask(0x00); // Don't write to stencil
 
         BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 


### PR DESCRIPTION
## About the PR
Correctly clear the framebuffer before copying the data to get rid of the stupid smearing issues.

## Why / Balance
This fixes a long-standing technical issue for many users, especially on AMD GPU's.

## Technical details
After setting up the framebuffer for copying, we begin writing to the offscreen boti framebuffer, clearing it, and continuing on to the copying step where we give it the rendered data.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- Fixed boti smearing.