### PR TITLE
fix(sonic-overlay): check if crosshair target is null before accessing it

### DIFF
--- a/src/main/java/dev/amble/ait/client/overlays/SonicOverlay.java
+++ b/src/main/java/dev/amble/ait/client/overlays/SonicOverlay.java
@@ -25,7 +25,7 @@ public class SonicOverlay implements HudRenderCallback {
     public void onHudRender(DrawContext drawContext, float v) {
         MinecraftClient mc = MinecraftClient.getInstance();
 
-        if (mc.player == null || mc.world == null)
+        if (mc.player == null || mc.world == null || mc.crosshairTarget == null)
             return;
 
         if (!mc.options.getPerspective().isFirstPerson())


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This PR fixes a crash with vivecraft. To trigger the bug, one would have to hold the sonic and trigger the world loading screen to appear with vivecraft mod enabled.

Original bug report can be found [here](https://discord.com/channels/1213989169878274068/1487958001557176360).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This PR fixes a crash that appears in certain situations with a popular mod (Vivecraft).

## Technical details
<!-- Summary of code changes for easier review. -->
Due to how vivecraft works, it seems like it still caused world rendering to happen even when the player is not really in a world. Meaning that the game would crash if you entered world loading while holding a sonic.

The fix is a simple null check.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->
None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: the game shouldn't crash when you're holding a sonic screwdriver with vivecraft anymore