### PR TITLE
fix: controls no longer require the subsystem they depend on to be enabled if they're a part of the flight sequence

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/control/Control.java
+++ b/src/main/java/dev/amble/ait/core/tardis/control/Control.java
@@ -140,7 +140,7 @@ public class Control implements Identifiable {
 
         SubSystem.IdLike dependent = this.requiredSubSystem();
 
-        if (dependent != null) {
+        if (dependent != null && !this.shouldBeAddedToSequence(tardis)) {
             boolean enabled = tardis.subsystems().get(dependent).isEnabled();
 
             if (!enabled)


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This PR fixes a bug where controls that are a part of the flight sequence would not be interactable.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Otherwise, some events would be a guaranteed failure.

## Technical details
<!-- Summary of code changes for easier review. -->
The subsystem requirement check was done in `#canRun`, while the sequence handling was done in `#runServer`, which was never called, since `#canRun` failed.

The fix adds a check in `#canRun` to ignore the subsystem dependency if the control is a part of the sequence. This should not break existing behavior, as `#runServer` exits early if the control is a part of the sequence.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: controls no longer require the subsystem they depend on to be enabled if they're a part of the flight sequence