### PR TITLE
fix: dragging/smearing

### DIFF
--- a/src/main/java/dev/amble/ait/client/boti/PaintingBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/PaintingBOTI.java
@@ -20,69 +20,71 @@ public class PaintingBOTI extends BOTI {
         if (!AITModClient.CONFIG.enableTardisBOTI)
             return;
 
-        if (MinecraftClient.getInstance().world == null
-                || MinecraftClient.getInstance().player == null) return;
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.world == null || client.player == null) return;
 
+        // Use the frame model for the shield
         PaintingFrameModel model = new PaintingFrameModel(PaintingFrameModel.getTexturedModelData().createModel());
-
-        stack.push();
-
-        MinecraftClient.getInstance().getFramebuffer().endWrite();
-
-        BOTI_HANDLER.setupFramebuffer();
-
-        BOTI.copyFramebuffer(MinecraftClient.getInstance().getFramebuffer(), BOTI_HANDLER.afbo);
-
         VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
 
+        // === PASS 1: THE DEPTH SHIELD (MAIN FRAMEBUFFER) ===
+        // Draw the frame mask to the main world with color disabled to block clouds/weather.
+        RenderSystem.colorMask(false, false, false, false);
+        RenderSystem.depthMask(true);
+
+        stack.push();
+        // Draw the frame model so the game knows something solid exists here
         model.render(stack, botiProvider.getBuffer(AITRenderLayers.getEntityCutout(frameTexture)), light, OverlayTexture.DEFAULT_UV, 1.0F, 1.0F, 1.0F, 1.0F);
         botiProvider.draw();
+        stack.pop();
 
-        stack.translate(0, 0, -0.125);
+        RenderSystem.colorMask(true, true, true, true);
 
-        // --- FIXED STENCIL AND MASK INITIALIZATION ---
+        // === PASS 2: SETUP CUSTOM FRAMEBUFFER ===
+        client.getFramebuffer().endWrite();
+        BOTI_HANDLER.setupFramebuffer();
+        BOTI.copyFramebuffer(client.getFramebuffer(), BOTI_HANDLER.afbo);
+        BOTI_HANDLER.afbo.beginWrite(false);
+
+        // Clear both Depth/Stencil to prevent AMD partial-clear corruption
+        GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_STENCIL_BUFFER_BIT);
         GL11.glEnable(GL11.GL_STENCIL_TEST);
 
-        GL11.glStencilMask(0xFF);
-        RenderSystem.depthMask(true);
-        RenderSystem.colorMask(true, true, true, true);
-        GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+        // === PASS 3: STENCIL MASK (AFBO) ===
+        RenderSystem.colorMask(false, false, false, false);
+        RenderSystem.depthMask(false);
 
+        GL11.glStencilMask(0xFF);
         GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
         GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
 
-        RenderSystem.depthMask(true);
         stack.push();
+        // Render frame again to set the stencil mask
         frame.renderWithFbo(stack, botiProvider, 0xf000f0, OverlayTexture.DEFAULT_UV, 0, 0, 0, 1, frameTexture);
         botiProvider.draw();
-        BOTI.copyDepth(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
-
-        BOTI_HANDLER.afbo.beginWrite(false);
-        GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
         stack.pop();
 
+        // === PASS 4: PAINTING CONTENT (AFBO) ===
+        RenderSystem.colorMask(true, true, true, true);
+        RenderSystem.depthMask(true);
         GL11.glStencilMask(0x00);
         GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xFF);
 
         stack.push();
-        stack.translate(0, 0, -4f);
+        stack.translate(0, 0, -4f); // Original Z offset logic
         RenderSystem.enableCull();
         paintingContents.render(stack, botiProvider.getBuffer(AITRenderLayers.getBotiInterior(paintingContentsTexture)), 0xf000f0, OverlayTexture.DEFAULT_UV, 1.0F, 1.0F, 1.0F, 1.0F);
         RenderSystem.disableCull();
         botiProvider.draw();
         stack.pop();
 
-        MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
+        // === PASS 5: COMPOSITE TO MAIN ===
+        client.getFramebuffer().beginWrite(true);
+        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 
-        BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
-
-        // --- FIXED CLEANUP ---
-        // Disable test and explicitly reset the mask back to full permissions (0xFF)
+        // Cleanup
         GL11.glDisable(GL11.GL_STENCIL_TEST);
         GL11.glStencilMask(0xFF);
