### PR TITLE
fix: don't crash if already crashing during remat

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -482,10 +482,15 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
                 : this.tardis.travel().destination().world(this.tardis.travel().previousPosition().getWorld());
 
         this.setState(State.MAT);
+
+        boolean wasWaiting = this.waiting;
         this.waiting = true;
 
-        SafePosSearch.wrapSafe(finalPos, this.vGroundSearch.get(),
-                this.hGroundSearch.get(), this::finishForceRemat);
+        // this method MAY get called twice.
+        if (!wasWaiting) {
+            SafePosSearch.wrapSafe(finalPos, this.vGroundSearch.get(),
+                    this.hGroundSearch.get(), this::finishForceRemat);
+        }
 
         return Optional.of(this.queueFor(State.LANDED));
     }

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -469,7 +469,9 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
                 .onLanded(this.tardis, initialPos);
 
         if (result.type() == TardisEvents.Interaction.FAIL) {
-            this.crash();
+            if (!this.isCrashing())
+                this.crash();
+            
             return Optional.of(this.queueFor(State.LANDED));
         }
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This PR fixes exterior being placed twice as a result of crashing.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Exterior duplication is bad.

## Technical details
<!-- Summary of code changes for easier review. -->
Apparently, `#forceRemat` may be called twice. And as it turns out, `#crash` also calls `#forceRemat`. And `#forceRemat` calls `#crash` if remat event fails.

A scenario in which `#forceRemat` was being called twice caused the `SafePosSearch#wrapSafe` method be called twice.

Fortunately, we already keep track whether we're calculating the safe pos search (via the `waiting` field).

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: no more exterior duplication during crashing