### PR TITLE
Feat: Fuel Transfer For Rift Ripper

### DIFF
--- a/src/main/java/dev/amble/ait/client/renderers/machines/ArtronCollectorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/ArtronCollectorRenderer.java
@@ -1,6 +1,7 @@
 package dev.amble.ait.client.renderers.machines;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.block.HorizontalFacingBlock;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.render.RenderLayer;
@@ -37,7 +38,7 @@ public class ArtronCollectorRenderer<T extends ArtronCollectorBlockEntity> imple
 
         BlockState blockState = entity.getCachedState();
 
-        float f = blockState.get(ArtronCollectorBlock.FACING).asRotation();
+        float f = blockState.get(HorizontalFacingBlock.FACING).asRotation();
 
         if (MinecraftClient.getInstance().world == null)
             return;

--- a/src/main/java/dev/amble/ait/client/renderers/machines/RiftRipperRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/RiftRipperRenderer.java
@@ -7,6 +7,7 @@ import dev.amble.ait.core.blockentities.RiftRipperBlockEntity;
 import dev.amble.ait.core.blocks.ArtronCollectorBlock;
 import dev.amble.ait.core.world.RiftChunkManager;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.HorizontalFacingBlock;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.model.ModelPart;
@@ -37,7 +38,7 @@ public class RiftRipperRenderer<T extends RiftRipperBlockEntity> implements Bloc
 
         BlockState blockState = entity.getCachedState();
 
-        float f = blockState.get(ArtronCollectorBlock.FACING).asRotation();
+        float f = blockState.get(HorizontalFacingBlock.FACING).asRotation();
 
         if (MinecraftClient.getInstance().world == null)
             return;

--- a/src/main/java/dev/amble/ait/core/blockentities/ArtronCollectorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/ArtronCollectorBlockEntity.java
@@ -1,7 +1,6 @@
 package dev.amble.ait.core.blockentities;
 
 import dev.amble.ait.core.engine.link.block.FluidLinkBlockEntity;
-import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -9,9 +8,6 @@ import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.network.listener.ClientPlayPacketListener;
-import net.minecraft.network.packet.Packet;
-import net.minecraft.network.packet.s2c.play.BlockEntityUpdateS2CPacket;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
@@ -30,6 +26,8 @@ import dev.amble.ait.core.world.RiftChunkManager;
 import dev.amble.ait.module.gun.core.item.StaserBoltMagazine;
 
 public class ArtronCollectorBlockEntity extends FluidLinkBlockEntity implements BlockEntityTicker<ArtronCollectorBlockEntity>, ArtronHolder {
+
+    public static final int FLOW_AMOUNT = 3;
 
     public double artronAmount = 0;
 
@@ -58,8 +56,8 @@ public class ArtronCollectorBlockEntity extends FluidLinkBlockEntity implements 
             if (stack.getItem() instanceof ArtronCollectorItem) {
                 double residual = ArtronCollectorItem.addFuel(stack, this.getCurrentFuel());
                 this.setCurrentFuel(residual);
-            } else if (stack.getItem() instanceof ArtronHolderItem) {
-                double residual = ((ArtronHolderItem) stack.getItem()).addFuel(this.getCurrentFuel(), stack);
+            } else if (stack.getItem() instanceof ArtronHolderItem artronHolderItem) {
+                double residual = artronHolderItem.addFuel(this.getCurrentFuel(), stack);
                 this.setCurrentFuel(residual);
             } else if (stack.getItem() instanceof ChargedZeitonCrystalItem crystal) {
                 double residual = crystal.addFuel(this.getCurrentFuel(), stack);
@@ -75,7 +73,6 @@ public class ArtronCollectorBlockEntity extends FluidLinkBlockEntity implements 
                     return;
                 }
 
-                // todo - instead of zeiton cluster for fuel, check for the TARDIS_FUEL tag
                 this.addFuel(15);
                 stack.decrement(1);
             }
@@ -98,11 +95,6 @@ public class ArtronCollectorBlockEntity extends FluidLinkBlockEntity implements 
         return this.artronAmount;
     }
 