-
         RenderSystem.depthMask(true);
-
-        stack.pop();
     }
 }

--- a/src/main/java/dev/amble/ait/client/boti/PaintingBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/PaintingBOTI.java
@@ -40,14 +40,16 @@ public class PaintingBOTI extends BOTI {
 
         stack.translate(0, 0, -0.125);
 
-        // Enable stencil testing and clear the stencil buffer
+        // --- FIXED STENCIL AND MASK INITIALIZATION ---
         GL11.glEnable(GL11.GL_STENCIL_TEST);
+
         GL11.glStencilMask(0xFF);
+        RenderSystem.depthMask(true);
+        RenderSystem.colorMask(true, true, true, true);
         GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+
         GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
         GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
-
-        // Render the mask overtop the interior of the interior stuff
 
         RenderSystem.depthMask(true);
         stack.push();
@@ -74,7 +76,10 @@ public class PaintingBOTI extends BOTI {
 
         BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
 
+        // --- FIXED CLEANUP ---
+        // Disable test and explicitly reset the mask back to full permissions (0xFF)
         GL11.glDisable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilMask(0xFF);
 
         RenderSystem.depthMask(true);
 

--- a/src/main/java/dev/amble/ait/client/boti/RiftBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/RiftBOTI.java
@@ -22,29 +22,47 @@ public class RiftBOTI extends BOTI {
         if (!AITModClient.CONFIG.enableTardisBOTI)
             return;
 
-        if (MinecraftClient.getInstance().world == null
-                || MinecraftClient.getInstance().player == null) return;
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.world == null || client.player == null) return;
 
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
 
-        MinecraftClient.getInstance().getFramebuffer().endWrite();
-
-        BOTI_HANDLER.setupFramebuffer();
-
-        BOTI.copyFramebuffer(MinecraftClient.getInstance().getFramebuffer(), BOTI_HANDLER.afbo);
-
         VertexConsumerProvider.Immediate portalProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
 
-        // Enable stencil testing
-        GL11.glEnable(GL11.GL_STENCIL_TEST);
-
-        GL11.glStencilMask(0xFF);
+        // === PASS 1: THE DEPTH SHIELD (MAIN FRAMEBUFFER) ===
+        // We draw the doorway mask directly to the main game world with color disabled.
+        // This physically blocks clouds and weather from drawing over the portal space.
+        RenderSystem.colorMask(false, false, false, false);
         RenderSystem.depthMask(true);
+
+        stack.push();
+        stack.translate(0, -0.7f, 0.05);
+        stack.scale(0.65f, 0.65f, 0.65f);
+        frame.render(stack, portalProvider.getBuffer(RenderLayer.getEntityTranslucentCull(CIRCLE_TEXTURE)), 0xf000f0, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
+        portalProvider.draw();
+        stack.pop();
+
+        // Re-enable color for the rest of the rendering
         RenderSystem.colorMask(true, true, true, true);
 
-        GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+        // === PASS 2: SETUP CUSTOM FRAMEBUFFER ===
+        client.getFramebuffer().endWrite();
+        BOTI_HANDLER.setupFramebuffer();
+        BOTI.copyFramebuffer(client.getFramebuffer(), BOTI_HANDLER.afbo);
+        BOTI_HANDLER.afbo.beginWrite(false);
 
+        // Clear AFBO entirely to prevent the AMD partial-clear corruption bug
+        GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_STENCIL_BUFFER_BIT);
+        GL11.glEnable(GL11.GL_STENCIL_TEST);
+
+        // === PASS 3: STENCIL MASK (AFBO) ===
+        // We need the mask in the stencil buffer, but we MUST NOT write depth here.
+        // If we write depth, the vortex will fail the depth test against the flat doorway!
+        RenderSystem.colorMask(false, false, false, false);
+        RenderSystem.depthMask(false); // <-- CRITICAL: Disables depth writes for the mask
+
+        GL11.glStencilMask(0xFF);
         GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
         GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
 
@@ -55,20 +73,17 @@ public class RiftBOTI extends BOTI {
         portalProvider.draw();
         stack.pop();
 
-        copyDepth(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
-
-        BOTI_HANDLER.afbo.beginWrite(false);
-        GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
-
+        // === PASS 4: VORTEX RENDERING ===
+        RenderSystem.colorMask(true, true, true, true);
+        RenderSystem.depthMask(true); // <-- Re-enable depth writes for the vortex itself
         GL11.glStencilMask(0x00);
         GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xFF);
 
         stack.push();
-        stack.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(MinecraftClient.getInstance().getTickDelta() + MinecraftClient.getInstance().player.age));
+        stack.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(client.getTickDelta() + client.player.age));
         stack.translate(0, -1, 400);
 
-        // --- DISABLE FOG ---
-        // Save the current fog state and push it to infinity
+        // Temporarily push fog to infinity so the vortex is always visible
         float oldFogStart = RenderSystem.getShaderFogStart();
         float oldFogEnd = RenderSystem.getShaderFogEnd();
         RenderSystem.setShaderFogStart(Float.MAX_VALUE);
@@ -76,27 +91,23 @@ public class RiftBOTI extends BOTI {
 
         VortexRender util = VortexRender.getCurrentInstance();
         util.render(stack);
-
-        // Ensure the provider draws while the fog is disabled
         portalProvider.draw();
 
-        // --- RESTORE FOG ---
-        // Bring the fog back to normal for the rest of the game world
+        // Restore fog
         RenderSystem.setShaderFogStart(oldFogStart);
         RenderSystem.setShaderFogEnd(oldFogEnd);
 
         stack.pop();
 
-        MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
+        // === PASS 5: COMPOSITE TO MAIN ===
+        client.getFramebuffer().beginWrite(true);
+        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 
-        BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
-
+        // Clean up states
         GL11.glDisable(GL11.GL_STENCIL_TEST);
         GL11.glStencilMask(0xFF);
-
         RenderSystem.depthMask(true);
 
         stack.pop();
-
     }
 }

