### PR TITLE
fix: an NPE with a null world supplied to RiftChunkManager

### DIFF
--- a/src/main/java/dev/amble/ait/core/world/RiftChunkManager.java
+++ b/src/main/java/dev/amble/ait/core/world/RiftChunkManager.java
@@ -119,6 +119,7 @@ public record RiftChunkManager(ServerWorld world) {
     }
 
     public static boolean isRiftChunk(StructureWorldAccess world, ChunkPos pos) {
+        if (world == null) return false;
         return ChunkRandom.getSlimeRandom(pos.x, pos.z,
                 world.getSeed(), 987234910L
         ).nextInt(8) == 0;


### PR DESCRIPTION
## About the PR
This PR fixes an NPE caused by a null world instance supplied to a `RiftChunkManager`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because crashes = bad.

## Technical details
<!-- Summary of code changes for easier review. -->
There was no null check. Yikes.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: dont crash if an invalid world was provided to a rift manager