### PR TITLE
fix: datagen stuff and the spacesuit only needing the chestplate

### DIFF
--- a/src/main/java/dev/amble/ait/config/AITServerConfig.java
+++ b/src/main/java/dev/amble/ait/config/AITServerConfig.java
@@ -72,7 +72,7 @@ public class AITServerConfig {
     @CustomDescription(value = "Dimensions listed here will be excluded. Ignored when the whitelist has entries.")
     @ListGroup(valueFactory = StringListFactory.class, controllerFactory = StringListFactory.class)
     @SerialEntry public List<String> travelBlacklist = Lists.newArrayList(
-            "ait-tardis", "ait:tardis_dimension_type", AITDimensions.TIME_VORTEX_WORLD.getValue().toString(), "ait:space");
+            "ait-tardis", "ait:tardis_dimension_type", AITDimensions.TIME_VORTEX_WORLD.getValue().toString(), "ait:space", "ait:moon", "ait:mars");
 
     @AutoGen(category = CATEGORY)
     @CustomDescription(value = "When populated, only these dimensions will be allowed and the blacklist is ignored.")

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1383,16 +1383,16 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
 
         // Hums
         provider.addTranslation("screen.ait.interior.settings.hum", "HUMS");
-        provider.addTranslation("ait.hum.beacon", "Beacon");
-        provider.addTranslation("ait.hum.copper", "Copper");
-        provider.addTranslation("ait.hum.eight", "Eight");
-        provider.addTranslation("ait.hum.exile", "Exile");
-        provider.addTranslation("ait.hum.prime", "Prime");
-        provider.addTranslation("ait.hum.renaissance", "Renaissance");
-        provider.addTranslation("ait.hum.toyota", "Toyota");
-        provider.addTranslation("ait.hum.coral", "Coral");
-        provider.addTranslation("ait.hum.christmas", "Christmas");
-        provider.addTranslation("ait.hum.off", "Off");
+        provider.addTranslation("hum.ait.beacon", "Beacon");
+        provider.addTranslation("hum.ait.copper", "Copper");
+        provider.addTranslation("hum.ait.eight", "Eight");
+        provider.addTranslation("hum.ait.exile", "Exile");
+        provider.addTranslation("hum.ait.prime", "Prime");
+        provider.addTranslation("hum.ait.renaissance", "Renaissance");
+        provider.addTranslation("hum.ait.toyota", "Toyota");
+        provider.addTranslation("hum.ait.coral", "Coral");
+        provider.addTranslation("hum.ait.christmas", "Christmas");
+        provider.addTranslation("hum.ait.off", "Off");
 
         // Astral Map
         provider.addTranslation("screen.ait.astral_map.show_structures", "Structures");

--- a/src/main/java/dev/amble/ait/module/planet/mixin/gravity/LivingEntityMixin.java
+++ b/src/main/java/dev/amble/ait/module/planet/mixin/gravity/LivingEntityMixin.java
@@ -34,23 +34,6 @@ public abstract class LivingEntityMixin extends Entity {
         super(type, world);
     }
 
-    /*@Inject(method = "tickFallFlying", at = @At("HEAD"), cancellable = true)
-    public void ait$tickFallFlying(CallbackInfo ci) {
-        if (!this.isLogicalSideForUpdatingMovement())
-            return;
-
-        Planet planet = PlanetRegistry.getInstance().get(this.getWorld());
-
-        if (planet == null || !planet.hasGravityModifier())
-            return;
-
-        *//*LivingEntity entity = (LivingEntity) (Object) this;*//*
-        // todo make this better its a yikes
-        if (planet.gravity() > 0) {
-            ci.cancel();
-        }
-    }*/
-
     @Inject(method = "tickMovement", at = @At("TAIL"))
     public void ait$tickMovement(CallbackInfo ci) {
         if (!this.isLogicalSideForUpdatingMovement())
@@ -125,7 +108,7 @@ public abstract class LivingEntityMixin extends Entity {
                 entity.setFrozenTicks(entity.getMinFreezeDamageTicks() + 20);
         }
 
-        if (!planet.hasOxygen() && !Planet.hasFullSuit(entity) && !Planet.hasOxygenInTank(entity)) {
+        if (!planet.hasOxygen() && (!Planet.hasFullSuit(entity) || !Planet.hasOxygenInTank(entity))) {
             entity.addStatusEffect(new StatusEffectInstance(StatusEffects.NAUSEA,
                     200, 1, false, false));
             entity.addStatusEffect(new StatusEffectInstance(StatusEffects.WITHER, 1,


### PR DESCRIPTION
## About the PR
I fixed the datagen for the hums. I missed it last time when I was working on everything else. I also fixed the spacesuit only requiring the chestplate to function.

## Why / Balance
First one is readability, second is because people abused this bug ALL the time for easy oxygenation.

## Technical details
swap ait.hum -> hum.ait, and change the and operator to an or for the fullsuit/hasoxygeninsuit check.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: hums are properly translated
- fix: spacesuits now need the whole suit to function