--- a/src/main/java/dev/amble/ait/client/boti/RiftBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/RiftBOTI.java
@@ -36,20 +36,25 @@ public class RiftBOTI extends BOTI {
 
         VertexConsumerProvider.Immediate portalProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
 
-        // Enable stencil testing and clear the stencil buffer
+        // Enable stencil testing
         GL11.glEnable(GL11.GL_STENCIL_TEST);
+
         GL11.glStencilMask(0xFF);
+        RenderSystem.depthMask(true);
+        RenderSystem.colorMask(true, true, true, true);
+
         GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+
         GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
         GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
 
-        RenderSystem.depthMask(true);
         stack.push();
         stack.translate(0, -0.7f, 0.05);
         stack.scale(0.65f, 0.65f, 0.65f);
         frame.render(stack, portalProvider.getBuffer(RenderLayer.getEntityTranslucentCull(CIRCLE_TEXTURE)), 0xf000f0, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
         portalProvider.draw();
         stack.pop();
+
         copyDepth(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
 
         BOTI_HANDLER.afbo.beginWrite(false);
@@ -87,9 +92,11 @@ public class RiftBOTI extends BOTI {
         BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
 
         GL11.glDisable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilMask(0xFF);
 
         RenderSystem.depthMask(true);
 
         stack.pop();
+
     }
 }

--- a/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
@@ -31,73 +31,74 @@ import dev.amble.ait.registry.impl.CategoryRegistry;
 
 public class TardisDoorBOTI extends BOTI {
     public static void renderInteriorDoorBoti(ClientTardis tardis, DoorBlockEntity door, ClientExteriorVariantSchema variant, MatrixStack stack, Identifier frameTex, AnimatedModel frame, ModelPart mask, int light, float tickDelta) {
-        ExteriorVariantSchema parent = variant.parent();
+        if (!AITModClient.CONFIG.enableTardisBOTI) return;
 
-        if (MinecraftClient.getInstance().world == null
-                || MinecraftClient.getInstance().player == null) return;
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.world == null || client.player == null) return;
+
+        // --- PASS 1: THE DEPTH SHIELD (MAIN FRAMEBUFFER) ---
+        // Draw the door mask to the main world with color disabled.
+        // This physically blocks clouds and weather from drawing over the portal space.
+        RenderSystem.colorMask(false, false, false, false);
+        RenderSystem.depthMask(true);
 
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
-
-        MinecraftClient.getInstance().getFramebuffer().endWrite();
-
-        BOTI_HANDLER.setupFramebuffer();
-
-        Vec3d skyColor = MinecraftClient.getInstance().world.getSkyColor(MinecraftClient.getInstance().player.getPos(), MinecraftClient.getInstance().getTickDelta());
-        if (AITModClient.CONFIG.greenScreenBOTI)
-            BOTI.setFramebufferColor(BOTI_HANDLER.afbo, 0, 1, 0, 1);
-        else
-            BOTI.setFramebufferColor(BOTI_HANDLER.afbo, (float) skyColor.x, (float) skyColor.y, (float) skyColor.z, 1);
-
-        BOTI.copyFramebuffer(MinecraftClient.getInstance().getFramebuffer(), BOTI_HANDLER.afbo);
-
-        VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
-
-        // --- FIXED STENCIL AND MASK INITIALIZATION ---
-        GL11.glEnable(GL11.GL_STENCIL_TEST);
-
-        // Force masks to true so the hardware driver accepts the clear command
-        GL11.glStencilMask(0xFF);
-        RenderSystem.depthMask(true);
-        RenderSystem.colorMask(true, true, true, true);
-
-        // Clear the stencil buffer completely
-        GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
-
-        // Setup stencil rules for drawing the portal door mask
-        GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
-        GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
-
-        RenderSystem.depthMask(true);
-        stack.push();
         StatsHandler stats = tardis.stats();
         Vector3f scale = tardis.travel().getScale();
+        ExteriorVariantSchema parent = variant.parent();
 
-        stack.scale((float) parent.portalWidth() * scale.x(),
-                (float) parent.portalHeight() * scale.y(), scale.z());
+        stack.scale((float) parent.portalWidth() * scale.x(), (float) parent.portalHeight() * scale.y(), scale.z());
         Vec3d vec = parent.door().getPortalPosition();
         if (vec == null) vec = new Vec3d(0, 0, 0);
         stack.translate(vec.x, vec.y - 0.575f, vec.z);
-        if (tardis.travel().getState() == TravelHandlerBase.State.LANDED) {
-            RenderLayer whichOne = AITModClient.CONFIG.greenScreenBOTI ?
-                    RenderLayer.getDebugFilledBox() : RenderLayer.getEndGateway();
-            float[] colorsForGreenScreen = AITModClient.CONFIG.greenScreenBOTI ? new float[]{0, 1, 0, 1} : new float[] {(float) skyColor.x, (float) skyColor.y, (float) skyColor.z};
-            mask.render(stack, botiProvider.getBuffer(whichOne), 0xf000f0, OverlayTexture.DEFAULT_UV, colorsForGreenScreen[0], colorsForGreenScreen[1], colorsForGreenScreen[2], 1);
-        } else {
-            mask.render(stack, botiProvider.getBuffer(RenderLayer.getEntityTranslucentCull(frameTex)), 0xf000f0, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
-        }
+
+        // Simple render of the mask to write to the main depth buffer
+        mask.render(stack, AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer().getBuffer(RenderLayer.getEndGateway()), 0xf000f0, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
+        AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer().draw();
+        stack.pop();
+
+        RenderSystem.colorMask(true, true, true, true);
+
+        // --- PASS 2: SETUP CUSTOM FRAMEBUFFER ---
+        client.getFramebuffer().endWrite();
+        BOTI_HANDLER.setupFramebuffer();
+        BOTI.copyFramebuffer(client.getFramebuffer(), BOTI_HANDLER.afbo);
+        BOTI_HANDLER.afbo.beginWrite(false);
+
+        // Clear BOTH Depth and Stencil. This provides a clean slate for AMD cards.
+        GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_STENCIL_BUFFER_BIT);
+        GL11.glEnable(GL11.GL_STENCIL_TEST);
+
+        // --- PASS 3: STENCIL MASK (AFBO) ---
+        // We mask the AFBO stencil without writing to the AFBO depth buffer.
+        RenderSystem.colorMask(false, false, false, false);
+        RenderSystem.depthMask(false);
+
+        GL11.glStencilMask(0xFF);
+        GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
+        GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
+
+        stack.push();
+        stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
+        stack.scale((float) parent.portalWidth() * scale.x(), (float) parent.portalHeight() * scale.y(), scale.z());
+        stack.translate(vec.x, vec.y - 0.575f, vec.z);
+
+        // Render mask again for AFBO stencil
+        VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
+        mask.render(stack, botiProvider.getBuffer(RenderLayer.getEntityTranslucentCull(frameTex)), 0xf000f0, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
         botiProvider.draw();
         stack.pop();
-        copyDepth(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
 
-        BOTI_HANDLER.afbo.beginWrite(false);
-        GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
-
+        // --- PASS 4: VORTEX AND DOOR RENDERING ---
+        RenderSystem.colorMask(true, true, true, true);
+        RenderSystem.depthMask(true);
         GL11.glStencilMask(0x00);
         GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xFF);
 
+        // RENDER VORTEX
         stack.push();
-        float delta = MinecraftClient.getInstance().getTickDelta() + MinecraftClient.getInstance().player.age;
+        float delta = client.getTickDelta() + client.player.age;
         if (!tardis.travel().autopilot() && tardis.travel().getState() != TravelHandlerBase.State.LANDED)
             stack.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees((delta) * (tardis.travel().speed() * 0.7f)));
         if (!tardis.crash().isNormal())
@@ -107,69 +108,50 @@ public class TardisDoorBOTI extends BOTI {
         stack.translate(0, 0, 500);
         stack.scale(1.5f, 1.5f, 1.5f);
         VortexRender util = stats.getVortexEffects().toRender();
-        if (!tardis.travel().isLanded() /*&& !tardis.flight().isFlying()*/) {
+        if (!tardis.travel().isLanded()) {
             util.setSpeed(tardis.travel().speed() < 1 ? 4 : tardis.travel().speed());
             util.render(stack);
-            /*// TODO not a clue if this will work but oh well - Loqor
-            stack.push();
-            stack.scale(0.9f, 0.9f, 0.9f);
-            util.renderVortex(stack);
-            stack.pop();*/
         }
         botiProvider.draw();
         stack.pop();
 
+        // RENDER DOOR
         if (!tardis.getExterior().getCategory().equals(CategoryRegistry.GEOMETRIC)) {
             stack.push();
             stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
             stack.scale(scale.x, scale.y, scale.z);
-
-            // TODO: use DoorRenderer/ClientLightUtil instead.
             frame.renderWithAnimations(tardis, door, frame.getPart(), stack, botiProvider.getBuffer(AITRenderLayers.getBotiInterior(variant.texture())), light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F, tickDelta);
-            //((DoorModel) frame).render(stack, botiProvider.getBuffer(AITRenderLayers.getBotiInterior(variant.texture())), light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F);
             botiProvider.draw();
             stack.pop();
 
+            // EMISSIVE
             stack.push();
             stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
             stack.scale(scale.x, scale.y, scale.z);
             if (variant.emission() != null) {
-                float u = 1;
-                float t = 1;
-                float s = 1;
-
+                float u = 1, t = 1, s = 1;
                 if ((stats.getName() != null && "partytardis".equalsIgnoreCase(stats.getName()) || (!tardis.extra().getInsertedDisc().isEmpty()))) {
                     final float[] rgb = ClientTardisUtil.getPartyColors();
-
-                    u = rgb[0];
-                    t = rgb[1];
-                    s = rgb[2];
+                    u = rgb[0]; t = rgb[1]; s = rgb[2];
                 }
-
                 boolean power = tardis.fuel().hasPower();
                 boolean alarm = tardis.alarm().isEnabled();
-
                 float red = power ? s : 0;
                 float green = power ? alarm ? 0.3f : t : 0;
-                float blue = power ? alarm ? 0.3f : u:  0;
-
+                float blue = power ? alarm ? 0.3f : u : 0;
                 frame.renderWithAnimations(tardis, door, frame.getPart(), stack, botiProvider.getBuffer((DependencyChecker.hasIris() ? AITRenderLayers.tardisEmissiveCullZOffset(variant.emission(), true) : AITRenderLayers.getText(variant.emission()))), 0xf000f0, OverlayTexture.DEFAULT_UV, red, green, blue, 1.0F, tickDelta);
                 botiProvider.draw();
             }
             stack.pop();
         }
 
-        MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
+        // --- PASS 5: COMPOSITE TO MAIN ---
+        client.getFramebuffer().beginWrite(true);
+        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 
-        BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
-
-        // --- FIXED CLEANUP ---
-        // Disable test and explicitly reset the mask back to full permissions (0xFF)
+        // Cleanup
         GL11.glDisable(GL11.GL_STENCIL_TEST);
         GL11.glStencilMask(0xFF);
-
         RenderSystem.depthMask(true);
-
-        stack.pop();
     }
 }

--- a/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
@@ -53,9 +53,18 @@ public class TardisDoorBOTI extends BOTI {
 
         VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
 
+        // --- FIXED STENCIL AND MASK INITIALIZATION ---
         GL11.glEnable(GL11.GL_STENCIL_TEST);
+
+        // Force masks to true so the hardware driver accepts the clear command
         GL11.glStencilMask(0xFF);
+        RenderSystem.depthMask(true);
+        RenderSystem.colorMask(true, true, true, true);
+
+        // Clear the stencil buffer completely
         GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+
+        // Setup stencil rules for drawing the portal door mask
         GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
         GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
 
@@ -154,7 +163,10 @@ public class TardisDoorBOTI extends BOTI {
 
         BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
 
+        // --- FIXED CLEANUP ---
+        // Disable test and explicitly reset the mask back to full permissions (0xFF)
         GL11.glDisable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilMask(0xFF);
 
         RenderSystem.depthMask(true);
 

--- a/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
@@ -31,46 +31,17 @@ import dev.amble.ait.registry.impl.exterior.ClientExteriorVariantRegistry;
 
 public class TardisExteriorBOTI extends BOTI {
     public void renderExteriorBoti(ExteriorBlockEntity exterior, ClientExteriorVariantSchema variant, MatrixStack stack, Identifier frameTex, ExteriorModel frame, ModelPart mask, int light) {
-        if (MinecraftClient.getInstance().world == null
-                || MinecraftClient.getInstance().player == null) return;
-
-        if (!exterior.isLinked())
-            return;
+        if (MinecraftClient.getInstance().world == null || MinecraftClient.getInstance().player == null) return;
+        if (!exterior.isLinked()) return;
 
         ClientTardis tardis = exterior.tardis().get().asClient();
+        MinecraftClient client = MinecraftClient.getInstance();
 
-        stack.push();
-
-        MinecraftClient.getInstance().getFramebuffer().endWrite();
-
-        BOTI_HANDLER.setupFramebuffer();
-
-        Vec3d skyColor = MinecraftClient.getInstance().world.getSkyColor(MinecraftClient.getInstance().player.getPos(), MinecraftClient.getInstance().getTickDelta());
-        if (AITModClient.CONFIG.greenScreenBOTI)
-            BOTI.setFramebufferColor(BOTI_HANDLER.afbo, 0, 1, 0, 1);
-        else
-            BOTI.setFramebufferColor(BOTI_HANDLER.afbo, (float) skyColor.x, (float) skyColor.y, (float) skyColor.z, 1);
-
-        BOTI.copyFramebuffer(MinecraftClient.getInstance().getFramebuffer(), BOTI_HANDLER.afbo);
-
-        VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
-
-        // --- FIXED STENCIL AND MASK INITIALIZATION ---
-        GL11.glEnable(GL11.GL_STENCIL_TEST);
-
-        // Force masks to true so the hardware driver accepts the clear command
-        GL11.glStencilMask(0xFF);
+        // --- PASS 1: THE DEPTH SHIELD (MAIN FRAMEBUFFER) ---
+        // Draw the mask to the main world with color disabled to block clouds/weather.
+        RenderSystem.colorMask(false, false, false, false);
         RenderSystem.depthMask(true);
-        RenderSystem.colorMask(true, true, true, true);
 
-        // Clear the stencil buffer completely
-        GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
-
-        // Setup stencil rules for drawing the portal exterior mask
-        GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
-        GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
-
-        RenderSystem.depthMask(true);
         stack.push();
         StatsHandler stats = tardis.stats();
         String name = stats.getName();
@@ -81,26 +52,58 @@ public class TardisExteriorBOTI extends BOTI {
             stack.translate(0, scale.y() + 0.25f, scale.z() - 1.7f);
         }
         ExteriorVariantSchema parent = variant.parent();
-        stack.scale((float) parent.portalWidth() * scale.x(),
-                (float) parent.portalHeight() * scale.y(), scale.z());
+        stack.scale((float) parent.portalWidth() * scale.x(), (float) parent.portalHeight() * scale.y(), scale.z());
         Vec3d vec = parent.getPortalPosition();
         if (vec == null) vec = new Vec3d(0, 0, 0);
         stack.translate(vec.x, vec.y - 0.475f, vec.z);
-        RenderLayer whichOne = AITModClient.CONFIG.greenScreenBOTI ?
-                RenderLayer.getDebugFilledBox() : RenderLayer.getEndGateway();
-        float[] colorsForGreenScreen = AITModClient.CONFIG.greenScreenBOTI ? new float[]{0, 1, 0, 1} : new float[] {(float) skyColor.x, (float) skyColor.y, (float) skyColor.z};
-        mask.render(stack, botiProvider.getBuffer(whichOne), light, OverlayTexture.DEFAULT_UV, colorsForGreenScreen[0], colorsForGreenScreen[1], colorsForGreenScreen[2], 1);
+
+        // Render the mask to create the depth shield
+        mask.render(stack, AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer().getBuffer(RenderLayer.getEndGateway()), light, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
+        AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer().draw();
+        stack.pop();
+
+        RenderSystem.colorMask(true, true, true, true);
+
+        // --- PASS 2: SETUP CUSTOM FRAMEBUFFER ---
+        client.getFramebuffer().endWrite();
+        BOTI_HANDLER.setupFramebuffer();
+        BOTI.copyFramebuffer(client.getFramebuffer(), BOTI_HANDLER.afbo);
+        BOTI_HANDLER.afbo.beginWrite(false);
+
+        // Clear BOTH Depth and Stencil. This is critical for AMD driver stability.
+        GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT | GL11.GL_STENCIL_BUFFER_BIT);
+        GL11.glEnable(GL11.GL_STENCIL_TEST);
+
+        // --- PASS 3: STENCIL MASK (AFBO) ---
+        RenderSystem.colorMask(false, false, false, false);
+        RenderSystem.depthMask(false);
+
+        GL11.glStencilMask(0xFF);
+        GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
+        GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
+
+        stack.push();
+        stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
+        if (name.equalsIgnoreCase("grumm") || name.equalsIgnoreCase("dinnerbone")) {
+            stack.multiply(RotationAxis.POSITIVE_X.rotationDegrees(-90f));
+            stack.translate(0, scale.y() + 0.25f, scale.z() - 1.7f);
+        }
+        stack.scale((float) parent.portalWidth() * scale.x(), (float) parent.portalHeight() * scale.y(), scale.z());
+        stack.translate(vec.x, vec.y - 0.475f, vec.z);
+
+        // Render mask again for the stencil
+        VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
+        mask.render(stack, botiProvider.getBuffer(RenderLayer.getEndGateway()), light, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
         botiProvider.draw();
         stack.pop();
 
-        copyDepth(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
-
-        BOTI_HANDLER.afbo.beginWrite(false);
-        GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
-
+        // --- PASS 4: EXTERIOR RENDERING ---
+        RenderSystem.colorMask(true, true, true, true);
+        RenderSystem.depthMask(true);
         GL11.glStencilMask(0x00);
         GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xFF);
 
+        // Render Doors
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
         if (name.equalsIgnoreCase("grumm") || name.equalsIgnoreCase("dinnerbone")) {
@@ -108,11 +111,11 @@ public class TardisExteriorBOTI extends BOTI {
             stack.translate(0, scale.y + 0.25f, scale.z -1.7f);
         }
         stack.scale(scale.x(), scale.y(), scale.z());
-
         frame.renderDoors(tardis, exterior, frame.getPart(), stack, botiProvider.getBuffer(AITRenderLayers.getBotiInterior(variant.texture())), light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F, true);
         botiProvider.draw();
         stack.pop();
 
+        // Render Biome
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
         if (name.equalsIgnoreCase("grumm") || name.equalsIgnoreCase("dinnerbone")) {
@@ -120,18 +123,16 @@ public class TardisExteriorBOTI extends BOTI {
             stack.translate(0, scale.y() + 0.25f, scale.z() -1.7f);
         }
         stack.scale(scale.x(), scale.y(), scale.z());
-
         if (variant != ClientExteriorVariantRegistry.CORAL_GROWTH) {
             BiomeHandler handler = exterior.tardis().get().handler(TardisComponent.Id.BIOME);
             Identifier biomeTexture = handler.getBiomeKey().get(variant.overrides());
             if (biomeTexture != null)
-                frame.renderDoors(tardis, exterior, frame.getPart(), stack,
-                        botiProvider.getBuffer(AITRenderLayers.getEntityTranslucentCull(biomeTexture)),
-                        light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F, true);
+                frame.renderDoors(tardis, exterior, frame.getPart(), stack, botiProvider.getBuffer(AITRenderLayers.getEntityTranslucentCull(biomeTexture)), light, OverlayTexture.DEFAULT_UV, 1, 1F, 1.0F, 1.0F, true);
         }
         botiProvider.draw();
         stack.pop();
 
+        // Render Emissive
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
         if (name.equalsIgnoreCase("grumm") || name.equalsIgnoreCase("dinnerbone")) {
@@ -140,17 +141,14 @@ public class TardisExteriorBOTI extends BOTI {
         }
         stack.scale(scale.x(), scale.y(), scale.z());
         if (variant.emission() != null) {
-            float u;
-            float t;
-            float s;
-
+            float u, t, s;
             if ((stats.getName() != null && "partytardis".equals(stats.getName().toLowerCase()) || (!exterior.tardis().get().extra().getInsertedDisc().isEmpty()))) {
                 int m = 25;
-                int n = MinecraftClient.getInstance().player.age / m + MinecraftClient.getInstance().player.getId();
+                int n = client.player.age / m + client.player.getId();
                 int o = DyeColor.values().length;
                 int p = n % o;
                 int q = (n + 1) % o;
-                float r = ((float) (MinecraftClient.getInstance().player.age % m)) / m;
+                float r = ((float) (client.player.age % m)) / m;
                 float[] fs = SheepEntity.getRgbColor(DyeColor.byId(p));
                 float[] gs = SheepEntity.getRgbColor(DyeColor.byId(q));
                 s = fs[0] * (1f - r) + gs[0] * r;
@@ -158,32 +156,26 @@ public class TardisExteriorBOTI extends BOTI {
                 u = fs[2] * (1f - r) + gs[2] * r;
             } else {
                 float[] hs = new float[]{1.0f, 1.0f, 1.0f};
-                s = hs[0];
-                t = hs[1];
-                u = hs[2];
+                s = hs[0]; t = hs[1]; u = hs[2];
             }
-
             boolean power = tardis.fuel().hasPower();
             boolean alarms = tardis.alarm().isEnabled();
-
             float red = power ? s : alarms ? 0.3f : 0;
             float green = power ? alarms ? 0.3f : t : 0;
             float blue = power ? alarms ? 0.3f : u : 0;
-
-            frame.renderDoors(tardis, exterior, frame.getPart(), stack, botiProvider.getBuffer(AITRenderLayers.tardisEmissiveCullZOffset(variant.emission(), true)), 0xf000f0,
-                    OverlayTexture.DEFAULT_UV, red, green, blue, 1, true);
+            frame.renderDoors(tardis, exterior, frame.getPart(), stack, botiProvider.getBuffer(AITRenderLayers.tardisEmissiveCullZOffset(variant.emission(), true)), 0xf000f0, OverlayTexture.DEFAULT_UV, red, green, blue, 1, true);
             botiProvider.draw();
         }
         stack.pop();
 
-        MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
+        // --- PASS 5: COMPOSITE TO MAIN ---
+        client.getFramebuffer().beginWrite(true);
+        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 
-        BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
+        // Cleanup
         GL11.glDisable(GL11.GL_STENCIL_TEST);
         GL11.glStencilMask(0xFF);
         RenderSystem.depthMask(true);
-
-        stack.pop();
     }
 
 }

--- a/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
@@ -55,9 +55,18 @@ public class TardisExteriorBOTI extends BOTI {
 
         VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
 
+        // --- FIXED STENCIL AND MASK INITIALIZATION ---
         GL11.glEnable(GL11.GL_STENCIL_TEST);
+
+        // Force masks to true so the hardware driver accepts the clear command
         GL11.glStencilMask(0xFF);
+        RenderSystem.depthMask(true);
+        RenderSystem.colorMask(true, true, true, true);
+
+        // Clear the stencil buffer completely
         GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+
+        // Setup stencil rules for drawing the portal exterior mask
         GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 0xFF);
         GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
 
@@ -170,9 +179,11 @@ public class TardisExteriorBOTI extends BOTI {
         MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
 
         BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
-
         GL11.glDisable(GL11.GL_STENCIL_TEST);
+        GL11.glStencilMask(0xFF);
+        RenderSystem.depthMask(true);
 
         stack.pop();
     }
+
 }


### PR DESCRIPTION
## About the PR
Should fix smearing on the screen when viewing the rifts, exterior/interior door boti, and paintings.

## Why / Balance
no more not being able to see!

## Technical details
switched around where the clears and masks go in each different boti class.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: smearing across the screen with rifts, exteriors, doors and paintings