### PR TITLE
fix: portal positions for datapack exteriors and adjusting of all portals, door and exteriors.

### DIFF
--- a/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
@@ -66,8 +66,9 @@ public class TardisDoorBOTI extends BOTI {
 
         stack.scale((float) parent.portalWidth() * scale.x(),
                 (float) parent.portalHeight() * scale.y(), scale.z());
-        Vec3d vec = parent.door().adjustPortalPos(new Vec3d(0, -0.55f, 0), Direction.NORTH);
-        stack.translate(vec.x, vec.y, vec.z);
+        Vec3d vec = parent.door().getPortalPosition();
+        if (vec == null) vec = new Vec3d(0, 0, 0);
+        stack.translate(vec.x, vec.y - 0.575f, vec.z);
         if (tardis.travel().getState() == TravelHandlerBase.State.LANDED) {
             RenderLayer whichOne = AITModClient.CONFIG.greenScreenBOTI ?
                     RenderLayer.getDebugFilledBox() : RenderLayer.getEndGateway();

--- a/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
@@ -1,6 +1,7 @@
 package dev.amble.ait.client.boti;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import dev.amble.lib.data.DirectedGlobalPos;
 import org.joml.Vector3f;
 import org.lwjgl.opengl.GL11;
 
@@ -36,7 +37,7 @@ public class TardisExteriorBOTI extends BOTI {
         if (!exterior.isLinked())
             return;
 
-        ClientTardis tardis = exterior.tardis().get().asClient();;
+        ClientTardis tardis = exterior.tardis().get().asClient();
 
         stack.push();
 
@@ -73,8 +74,9 @@ public class TardisExteriorBOTI extends BOTI {
         ExteriorVariantSchema parent = variant.parent();
         stack.scale((float) parent.portalWidth() * scale.x(),
                 (float) parent.portalHeight() * scale.y(), scale.z());
-        Vec3d vec = parent.adjustPortalPos(new Vec3d(0, -0.4675f, 0), (byte) 0);
-        stack.translate(vec.x, vec.y, vec.z);
+        Vec3d vec = parent.getPortalPosition();
+        if (vec == null) vec = new Vec3d(0, 0, 0);
+        stack.translate(vec.x, vec.y - 0.475f, vec.z);
         RenderLayer whichOne = AITModClient.CONFIG.greenScreenBOTI ?
                 RenderLayer.getDebugFilledBox() : RenderLayer.getEndGateway();
         float[] colorsForGreenScreen = AITModClient.CONFIG.greenScreenBOTI ? new float[]{0, 1, 0, 1} : new float[] {(float) skyColor.x, (float) skyColor.y, (float) skyColor.z};

--- a/src/main/java/dev/amble/ait/data/schema/door/impl/CapsuleDoorVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/door/impl/CapsuleDoorVariant.java
@@ -33,13 +33,6 @@ public class CapsuleDoorVariant extends DoorSchema {
 
     @Override
     public Vec3d adjustPortalPos(Vec3d pos, Direction direction) {
-        return switch (direction) {
-            case DOWN, UP -> pos;
-            case NORTH -> pos.add(0, 0.04, -0.3);
-            case SOUTH -> pos.add(0, 0.04, 0.3);
-            case WEST -> pos.add(-0, 0.04, -0.3);
-            case EAST -> pos.add(0.0, 0.04, -0.3);
-        };
-
+        return pos.add(0, 0.04, -0.3);
     }
 }

--- a/src/main/java/dev/amble/ait/data/schema/door/impl/DalekModDoorVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/door/impl/DalekModDoorVariant.java
@@ -23,10 +23,10 @@ public class DalekModDoorVariant extends DoorSchema {
     public Vec3d adjustPortalPos(Vec3d pos, Direction direction) {
         return switch (direction) {
             case DOWN, UP -> pos;
-            case NORTH -> pos.add(0, -0.1, -0.425);
-            case SOUTH -> pos.add(0, -0.1, 0.425);
-            case WEST -> pos.add(-0, -0.1, -0.425);
-            case EAST -> pos.add(0.0, -0.1, -0.425);
+            case NORTH -> pos.add(0, 0.08, -0.425);
+            case SOUTH -> pos.add(0, 0.08, 0.425);
+            case WEST -> pos.add(-0, 0.08, -0.425);
+            case EAST -> pos.add(0.0, 0.08, -0.425);
         };
     }
 }

--- a/src/main/java/dev/amble/ait/data/schema/door/impl/TardimDoorVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/door/impl/TardimDoorVariant.java
@@ -18,15 +18,4 @@ public class TardimDoorVariant extends DoorSchema {
     public boolean isDouble() {
         return true;
     }
-
-    @Override
-    public Vec3d adjustPortalPos(Vec3d pos, Direction direction) {
-        return switch (direction) {
-            case DOWN, UP -> pos;
-            case NORTH -> pos.add(0, 0, -0.499f);
-            case SOUTH -> pos.add(0, 0, 0.499f);
-            case WEST -> pos.add(-0.499f, 0, 0);
-            case EAST -> pos.add(0.499f, 0, 0);
-        };
-    }
 }

--- a/src/main/java/dev/amble/ait/data/schema/exterior/variant/box/PoliceBoxVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/exterior/variant/box/PoliceBoxVariant.java
@@ -51,7 +51,7 @@ public abstract class PoliceBoxVariant extends ExteriorVariantSchema {
 
     @Override
     public double portalHeight() {
-        return 2d;
+        return 2.3d;
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/data/schema/exterior/variant/dalek_mod/DalekModVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/exterior/variant/dalek_mod/DalekModVariant.java
@@ -23,14 +23,14 @@ public abstract class DalekModVariant extends ExteriorVariantSchema {
     @Override
     public Vec3d adjustPortalPos(Vec3d pos, byte direction) {
         return switch (direction) {
-            case 0 -> pos.add(0, -0.25, -0.59); // NORTH
-            case 1, 2, 3 -> pos.add(0.43, -0.25, -0.3); // NORTH EAST p n
-            case 4 -> pos.add(0.628, -0.25, 0); // EAST
-            case 5, 6, 7 -> pos.add(0.42, -0.25, 0.42); // SOUTH EAST p p
-            case 8 -> pos.add(0, -0.25, 0.628); // SOUTH
-            case 9, 10, 11 -> pos.add(-0.43, -0.25, 0.45); // SOUTH WEST n p
-            case 12 -> pos.add(-0.628, -0.25, 0); // WEST
-            case 13, 14, 15 -> pos.add(-0.43, -0.25, -0.45); // NORTH WEST n n
+            case 0 -> pos.add(0, -0.05, -0.59); // NORTH
+            case 1, 2, 3 -> pos.add(0.43, -0.05, -0.3); // NORTH EAST p n
+            case 4 -> pos.add(0.628, -0.05, 0); // EAST
+            case 5, 6, 7 -> pos.add(0.42, -0.05, 0.42); // SOUTH EAST p p
+            case 8 -> pos.add(0, -0.05, 0.628); // SOUTH
+            case 9, 10, 11 -> pos.add(-0.43, -0.05, 0.45); // SOUTH WEST n p
+            case 12 -> pos.add(-0.628, -0.05, 0); // WEST
+            case 13, 14, 15 -> pos.add(-0.43, -0.05, -0.45); // NORTH WEST n n
             default -> pos;
         };
     }


### PR DESCRIPTION
## About the PR
I fixed the portal positioning issues we've had with the rendered End Portal BOTI effect that affected datapack exteriors and interior doors alike.

## Why / Balance
It was annoying.

## Technical details
I forgot to change adjustPortalPos() in TardisExteriorBOTI and TardisDoorBOTI classes to parent.getPortalPosition() and parent.door().getPortalPosition() respectively. This has fixed a plethora of maladjusted portal positions across the mod.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: portal positions for all exteriors and their respective interior doors (namely datapacked exteriors) now work as intended.
