### PR TITLE
fix: simplify sucking condition & suck harder

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -170,7 +170,7 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
                     if (!(tardis.asServer().world().getBlockEntity(directed.getPos()) instanceof DoorBlockEntity))
                         return;
 
-                    Vec3d pos = directed.getPos().toCenterPos().offset(directed.toMinecraftDirection(), 1f);
+                    Vec3d pos = directed.getPos().toCenterPos(); //.offset(directed.toMinecraftDirection(), 1f);
 
                     float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.08f: 0.05f;
                     Vec3d motion = pos.subtract(entity.getPos()).normalize().multiply(suckValue);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -171,7 +171,7 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
                         return;
 
                     Vec3d pos = new Vec3d(directed.getPos().getX(), directed.getPos().getY(),
-                            directed.getPos().getZ()).offset(directed.toMinecraftDirection(), -1f);
+                            directed.getPos().getZ()).offset(directed.toMinecraftDirection(), -1.5f);
 
                     float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.08f: 0.05f;
                     Vec3d motion = pos.subtract(entity.getPos()).normalize().multiply(suckValue);
@@ -189,8 +189,9 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
         if (directed == null)
             return false;
 
-        return tardis.travel().position().getDimension().equals(AITDimensions.SPACE) && this.isOpen() && !tardis.areShieldsActive()
-                || (!tardis.travel().isLanded() && this.isOpen() && !tardis.areShieldsActive() && !tardis.travel().autopilot());
+        return this.isOpen() && !tardis.areShieldsActive() 
+            && ((!tardis.travel().isLanded() && !tardis.travel().autopilot()) 
+                || tardis.travel().position().getDimension().equals(AITDimensions.SPACE));
     }
 
     public boolean isRightOpen() {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -170,8 +170,7 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
                     if (!(tardis.asServer().world().getBlockEntity(directed.getPos()) instanceof DoorBlockEntity))
                         return;
 
-                    Vec3d pos = new Vec3d(directed.getPos().getX(), directed.getPos().getY(),
-                            directed.getPos().getZ()).offset(directed.toMinecraftDirection(), 1f);
+                    Vec3d pos = directed.getPos().toCenterPos().offset(directed.toMinecraftDirection(), 1f);
 
                     float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.08f: 0.05f;
                     Vec3d motion = pos.subtract(entity.getPos()).normalize().multiply(suckValue);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -171,7 +171,7 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
                         return;
 
                     Vec3d pos = new Vec3d(directed.getPos().getX(), directed.getPos().getY(),
-                            directed.getPos().getZ()).offset(directed.toMinecraftDirection(), 0f);
+                            directed.getPos().getZ()).offset(directed.toMinecraftDirection(), 1f);
 
                     float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.08f: 0.05f;
                     Vec3d motion = pos.subtract(entity.getPos()).normalize().multiply(suckValue);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -170,7 +170,7 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
                     if (!(tardis.asServer().world().getBlockEntity(directed.getPos()) instanceof DoorBlockEntity))
                         return;
 
-                    Vec3d pos = directed.getPos().toCenterPos().offset(directed.toMinecraftDirection(), -0.5f);
+                    Vec3d pos = directed.getPos().toCenterPos().offset(directed.toMinecraftDirection(), 0.5f);
 
                     float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.08f: 0.05f;
                     Vec3d motion = pos.subtract(entity.getPos()).normalize().multiply(suckValue);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -170,7 +170,7 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
                     if (!(tardis.asServer().world().getBlockEntity(directed.getPos()) instanceof DoorBlockEntity))
                         return;
 
-                    Vec3d pos = directed.getPos().toCenterPos(); //.offset(directed.toMinecraftDirection(), 1f);
+                    Vec3d pos = directed.getPos().toCenterPos().offset(directed.toMinecraftDirection(), -0.5f);
 
                     float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.08f: 0.05f;
                     Vec3d motion = pos.subtract(entity.getPos()).normalize().multiply(suckValue);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -171,7 +171,7 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
                         return;
 
                     Vec3d pos = new Vec3d(directed.getPos().getX(), directed.getPos().getY(),
-                            directed.getPos().getZ()).offset(directed.toMinecraftDirection(), -1.5f);
+                            directed.getPos().getZ()).offset(directed.toMinecraftDirection(), 0f);
 
                     float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.08f: 0.05f;
                     Vec3d motion = pos.subtract(entity.getPos()).normalize().multiply(suckValue);


### PR DESCRIPTION
## About the PR
This PR fixes a problem of the door not sucking hard enough.

## Why / Balance
Because it sucks.

## Technical details
Simplified the suck conditions and change it to use the proper suck offset. Apparently, the direction was reversed, so the sign of the offset has to be positive.

Also, made it use `#toCenterPos`, instead of creating `Vec3d` from the `BlockPos`' coordinates, since that would create a vector on the corner of the block which is not the intended behavior.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: suck harder & proper