-    @Nullable @Override
-    public Packet<ClientPlayPacketListener> toUpdatePacket() {
-        return BlockEntityUpdateS2CPacket.create(this);
-    }
-
     @Override
     public NbtCompound toInitialChunkDataNbt() {
         NbtCompound nbtCompound = super.toInitialChunkDataNbt();
@@ -122,26 +114,26 @@ public class ArtronCollectorBlockEntity extends FluidLinkBlockEntity implements 
         RiftChunkManager manager = RiftChunkManager.getInstance(serverWorld);
 
         if (shouldDrainChunk(manager, chunk)) {
-            manager.removeFuel(chunk, 3);
-            this.addFuel(3);
+            manager.removeFuel(chunk, FLOW_AMOUNT);
+            this.addFuel(FLOW_AMOUNT);
 
             this.updateListeners(state);
         }
 
         if (shouldDrawFluid()) {
-            this.removeFuel(3);
-            blockEntity.source().addLevel(3);
+            this.removeFuel(FLOW_AMOUNT);
+            blockEntity.source().addLevel(FLOW_AMOUNT);
             this.updateListeners(state);
         }
     }
 
     private boolean shouldDrainChunk(RiftChunkManager manager, ChunkPos pos) {
         return this.getCurrentFuel() < ArtronCollectorItem.COLLECTOR_MAX_FUEL
-                && manager.getArtron(pos) >= 3;
+                && manager.getArtron(pos) >= FLOW_AMOUNT;
     }
 
     private boolean shouldDrawFluid() {
-        return this.getCurrentFuel() >= 3 && source() != null && !source().isFull();
+        return this.getCurrentFuel() >= FLOW_AMOUNT && source() != null && !source().isLevelFull();
     }
 
     private void updateListeners(BlockState state) {

--- a/src/main/java/dev/amble/ait/core/blockentities/ArtronCollectorBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/ArtronCollectorBlockEntity.java
@@ -1,10 +1,10 @@
 package dev.amble.ait.core.blockentities;
 
+import dev.amble.ait.core.engine.link.block.FluidLinkBlockEntity;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -29,7 +29,7 @@ import dev.amble.ait.core.item.ChargedZeitonCrystalItem;
 import dev.amble.ait.core.world.RiftChunkManager;
 import dev.amble.ait.module.gun.core.item.StaserBoltMagazine;
 
-public class ArtronCollectorBlockEntity extends BlockEntity implements BlockEntityTicker<ArtronCollectorBlockEntity>, ArtronHolder {
+public class ArtronCollectorBlockEntity extends FluidLinkBlockEntity implements BlockEntityTicker<ArtronCollectorBlockEntity>, ArtronHolder {
 
     public double artronAmount = 0;
 
@@ -38,7 +38,7 @@ public class ArtronCollectorBlockEntity extends BlockEntity implements BlockEnti
     }
 
     @Override
-    protected void writeNbt(NbtCompound nbt) {
+    public void writeNbt(NbtCompound nbt) {
         super.writeNbt(nbt);
         nbt.putDouble("artronAmount", this.artronAmount);
     }
@@ -112,26 +112,36 @@ public class ArtronCollectorBlockEntity extends BlockEntity implements BlockEnti
 
     @Override
     public void tick(World world, BlockPos pos, BlockState state, ArtronCollectorBlockEntity blockEntity) {
-        if (world.isClient())
+        if (!(world instanceof ServerWorld serverWorld))
             return;
 
-        if (world.getServer().getTicks() % 3 == 0)
+        if (serverWorld.getServer().getTicks() % 3 == 0)
             return;
 
-        RiftChunkManager manager = RiftChunkManager.getInstance((ServerWorld) this.world);
         ChunkPos chunk = new ChunkPos(pos);
+        RiftChunkManager manager = RiftChunkManager.getInstance(serverWorld);
 
-        if (shouldDrain(manager, chunk)) {
+        if (shouldDrainChunk(manager, chunk)) {
             manager.removeFuel(chunk, 3);
             this.addFuel(3);
 
             this.updateListeners(state);
         }
+
+        if (shouldDrawFluid()) {
+            this.removeFuel(3);
+            blockEntity.source().addLevel(3);
+            this.updateListeners(state);
+        }
     }
 
-    private boolean shouldDrain(RiftChunkManager manager, ChunkPos pos) {
+    private boolean shouldDrainChunk(RiftChunkManager manager, ChunkPos pos) {
         return this.getCurrentFuel() < ArtronCollectorItem.COLLECTOR_MAX_FUEL
                 && manager.getArtron(pos) >= 3;
+    }
+
+    private boolean shouldDrawFluid() {
+        return this.getCurrentFuel() >= 3 && source() != null && !source().isFull();
     }
 
     private void updateListeners(BlockState state) {

--- a/src/main/java/dev/amble/ait/core/blockentities/RiftRipperBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/RiftRipperBlockEntity.java
@@ -60,28 +60,8 @@ public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements Block
     }
 
     @Override
-    public double addFuel(double var) {
-        return ArtronHolder.super.addFuel(var);
-    }
-
-    @Override
-    public void removeFuel(double var) {
-        ArtronHolder.super.removeFuel(var);
-    }
-
-    @Override
     public double getMaxFuel() {
         return ArtronCollectorItem.COLLECTOR_MAX_FUEL;
-    }
-
-    @Override
-    public boolean isOutOfFuel() {
-        return ArtronHolder.super.isOutOfFuel();
-    }
-
-    @Override
-    public boolean isFull() {
-        return ArtronHolder.super.isFull();
     }
 
     @Override
@@ -103,7 +83,7 @@ public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements Block
 
         if (!firstTickHandled) {
             firstTickHandled = true;
-            FluidNetwork.rebuildFrom((ServerWorld) world, pos);
+            FluidNetwork.rebuildFrom(serverWorld, pos);
         }
 
         if (serverWorld.getServer().getTicks() % 3 == 0)
@@ -154,8 +134,8 @@ public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements Block
     }
 
     private void rebuildOwnNetwork() {
-        if (this.hasWorld() && !this.getWorld().isClient()) {
-            FluidNetwork.rebuildFrom((ServerWorld) this.getWorld(), this.getPos());
+        if (this.getWorld() instanceof ServerWorld serverWorld) {
+            FluidNetwork.rebuildFrom(serverWorld, this.getPos());
         }
     }
 
@@ -170,7 +150,7 @@ public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements Block
     }
 
     @Override
-    public double max() {
+    public double maxLevel() {
         return this.getMaxFuel();
     }
 

--- a/src/main/java/dev/amble/ait/core/blockentities/RiftRipperBlockEntity.java
+++ b/src/main/java/dev/amble/ait/core/blockentities/RiftRipperBlockEntity.java
@@ -5,7 +5,10 @@ import dev.amble.ait.api.ArtronHolderItem;
 import dev.amble.ait.core.AITBlockEntityTypes;
 import dev.amble.ait.core.AITBlocks;
 import dev.amble.ait.core.AITItems;
+import dev.amble.ait.core.engine.link.IFluidLink;
+import dev.amble.ait.core.engine.link.IFluidSource;
 import dev.amble.ait.core.engine.link.block.FluidLinkBlockEntity;
+import dev.amble.ait.core.engine.link.tracker.FluidNetwork;
 import dev.amble.ait.core.item.ArtronCollectorItem;
 import dev.amble.ait.core.item.ChargedZeitonCrystalItem;
 import dev.amble.ait.core.world.RiftChunkManager;
@@ -28,8 +31,9 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
-public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements BlockEntityTicker<RiftRipperBlockEntity>, ArtronHolder {
+public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements BlockEntityTicker<RiftRipperBlockEntity>, ArtronHolder, IFluidSource {
 
+    private boolean firstTickHandled;
     public double artronAmount = 0;
 
     public RiftRipperBlockEntity(BlockPos pos, BlockState state) {
@@ -49,42 +53,20 @@ public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements Block
         super.readNbt(nbt);
     }
 
-    public void useOn(World world, boolean sneaking, PlayerEntity player) {
-        if (!world.isClient()) {
-            player.sendMessage(Text.literal(this.getCurrentFuel() + "/" + ArtronCollectorItem.COLLECTOR_MAX_FUEL)
-                    .formatted(Formatting.GOLD));
-            ItemStack stack = player.getMainHandStack();
-            if (stack.getItem() instanceof ArtronCollectorItem) {
-                double residual = ArtronCollectorItem.addFuel(stack, this.getCurrentFuel());
-                this.setCurrentFuel(residual);
-            } else if (stack.getItem() instanceof ArtronHolderItem) {
-                double residual = ((ArtronHolderItem) stack.getItem()).addFuel(this.getCurrentFuel(), stack);
-                this.setCurrentFuel(residual);
-            } else if (stack.getItem() instanceof ChargedZeitonCrystalItem crystal) {
-                double residual = crystal.addFuel(this.getCurrentFuel(), stack);
-                this.setCurrentFuel(residual);
-            } else if (stack.getItem() instanceof StaserBoltMagazine magazine) {
-                double residual = magazine.addFuel(this.getCurrentFuel(), stack);
-                this.setCurrentFuel(residual);
-            }
-            if (stack.isOf(AITBlocks.ZEITON_CLUSTER.asItem())) {
-                if (sneaking) {
-                    player.getInventory().setStack(player.getInventory().selectedSlot,
-                            new ItemStack(AITItems.CHARGED_ZEITON_CRYSTAL));
-                    return;
-                }
-
-                // todo - instead of zeiton cluster for fuel, check for the TARDIS_FUEL tag
-                this.addFuel(15);
-                stack.decrement(1);
-            }
-        }
-    }
-
     @Override
     public void setCurrentFuel(double artronAmount) {
         this.artronAmount = artronAmount;
         this.updateListeners(this.getCachedState());
+    }
+
+    @Override
+    public double addFuel(double var) {
+        return ArtronHolder.super.addFuel(var);
+    }
+
+    @Override
+    public void removeFuel(double var) {
+        ArtronHolder.super.removeFuel(var);
     }
 
     @Override
@@ -93,13 +75,18 @@ public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements Block
     }
 
     @Override
-    public double getCurrentFuel() {
-        return this.artronAmount;
+    public boolean isOutOfFuel() {
+        return ArtronHolder.super.isOutOfFuel();
     }
 
-    @Nullable @Override
-    public Packet<ClientPlayPacketListener> toUpdatePacket() {
-        return BlockEntityUpdateS2CPacket.create(this);
+    @Override
+    public boolean isFull() {
+        return ArtronHolder.super.isFull();
+    }
+
+    @Override
+    public double getCurrentFuel() {
+        return this.artronAmount;
     }
 
     @Override
@@ -111,13 +98,18 @@ public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements Block
 
     @Override
     public void tick(World world, BlockPos pos, BlockState state, RiftRipperBlockEntity blockEntity) {
-        if (world.isClient())
+        if (!(world instanceof ServerWorld serverWorld))
             return;
 
-        if (world.getServer().getTicks() % 3 == 0)
+        if (!firstTickHandled) {
+            firstTickHandled = true;
+            FluidNetwork.rebuildFrom((ServerWorld) world, pos);
+        }
+
+        if (serverWorld.getServer().getTicks() % 3 == 0)
             return;
 
-        RiftChunkManager manager = RiftChunkManager.getInstance((ServerWorld) this.world);
+        RiftChunkManager manager = RiftChunkManager.getInstance(serverWorld);
         ChunkPos chunk = new ChunkPos(pos);
 
         if (shouldDrain(manager, chunk)) {
@@ -126,6 +118,13 @@ public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements Block
 
             this.updateListeners(state);
         }
+    }
+
+    @Override
+    public void onBroken(World world, BlockPos pos) {
+        this.onLoseFluid(); // always.
+
+        super.onBroken(world, pos);
     }
 
     private boolean shouldDrain(RiftChunkManager manager, ChunkPos pos) {
@@ -140,5 +139,63 @@ public class RiftRipperBlockEntity extends FluidLinkBlockEntity implements Block
             return;
 
         this.world.updateListeners(this.getPos(), this.getCachedState(), state, Block.NOTIFY_ALL);
+    }
+
+    @Override
+    public void onGainFluid() {
+        super.onGainFluid();
+        this.rebuildOwnNetwork();
+    }
+
+    @Override
+    public void onLoseFluid() {
+        super.onLoseFluid();
+        this.rebuildOwnNetwork();
+    }
+
+    private void rebuildOwnNetwork() {
+        if (this.hasWorld() && !this.getWorld().isClient()) {
+            FluidNetwork.rebuildFrom((ServerWorld) this.getWorld(), this.getPos());
+        }
+    }
+
+    @Override
+    public double level() {
+        return this.getCurrentFuel();
+    }
+
+    @Override
+    public void setLevel(double level) {
+        this.setCurrentFuel(level);
+    }
+
+    @Override
+    public double max() {
+        return this.getMaxFuel();
+    }
+
+    @Override
+    public void setSource(IFluidSource source) {
+
+    }
+
+    @Override
+    public void setLast(IFluidLink last) {
+
+    }
+
+    @Override
+    public IFluidSource source(boolean search) {
+        return this;
+    }
+
+    @Override
+    public BlockPos getLastPos() {
+        return this.getPos();
+    }
+
+    @Override
+    public IFluidLink last() {
+        return this;
     }
 }

--- a/src/main/java/dev/amble/ait/core/blocks/ArtronCollectorBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/ArtronCollectorBlock.java
@@ -4,6 +4,8 @@ import static dev.amble.ait.client.util.TooltipUtil.addShiftHiddenTooltip;
 
 import java.util.List;
 
+import dev.amble.ait.core.engine.link.block.FluidLinkBlockEntity;
+import dev.amble.ait.core.engine.link.block.HorizontalFluidLinkBlock;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,9 +30,9 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
 import dev.amble.ait.core.blockentities.ArtronCollectorBlockEntity;
-import dev.amble.ait.core.blocks.types.HorizontalDirectionalBlock;
 
-public class ArtronCollectorBlock extends HorizontalDirectionalBlock implements BlockEntityProvider {
+@SuppressWarnings("deprecation")
+public class ArtronCollectorBlock extends HorizontalFluidLinkBlock implements BlockEntityProvider {
 
     protected static final VoxelShape Y_SHAPE = Block.createCuboidShape(6.0, 0.0, 6.0, 10.0, 29.0, 10.0);
 
@@ -64,7 +66,7 @@ public class ArtronCollectorBlock extends HorizontalDirectionalBlock implements 
     }
 
     @Nullable @Override
-    public BlockEntity createBlockEntity(BlockPos pos, BlockState state) {
+    public FluidLinkBlockEntity createBlockEntity(BlockPos pos, BlockState state) {
         return new ArtronCollectorBlockEntity(pos, state);
     }
 

--- a/src/main/java/dev/amble/ait/core/blocks/PowerConverterBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/PowerConverterBlock.java
@@ -29,10 +29,10 @@ import dev.amble.ait.core.AITBlockEntityTypes;
 import dev.amble.ait.core.AITSounds;
 import dev.amble.ait.core.AITTags;
 import dev.amble.ait.core.advancement.TardisCriterions;
-import dev.amble.ait.core.engine.link.block.DirectionalFluidLinkBlock;
+import dev.amble.ait.core.engine.link.block.HorizontalFluidLinkBlock;
 import dev.amble.ait.core.engine.link.block.FluidLinkBlockEntity;
 
-public class PowerConverterBlock extends DirectionalFluidLinkBlock implements ConsumableBlock {
+public class PowerConverterBlock extends HorizontalFluidLinkBlock implements ConsumableBlock {
 
     public static final DirectionProperty FACING = HorizontalFacingBlock.FACING;
     protected static final VoxelShape Y_SHAPE = Block.createCuboidShape(

--- a/src/main/java/dev/amble/ait/core/blocks/RiftRipperBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/RiftRipperBlock.java
@@ -1,10 +1,8 @@
 package dev.amble.ait.core.blocks;
 
 import dev.amble.ait.core.AITEntityTypes;
-import dev.amble.ait.core.blockentities.ArtronCollectorBlockEntity;
 import dev.amble.ait.core.blockentities.RiftRipperBlockEntity;
-import dev.amble.ait.core.blocks.types.HorizontalDirectionalBlock;
-import dev.amble.ait.core.engine.link.block.DirectionalFluidLinkBlock;
+import dev.amble.ait.core.engine.link.block.HorizontalFluidLinkBlock;
 import dev.amble.ait.core.engine.link.block.FluidLinkBlockEntity;
 import dev.amble.ait.core.entities.RiftEntity;
 import dev.amble.ait.core.world.RiftChunkManager;
@@ -40,7 +38,7 @@ import org.joml.Vector3f;
  * The purpose of this block is to rip open rifts in rift chunks as opposed to the silly entities.
  * It mimics the Lodestone block from Doctor Who lore as opposed to the usual Lodestone in Minecraft.
  * */
-public class RiftRipperBlock extends DirectionalFluidLinkBlock implements BlockEntityProvider {
+public class RiftRipperBlock extends HorizontalFluidLinkBlock implements BlockEntityProvider {
 
     // 10 seconds = 200 ticks. We tick every 2 ticks, so 100 steps.
     private static final int TOTAL_STEPS = 30;
@@ -110,8 +108,6 @@ public class RiftRipperBlock extends DirectionalFluidLinkBlock implements BlockE
         int centerX = pos.getX();
         int centerZ = pos.getZ();
 
-        int topY = chunk.sampleHeightmap(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES,
-                centerX & 15, centerZ & 15);
         double targetY = pos.getY() + 1;
 
         double startX = pos.getX() + 0.5;
@@ -126,26 +122,22 @@ public class RiftRipperBlock extends DirectionalFluidLinkBlock implements BlockE
         spawnBeamParticles(world, startX, startY, startZ, endX, targetY, endZ, progress, step);
 
         if (step == TOTAL_STEPS) {
-            // Animation complete — spawn the rift
             RiftEntity riftEntity = AITEntityTypes.RIFT_ENTITY.create(world);
 
             if (riftEntity != null) {
                 riftEntity.refreshPositionAndAngles(endX, targetY, endZ, 0, 0);
                 world.spawnEntity(riftEntity);
 
-                // Set back to a regular lodestone
                 world.setBlockState(pos, Blocks.LODESTONE.getDefaultState());
             }
 
             world.playSound(null, pos, SoundEvents.BLOCK_RESPAWN_ANCHOR_DEPLETE.value(),
                     SoundCategory.BLOCKS, 1.5f, 0.5f);
 
-            // Reset block state
             world.setBlockState(pos, state.with(CHARGE_TICK, 0));
             return;
         }
 
-        // Advance to the next step
         world.setBlockState(pos, state.with(CHARGE_TICK, step + 1));
         world.scheduleBlockTick(pos, this, TICK_INTERVAL);
     }

--- a/src/main/java/dev/amble/ait/core/engine/link/IFluidSource.java
+++ b/src/main/java/dev/amble/ait/core/engine/link/IFluidSource.java
@@ -31,8 +31,8 @@ public interface IFluidSource extends IFluidLink {
         }
     }
 
-    double max();
-    default boolean isFull() {
-        return level() >= max();
+    double maxLevel();
+    default boolean isLevelFull() {
+        return level() >= maxLevel();
     }
 }

--- a/src/main/java/dev/amble/ait/core/engine/link/ITardisSource.java
+++ b/src/main/java/dev/amble/ait/core/engine/link/ITardisSource.java
@@ -22,7 +22,7 @@ public interface ITardisSource extends IFluidSource {
     }
 
     @Override
-    default double max() {
+    default double maxLevel() {
         if (getTardisForFluid() == null) return 0;
 
         return getTardisForFluid().fuel().getMaxFuel();

--- a/src/main/java/dev/amble/ait/core/engine/link/block/HorizontalFluidLinkBlock.java
+++ b/src/main/java/dev/amble/ait/core/engine/link/block/HorizontalFluidLinkBlock.java
@@ -9,8 +9,8 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.util.math.Direction;
 
-public abstract class DirectionalFluidLinkBlock extends FluidLinkBlock {
-    public DirectionalFluidLinkBlock(Settings settings) {
+public abstract class HorizontalFluidLinkBlock extends FluidLinkBlock {
+    public HorizontalFluidLinkBlock(Settings settings) {
         super(settings);
 
         this.setDefaultState(this.stateManager.getDefaultState().with(HorizontalFacingBlock.FACING, Direction.NORTH));


### PR DESCRIPTION
## About the PR
This pull request added fuel transfer capabilities between the Artron Collector and the Rift Ripper, allowing fuel to pass from the chunk through the collector to the Rift Ripper, ripping open rifts instead of the old way.

## Why / Balance
Revises the old, and then the silly refactor, way of getting corally bits from rifts.

## Technical details
Made the Rift Ripper a fluid source, allow the collector to pass fuel through the cables, and be received by the Ripper.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- Rename `DirectionalFluidLinkBlock` -> `HorizontalFluidLinkBlock`
- Rename `ITardisSource#max` -> `ITardisSource#maxLevel`
- Rename `IFluidSource#isFull` -> `IFluidSource#isLevelFull`
- Rename `IFluidSource#max` -> `IFluidSource#maxLevel`
These refactors were made because of a conflict between `ArtronHolder` and `IFluidSource`

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Rift Ripper for opening rifts, powered by Artron Collectors in rift chunks connected via cables