### PR TITLE
Fix: Console Animations

### DIFF
--- a/.github/workflows/publish-devbuilds.yml
+++ b/.github/workflows/publish-devbuilds.yml
@@ -80,7 +80,7 @@ jobs:
         avatar: 'https://i.imgur.com/uiFqrQh.png'
         
         message: |
-          <:al_error:1513885241339678852> New <:al_ait:1393920126645960704> **Adventures in Time** (**AIT**) dev build [**`#${{ github.run_number }}`**](<https://github.com/amblelabs/ait/actions/runs/${{ github.run_id }}>) **failed** to build! <a:al_explosion:1467652202356150272>
+          <:al_error:1513885241339678852> New <:al_ait:1393920126645960704> **Adventures in Time** (**AIT**) dev build [**`#${{ github.run_number }}`**](<https://github.com/amblelabs/ait/actions/runs/${{ github.run_id }}>) **failed** to build!
   maven:
     runs-on: ubuntu-latest
     permissions:

--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -110,6 +110,7 @@ import dev.amble.ait.registry.impl.exterior.ClientExteriorVariantRegistry;
 public class AITModClient implements ClientModInitializer {
 
     public static AITClientConfig CONFIG;
+    public static final MinecraftClient client = MinecraftClient.getInstance();
 
     @Override
     public void onInitializeClient() {
@@ -501,7 +502,6 @@ public class AITModClient implements ClientModInitializer {
     public void exteriorBOTI(WorldRenderContext context) {
         if (skipBuiltInBOTI()) return;
 
-        MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
         MatrixStack stack = context.matrixStack();
@@ -534,7 +534,6 @@ public class AITModClient implements ClientModInitializer {
     public void doorBOTI(WorldRenderContext context) {
         if (skipBuiltInBOTI()) return;
 
-        MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
         MatrixStack stack = context.matrixStack();
@@ -568,7 +567,6 @@ public class AITModClient implements ClientModInitializer {
     public void gallifreyanBOTI(WorldRenderContext context) {
         if (skipPaintingBOTI()) return;
 
-        MinecraftClient client = MinecraftClient.getInstance();
         SinglePartEntityModel contents = new GallifreyFallsModel(GallifreyFallsModel.getTexturedModelData().createModel());
         Identifier frameTex = GallifreyanPaintingEntityRenderer.GALLIFREY_FRAME_TEXTURE;
         Identifier contentsTex = GallifreyanPaintingEntityRenderer.GALLIFREY_PAINTING_TEXTURE;
@@ -597,7 +595,6 @@ public class AITModClient implements ClientModInitializer {
     public void trenzaloreBOTI(WorldRenderContext context) {
         if (skipPaintingBOTI()) return;
 
-        MinecraftClient client = MinecraftClient.getInstance();
         SinglePartEntityModel contents = new TrenzalorePaintingModel(TrenzalorePaintingModel.getTexturedModelData().createModel());
         Identifier frameTex = TrenzalorePaintingEntityRenderer.TRENZALORE_FRAME_TEXTURE;
         Identifier contentsTex = TrenzalorePaintingEntityRenderer.TRENZALORE_PAINTING_TEXTURE;
@@ -626,7 +623,6 @@ public class AITModClient implements ClientModInitializer {
     public void riftBOTI(WorldRenderContext context) {
         if (skipPaintingBOTI()) return;
 
-        MinecraftClient client = MinecraftClient.getInstance();
         if (client.player == null || client.world == null) return;
         ClientWorld world = client.world;
         MatrixStack stack = context.matrixStack();

--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -110,7 +110,7 @@ import dev.amble.ait.registry.impl.exterior.ClientExteriorVariantRegistry;
 public class AITModClient implements ClientModInitializer {
 
     public static AITClientConfig CONFIG;
-    public static final MinecraftClient client = MinecraftClient.getInstance();
+    private final MinecraftClient client = MinecraftClient.getInstance();
 
     @Override
     public void onInitializeClient() {

--- a/src/main/java/dev/amble/ait/client/boti/BOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/BOTI.java
@@ -19,6 +19,7 @@ import dev.amble.ait.core.entities.BOTIPaintingEntity;
 import dev.amble.ait.core.entities.RiftEntity;
 
 public class BOTI {
+    public static final MinecraftClient client = MinecraftClient.getInstance();
     public static final Queue<RiftEntity> RIFT_RENDERING_QUEUE = new LinkedList<>();
     public static BOTIInit BOTI_HANDLER = new BOTIInit();
     public static AITBufferBuilderStorage AIT_BUF_BUILDER_STORAGE = new AITBufferBuilderStorage();

--- a/src/main/java/dev/amble/ait/client/boti/PaintingBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/PaintingBOTI.java
@@ -20,18 +20,18 @@ public class PaintingBOTI extends BOTI {
         if (!AITModClient.CONFIG.enableTardisBOTI)
             return;
 
-        if (MinecraftClient.getInstance().world == null
-                || MinecraftClient.getInstance().player == null) return;
+        if (client.world == null
+                || client.player == null) return;
 
         PaintingFrameModel model = new PaintingFrameModel(PaintingFrameModel.getTexturedModelData().createModel());
 
         stack.push();
 
-        MinecraftClient.getInstance().getFramebuffer().endWrite();
+        client.getFramebuffer().endWrite();
 
         BOTI_HANDLER.setupFramebuffer();
 
-        BOTI.copyFramebuffer(MinecraftClient.getInstance().getFramebuffer(), BOTI_HANDLER.afbo);
+        BOTI.copyFramebuffer(client.getFramebuffer(), BOTI_HANDLER.afbo);
 
         VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
 
@@ -53,7 +53,7 @@ public class PaintingBOTI extends BOTI {
         stack.push();
         frame.renderWithFbo(stack, botiProvider, 0xf000f0, OverlayTexture.DEFAULT_UV, 0, 0, 0, 1, frameTexture);
         botiProvider.draw();
-        BOTI.copyDepth(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
+        BOTI.copyDepth(BOTI_HANDLER.afbo, client.getFramebuffer());
 
         BOTI_HANDLER.afbo.beginWrite(false);
         GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
@@ -70,9 +70,9 @@ public class PaintingBOTI extends BOTI {
         botiProvider.draw();
         stack.pop();
 
-        MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
+        client.getFramebuffer().beginWrite(true);
 
-        BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
+        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 
         GL11.glDisable(GL11.GL_STENCIL_TEST);
 

--- a/src/main/java/dev/amble/ait/client/boti/RiftBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/RiftBOTI.java
@@ -22,17 +22,17 @@ public class RiftBOTI extends BOTI {
         if (!AITModClient.CONFIG.enableTardisBOTI)
             return;
 
-        if (MinecraftClient.getInstance().world == null
-                || MinecraftClient.getInstance().player == null) return;
+        if (client.world == null
+                || client.player == null) return;
 
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
 
-        MinecraftClient.getInstance().getFramebuffer().endWrite();
+        client.getFramebuffer().endWrite();
 
         BOTI_HANDLER.setupFramebuffer();
 
-        BOTI.copyFramebuffer(MinecraftClient.getInstance().getFramebuffer(), BOTI_HANDLER.afbo);
+        BOTI.copyFramebuffer(client.getFramebuffer(), BOTI_HANDLER.afbo);
 
         VertexConsumerProvider.Immediate portalProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
 
@@ -50,7 +50,7 @@ public class RiftBOTI extends BOTI {
         frame.render(stack, portalProvider.getBuffer(RenderLayer.getEntityTranslucentCull(CIRCLE_TEXTURE)), 0xf000f0, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
         portalProvider.draw();
         stack.pop();
-        copyDepth(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
+        copyDepth(BOTI_HANDLER.afbo, client.getFramebuffer());
 
         BOTI_HANDLER.afbo.beginWrite(false);
         GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
@@ -59,7 +59,7 @@ public class RiftBOTI extends BOTI {
         GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xFF);
 
         stack.push();
-        stack.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(MinecraftClient.getInstance().getTickDelta() + MinecraftClient.getInstance().player.age));
+        stack.multiply(RotationAxis.POSITIVE_Z.rotationDegrees(client.getTickDelta() + client.player.age));
         stack.translate(0, -1, 400);
 
         // --- DISABLE FOG ---
@@ -82,9 +82,9 @@ public class RiftBOTI extends BOTI {
 
         stack.pop();
 
-        MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
+        client.getFramebuffer().beginWrite(true);
 
-        BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
+        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 
         GL11.glDisable(GL11.GL_STENCIL_TEST);
 

--- a/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisDoorBOTI.java
@@ -33,23 +33,23 @@ public class TardisDoorBOTI extends BOTI {
     public static void renderInteriorDoorBoti(ClientTardis tardis, DoorBlockEntity door, ClientExteriorVariantSchema variant, MatrixStack stack, Identifier frameTex, AnimatedModel frame, ModelPart mask, int light, float tickDelta) {
         ExteriorVariantSchema parent = variant.parent();
 
-        if (MinecraftClient.getInstance().world == null
-                || MinecraftClient.getInstance().player == null) return;
+        if (client.world == null
+                || client.player == null) return;
 
         stack.push();
         stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180));
 
-        MinecraftClient.getInstance().getFramebuffer().endWrite();
+        client.getFramebuffer().endWrite();
 
         BOTI_HANDLER.setupFramebuffer();
 
-        Vec3d skyColor = MinecraftClient.getInstance().world.getSkyColor(MinecraftClient.getInstance().player.getPos(), MinecraftClient.getInstance().getTickDelta());
+        Vec3d skyColor = client.world.getSkyColor(client.player.getPos(), client.getTickDelta());
         if (AITModClient.CONFIG.greenScreenBOTI)
             BOTI.setFramebufferColor(BOTI_HANDLER.afbo, 0, 1, 0, 1);
         else
             BOTI.setFramebufferColor(BOTI_HANDLER.afbo, (float) skyColor.x, (float) skyColor.y, (float) skyColor.z, 1);
 
-        BOTI.copyFramebuffer(MinecraftClient.getInstance().getFramebuffer(), BOTI_HANDLER.afbo);
+        BOTI.copyFramebuffer(client.getFramebuffer(), BOTI_HANDLER.afbo);
 
         VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
 
@@ -79,7 +79,7 @@ public class TardisDoorBOTI extends BOTI {
         }
         botiProvider.draw();
         stack.pop();
-        copyDepth(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
+        copyDepth(BOTI_HANDLER.afbo, client.getFramebuffer());
 
         BOTI_HANDLER.afbo.beginWrite(false);
         GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
@@ -88,7 +88,7 @@ public class TardisDoorBOTI extends BOTI {
         GL11.glStencilFunc(GL11.GL_EQUAL, 1, 0xFF);
 
         stack.push();
-        float delta = MinecraftClient.getInstance().getTickDelta() + MinecraftClient.getInstance().player.age;
+        float delta = client.getTickDelta() + client.player.age;
         if (!tardis.travel().autopilot() && tardis.travel().getState() != TravelHandlerBase.State.LANDED)
             stack.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees((delta) * (tardis.travel().speed() * 0.7f)));
         if (!tardis.crash().isNormal())
@@ -150,9 +150,9 @@ public class TardisDoorBOTI extends BOTI {
             stack.pop();
         }
 
-        MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
+        client.getFramebuffer().beginWrite(true);
 
-        BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
+        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 
         GL11.glDisable(GL11.GL_STENCIL_TEST);
 

--- a/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
+++ b/src/main/java/dev/amble/ait/client/boti/TardisExteriorBOTI.java
@@ -31,8 +31,8 @@ import dev.amble.ait.registry.impl.exterior.ClientExteriorVariantRegistry;
 
 public class TardisExteriorBOTI extends BOTI {
     public void renderExteriorBoti(ExteriorBlockEntity exterior, ClientExteriorVariantSchema variant, MatrixStack stack, Identifier frameTex, ExteriorModel frame, ModelPart mask, int light) {
-        if (MinecraftClient.getInstance().world == null
-                || MinecraftClient.getInstance().player == null) return;
+        if (client.world == null
+                || client.player == null) return;
 
         if (!exterior.isLinked())
             return;
@@ -41,17 +41,17 @@ public class TardisExteriorBOTI extends BOTI {
 
         stack.push();
 
-        MinecraftClient.getInstance().getFramebuffer().endWrite();
+        client.getFramebuffer().endWrite();
 
         BOTI_HANDLER.setupFramebuffer();
 
-        Vec3d skyColor = MinecraftClient.getInstance().world.getSkyColor(MinecraftClient.getInstance().player.getPos(), MinecraftClient.getInstance().getTickDelta());
+        Vec3d skyColor = client.world.getSkyColor(client.player.getPos(), client.getTickDelta());
         if (AITModClient.CONFIG.greenScreenBOTI)
             BOTI.setFramebufferColor(BOTI_HANDLER.afbo, 0, 1, 0, 1);
         else
             BOTI.setFramebufferColor(BOTI_HANDLER.afbo, (float) skyColor.x, (float) skyColor.y, (float) skyColor.z, 1);
 
-        BOTI.copyFramebuffer(MinecraftClient.getInstance().getFramebuffer(), BOTI_HANDLER.afbo);
+        BOTI.copyFramebuffer(client.getFramebuffer(), BOTI_HANDLER.afbo);
 
         VertexConsumerProvider.Immediate botiProvider = AIT_BUF_BUILDER_STORAGE.getBotiVertexConsumer();
 
@@ -84,7 +84,7 @@ public class TardisExteriorBOTI extends BOTI {
         botiProvider.draw();
         stack.pop();
 
-        copyDepth(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
+        copyDepth(BOTI_HANDLER.afbo, client.getFramebuffer());
 
         BOTI_HANDLER.afbo.beginWrite(false);
         GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
@@ -137,11 +137,11 @@ public class TardisExteriorBOTI extends BOTI {
 
             if ((stats.getName() != null && "partytardis".equals(stats.getName().toLowerCase()) || (!exterior.tardis().get().extra().getInsertedDisc().isEmpty()))) {
                 int m = 25;
-                int n = MinecraftClient.getInstance().player.age / m + MinecraftClient.getInstance().player.getId();
+                int n = client.player.age / m + client.player.getId();
                 int o = DyeColor.values().length;
                 int p = n % o;
                 int q = (n + 1) % o;
-                float r = ((float) (MinecraftClient.getInstance().player.age % m)) / m;
+                float r = ((float) (client.player.age % m)) / m;
                 float[] fs = SheepEntity.getRgbColor(DyeColor.byId(p));
                 float[] gs = SheepEntity.getRgbColor(DyeColor.byId(q));
                 s = fs[0] * (1f - r) + gs[0] * r;
@@ -167,9 +167,9 @@ public class TardisExteriorBOTI extends BOTI {
         }
         stack.pop();
 
-        MinecraftClient.getInstance().getFramebuffer().beginWrite(true);
+        client.getFramebuffer().beginWrite(true);
 
-        BOTI.copyColor(BOTI_HANDLER.afbo, MinecraftClient.getInstance().getFramebuffer());
+        BOTI.copyColor(BOTI_HANDLER.afbo, client.getFramebuffer());
 
         GL11.glDisable(GL11.GL_STENCIL_TEST);
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/AlnicoConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/AlnicoConsoleModel.java
@@ -1402,65 +1402,55 @@ public class AlnicoConsoleModel extends SimpleConsoleModel {
         alnico.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
     }
 
-    private float throttleAngle = 0f;
-    private float handbrakeAngle = 0f;
-    private float powerAngle = 0f;
-    private float doorControlAngle = 0f;
-    private float doorLockAngle = 0f;
-    private float incrementAngle = 0f;
-    private float directionAngle = 0f;
-    private float securityAngle = 0f;
-    private float shieldAngle = 0f;
-    private float siegeAngle = 0f;
-    private float autopilotAngle = 0f;
-
     @Override
     public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        float delta = 0.1f * MinecraftClient.getInstance().getTickDelta();
+        float delta = 0.1f * client.getTickDelta();
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
+        // Throttle Control
         ModelPart throttle = alnico.getChild("section1").getChild("controls").getChild("fliplever1").getChild("bone5");
         float throttleTarget = tardis.travel().maxSpeed().get() > 0 ? ((float) tardis.travel().speed() / (float) tardis.travel().maxSpeed().get()) * 1.5f: 0f;
-        this.throttleAngle = MathHelper.lerp(delta, this.throttleAngle, throttleTarget);
-        throttle.pitch = this.throttleAngle;
+        throttle.pitch = getAngle(console, "throttle", throttleTarget, delta);
 
+        // Handbrake Control
         ModelPart handbrake = alnico.getChild("section1").getChild("controls").getChild("biglever").getChild("bone");
         float handbrakeTarget = !tardis.travel().handbrake() ? -0.9f : 0.9f;
-        this.handbrakeAngle = MathHelper.lerp(delta, this.handbrakeAngle, handbrakeTarget);
-        handbrake.pitch = this.handbrakeAngle;
+        handbrake.pitch = getAngle(console, "handbrake", handbrakeTarget, delta);
 
+        // Power Control
         ModelPart power = alnico.getChild("section4").getChild("controls4").getChild("biglever2").getChild("bone12");
         float powerTarget = !tardis.fuel().hasPower() ? -0.9f : 0.9f;
-        this.powerAngle = MathHelper.lerp(delta, this.powerAngle, powerTarget);
-        power.pitch = this.powerAngle;
+        power.pitch = getAngle(console, "power", powerTarget, delta);
 
+        // Auto Pilot Control
         ModelPart autoPilot = alnico.getChild("section1").getChild("controls").getChild("multiswitchpanel")
                 .getChild("longswitch1");
         float autopilotTarget = tardis.travel().autopilot() ? 0.5f : 0;
-        this.autopilotAngle = MathHelper.lerp(delta, this.autopilotAngle, autopilotTarget);
-        autoPilot.pitch = this.autopilotAngle;
+        autoPilot.pitch = getAngle(console, "autopilot", autopilotTarget, delta);
 
+        // Security Control
         ModelPart security = alnico.getChild("section1").getChild("controls").getChild("multiswitchpanel")
                 .getChild("longswitch4");
         float securityTarget = tardis.stats().security().get() ? 0.5f : 0;
-        this.securityAngle = MathHelper.lerp(delta, this.securityAngle, securityTarget);
-        security.pitch = this.securityAngle;
+        security.pitch = getAngle(console, "security", securityTarget, delta);
 
+        // Siege Mode Control
         ModelPart siegeMode = alnico.getChild("section3").getChild("controls3").getChild("siegemode").getChild("lever");
         float siegeTarget = tardis.siege().isActive() ? 0.9f : 0;
-        this.siegeAngle = MathHelper.lerp(delta, this.siegeAngle, siegeTarget);
-        siegeMode.pitch = this.siegeAngle;
+        siegeMode.pitch = getAngle(console, "siege_mode", siegeTarget, delta);
 
+        // Refueler
         ModelPart refueler = alnico.getChild("section5").getChild("controls5").getChild("refueler").getChild("gasknob");
         refueler.yaw = !tardis.isRefueling() ? refueler.yaw - 0.7854f : refueler.yaw;
 
+        // Fuel Gauge
         ModelPart fuelGauge = alnico.getChild("section3").getChild("controls3").getChild("geiger").getChild("needle");
         fuelGauge.roll = (float) (((tardis.getFuel() / FuelHandler.TARDIS_MAX_FUEL) * 2) - 1);
 
+        // Increment Control
         ModelPart increment = alnico.getChild("section5").getChild("controls5").getChild("multiswitchpanel2").getChild("longswitch5");
-
         int incrementVal = IncrementManager.increment(tardis);
         float targetOffset;
 
@@ -1475,35 +1465,35 @@ public class AlnicoConsoleModel extends SimpleConsoleModel {
         } else {
             targetOffset = 1.5f;
         }
+        increment.pitch = getAngle(console, "increment", targetOffset, delta);
 
-        this.incrementAngle = MathHelper.lerp(delta, this.incrementAngle,  targetOffset);
-        increment.pitch = this.incrementAngle;
-
+        // Shield Control
         ModelPart shield = alnico.getChild("section5").getChild("controls5").getChild("multiswitchpanel2")
                 .getChild("longswitch8");
         float shieldTarget = tardis.shields().shielded().get() ? 1f : 0;
-        this.shieldAngle = MathHelper.lerp(delta, this.shieldAngle, shieldTarget);
-        shield.pitch = this.shieldAngle;
+        shield.pitch = getAngle(console, "shields", shieldTarget, delta);
 
+        // Land Type
         ModelPart landtype = alnico.getChild("section1").getChild("controls").getChild("tinyswitch2").getChild("bone2");
-        landtype.yaw = landtype.yaw + ((tardis.travel().horizontalSearch().get() ? 1.5708f : 0)); // FIXME use
-                                                                                                    // TravelHandler#horizontalSearch/#verticalSearch
+        landtype.yaw = landtype.yaw + ((tardis.travel().horizontalSearch().get() ? 1.5708f : 0));
 
+        // Anti Gravs
         ModelPart antigravs = alnico.getChild("section1").getChild("controls").getChild("tinyswitch").getChild("bone3");
         antigravs.yaw = antigravs.yaw + (tardis.travel().antigravs().get() ? 1.5708f : 0);
 
+        // Door Control
         ModelPart doorControl = alnico.getChild("section5").getChild("controls5").getChild("tinyswitch6")
                 .getChild("bone24");
         float doorControlTarget = tardis.door().isOpen() ? tardis.door().isRightOpen() ? 1.5708f * 2f : 1.5708f : 0;
-        this.doorControlAngle = MathHelper.lerp(delta, this.doorControlAngle, doorControlTarget);
-        doorControl.yaw = this.doorControlAngle;
+        doorControl.yaw = getAngle(console, "door_control", doorControlTarget, delta);
 
+        // Door Lock
         ModelPart doorLock = alnico.getChild("section5").getChild("controls5").getChild("tinyswitch7")
                 .getChild("bone25");
         float doorLockTarget = tardis.door().locked() ? 1.5708f : 0;
-        this.doorLockAngle = MathHelper.lerp(delta, this.doorLockAngle, doorLockTarget);
-        doorLock.yaw = this.doorLockAngle;
+        doorLock.yaw = getAngle(console, "door_lock", doorLockTarget, delta);
 
+        // Waypoints
         ModelPart toast1 = alnico.getChild("section2").getChild("controls2").getChild("waypointcatridge")
                 .getChild("toast1");
         ModelPart toastlever = alnico.getChild("section2").getChild("controls2").getChild("waypointcatridge")
@@ -1514,14 +1504,11 @@ public class AlnicoConsoleModel extends SimpleConsoleModel {
         toastlever.pivotY = toastlever.pivotY + (!tardis.waypoint().hasCartridge() ? 2f : 0);
         toast2.visible = tardis.waypoint().hasCartridge();
 
+        // Direction Control
         ModelPart direction = alnico.getChild("section5").getChild("controls5").getChild("tinyswitch9")
                 .getChild("bone26");
         float directionTargetDegrees = (0.3927f * tardis.travel().destination().getRotation()) * (180f / (float) Math.PI);
-        float currentAngleDegrees = this.directionAngle * (180f / (float) Math.PI);
-        float nextAngleDegrees = MathHelper.lerpAngleDegrees(delta, currentAngleDegrees, directionTargetDegrees);
-
-        this.directionAngle = nextAngleDegrees * ((float) Math.PI / 180f);
-        direction.yaw = this.directionAngle;
+        direction.yaw = getLerpedDegrees(console, "direction", directionTargetDegrees, delta);
 
         super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
 

--- a/src/main/java/dev/amble/ait/client/models/consoles/CopperConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/CopperConsoleModel.java
@@ -1749,43 +1749,28 @@ public class CopperConsoleModel extends SimpleConsoleModel {
         matrices.pop();
     }
 
-    private float throttleAngle = 0f;
-    private float handbrakeAngle = 0f;
-    private float powerAngle = 0f;
-    private float doorControlAngle = 0f;
-    private float doorLockAngle = 0f;
-    private float directionAngle = 0f;
-    private float cloakAngle = 0f;
-    private float securityAngle = 0f;
-    private float antiGravAngle = 0f;
-    private float shieldAngle = 0f;
-    private float shield2Angle = 0f;
-    private float siegeAngle = 0f;
-    private float autopilotAngle = 0f;
-    private float fuelAngle = 0f;
-
     @Override
     public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        float delta = 0.1f * MinecraftClient.getInstance().getTickDelta();
+        float delta = 0.1f * client.getTickDelta();
         matrices.push();
         matrices.translate(0.5f, -1.52f, -0.5f);
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(150f));
 
+        // Fuel Gauge
         float fuelTarget = (float) ((tardis.getFuel() / FuelHandler.TARDIS_MAX_FUEL) * 3f);
-        this.fuelAngle = MathHelper.lerp(delta, this.fuelAngle, fuelTarget);
-        this.copper.getChild("pillars").getChild("pillars2").getChild("pillars3").getChild("pillars4").getChild("bone121").getChild("fuel_gauge").yaw = this.fuelAngle;
+        this.copper.getChild("pillars").getChild("pillars2").getChild("pillars3").getChild("pillars4").getChild("bone121").getChild("fuel_gauge").yaw = getAngle(console, "fuel", fuelTarget, delta);
 
+        // Direction
         float directionTargetDegrees = tardis.travel().destination().getRotation() * 22.5f;
-        float currentDirectionDegrees = (float) Math.toDegrees(this.directionAngle);
-        float nextDirectionDegrees = MathHelper.lerpAngleDegrees(delta, currentDirectionDegrees, directionTargetDegrees);
-        this.directionAngle = (float) Math.toRadians(nextDirectionDegrees);
-        this.copper.getChild("pillars").getChild("pillars2").getChild("pillars3").getChild("pillars4").getChild("pillars5").getChild("bone126").pitch = -this.directionAngle;
+        float directionAngle = getLerpedDegrees(console, "direction", directionTargetDegrees, delta);
+        this.copper.getChild("pillars").getChild("pillars2").getChild("pillars3").getChild("pillars4").getChild("pillars5").getChild("bone126").pitch = -directionAngle;
 
+        // Handbrake
         float handbrakeTarget = tardis.travel().handbrake() ? -1.0f : 0f;
-        this.handbrakeAngle = MathHelper.lerp(delta, this.handbrakeAngle, handbrakeTarget);
-        this.copper.getChild("pillars").getChild("pillars2").getChild("pillars3").getChild("handbrake").pitch = this.handbrakeAngle;
+        this.copper.getChild("pillars").getChild("pillars2").getChild("pillars3").getChild("handbrake").pitch = getAngle(console, "handbrake", handbrakeTarget, delta);
 
+        // Throttle
         ModelPart throttle1 = this.copper.getChild("controls").getChild("panel_2").getChild("rot8").getChild("lever2").getChild("bone29");
         ModelPart throttle2 = this.copper.getChild("controls").getChild("panel_2").getChild("rot8").getChild("lever2").getChild("bone30");
 
@@ -1799,9 +1784,9 @@ public class CopperConsoleModel extends SimpleConsoleModel {
         float throttleTarget = speedPercent * 2f;
         float clampedSpeedAmount = Math.max(0f, Math.min(speedPercent, 5f)) * 5f;
 
-        this.throttleAngle = MathHelper.lerp(delta, this.throttleAngle, throttleTarget);
-        throttle1.roll = this.throttleAngle - 1f;
-        throttle2.roll = this.throttleAngle - 1f;
+        float throttleAngle = getAngle(console, "throttle", throttleTarget, delta);
+        throttle1.roll = throttleAngle - 1f;
+        throttle2.roll = throttleAngle - 1f;
 
         lights.visible = clampedSpeedAmount >= 5f;
         lights2.visible = clampedSpeedAmount >= 4f;
@@ -1809,31 +1794,32 @@ public class CopperConsoleModel extends SimpleConsoleModel {
         lights4.visible = clampedSpeedAmount >= 2f;
         lights5.visible = clampedSpeedAmount >= 1f;
 
+        // Cloak
         ModelPart cloak = this.copper.getChild("desktop").getChild("desktop2").getChild("desktop3").getChild("desktop4").getChild("desktop5").getChild("desktop6").getChild("panels12").getChild("rot6").getChild("bone150");
         float cloakTarget = tardis.cloak().cloaked().get() ? 2f : 0f;
-        this.cloakAngle = MathHelper.lerp(delta, this.cloakAngle, cloakTarget);
-        cloak.roll = this.cloakAngle;
+        cloak.roll = getAngle(console, "cloak", cloakTarget, delta);
 
+        // Power
         ModelPart power = this.copper.getChild("desktop").getChild("desktop2").getChild("desktop3").getChild("desktop4").getChild("desktop5").getChild("desktop6").getChild("panels12").getChild("rot6").getChild("lever9").getChild("bone131");
         float powerTarget = tardis.fuel().hasPower() ? 0f : -1.0f;
-        this.powerAngle = MathHelper.lerp(delta, this.powerAngle, powerTarget);
-        power.roll = this.powerAngle + 1f;
+        power.roll = getAngle(console, "power", powerTarget, delta) + 1f;
 
+        // Wibbly Lever (Siege)
         ModelPart wibblyLever = this.copper.getChild("controls").getChild("panel_3").getChild("rot9").getChild("lever7").getChild("bone96");
         float siegeTarget = tardis.siege().isActive() ? -2.0f : 0f;
-        this.siegeAngle = MathHelper.lerp(delta, this.siegeAngle, siegeTarget);
-        wibblyLever.roll = this.siegeAngle;
+        wibblyLever.roll = getAngle(console, "siege", siegeTarget, delta);
 
+        // Security Control
         ModelPart securityControl = this.copper.getChild("controls").getChild("panel_3").getChild("rot9").getChild("lever10").getChild("bone97");
         float securityTarget = tardis.stats().security().get() ? 0.75f : 0f;
-        this.securityAngle = MathHelper.lerp(delta, this.securityAngle, securityTarget);
-        securityControl.roll = this.securityAngle;
+        securityControl.roll = getAngle(console, "security", securityTarget, delta);
 
+        // Stabilisers (Autopilot)
         ModelPart stabilisers = this.copper.getChild("controls").getChild("panel_3").getChild("rot9").getChild("stabilizers").getChild("bone25");
         float stabiliserTarget = tardis.travel().autopilot() ? -0.8f : 0f;
-        this.autopilotAngle = MathHelper.lerp(delta, this.autopilotAngle, stabiliserTarget);
-        stabilisers.pivotY = this.autopilotAngle;
+        stabilisers.pivotY = getAngle(console, "stabilisers", stabiliserTarget, delta);
 
+        // Door Control
         ModelPart doorControl = this.copper.getChild("controls").getChild("panel_2").getChild("rot8").getChild("crank").getChild("bone36");
         float doorControlTarget = 0f;
         if (tardis.door().isRightOpen()) {
@@ -1841,29 +1827,25 @@ public class CopperConsoleModel extends SimpleConsoleModel {
         } else if (tardis.door().isLeftOpen()) {
             doorControlTarget = -0.5f;
         }
-        this.doorControlAngle = MathHelper.lerp(delta, this.doorControlAngle, doorControlTarget);
-        doorControl.pitch = this.doorControlAngle;
+        doorControl.pitch = getAngle(console, "door_control", doorControlTarget, delta);
 
+        // Door Lock
         ModelPart doorLock = this.copper.getChild("controls").getChild("panel_4").getChild("rot16").getChild("crank3").getChild("bone101");
         float doorLockTarget = tardis.door().locked() ? 1.575f : 0f;
-        this.doorLockAngle = MathHelper.lerp(delta, this.doorLockAngle, doorLockTarget);
-        doorLock.yaw = this.doorLockAngle;
+        doorLock.yaw = getAngle(console, "door_lock", doorLockTarget, delta);
 
+        // Shields
         ModelPart shields = this.copper.getChild("controls").getChild("panel_4").getChild("rot16").getChild("t_switch").getChild("bone106");
-
         float shieldYTarget = tardis.shields().shielded().get() ? 0.8f : 0f;
         float shieldZTarget = tardis.shields().visuallyShielded().get() ? -0.4f : 0f;
 
-        this.shieldAngle = MathHelper.lerp(delta, this.shieldAngle, shieldYTarget);
-        this.shield2Angle = MathHelper.lerp(delta, this.shield2Angle, shieldZTarget);
+        shields.pivotY = getAngle(console, "shields_y", shieldYTarget, delta);
+        shields.pivotZ = getAngle(console, "shields_z", shieldZTarget, delta);
 
-        shields.pivotY += this.shieldAngle;
-        shields.pivotZ += this.shield2Angle;
-
+        // Antigravs
         ModelPart antigravs = this.copper.getChild("controls").getChild("panel_4").getChild("rot16").getChild("lever8").getChild("bone103");
         float antigravTarget = tardis.travel().antigravs().get() ? 0f : -2f;
-        this.antiGravAngle = MathHelper.lerp(delta, this.antiGravAngle, antigravTarget);
-        antigravs.roll = this.antiGravAngle + 1f;
+        antigravs.roll = getAngle(console, "antigravs", antigravTarget, delta) + 1f;
 
         super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();

--- a/src/main/java/dev/amble/ait/client/models/consoles/CoralConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/CoralConsoleModel.java
@@ -2421,25 +2421,10 @@ public class CoralConsoleModel extends SimpleConsoleModel {
         console.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
     }
 
-    private float throttleAngle = 0f;
-    private float handbrakeAngle = 0f;
-    private float powerAngle = 0f;
-    private float power2Angle = 0f;
-    private float doorControlAngle = 0f;
-    private float incrementAngle = 0f;
-    private float increment2Angle = 0f;
-    private float refuelerAngle = 0f;
-    private float groundSearchAngle = 0f;
-    private float securityAngle = 0f;
-    private float antiGravAngle = 0f;
-    private float shieldAngle = 0f;
-    private float siegeAngle = 0f;
-    private float autopilotAngle = 0f;
-
     @Override
     public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        float delta = 0.1f * MinecraftClient.getInstance().getTickDelta();
+        float delta = 0.1f * client.getTickDelta();
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -2460,30 +2445,25 @@ public class CoralConsoleModel extends SimpleConsoleModel {
         // Anti-gravs Lever
         ModelPart antigrav = controls.getChild("p_ctrl_1").getChild("bone29").getChild("lever").getChild("bone8");
         float antigravsTarget = tardis.travel().antigravs().get() ? 0.829F : 0.829F - 1.5f;
-        this.antiGravAngle = MathHelper.lerp(delta, this.antiGravAngle, antigravsTarget);
-        antigrav.roll = this.antiGravAngle - 0.5f;
+        antigrav.roll = getAngle(console, "antigravs", antigravsTarget, delta) - 0.5f;
 
         // Door Control
         ModelPart doorControl = controls.getChild("p_ctrl_1").getChild("bone29").getChild("crank").getChild("bone32");
         float doorControlTarget = tardis.door().isLeftOpen() ? -0.6981F - 0.8f: tardis.door().isRightOpen() ? -0.6981F - 1.5f : 0;
-        this.doorControlAngle = MathHelper.lerp(delta, this.doorControlAngle, doorControlTarget);
-        doorControl.pitch = this.doorControlAngle;
+        doorControl.pitch = getAngle(console, "door_control", doorControlTarget, delta);
 
         // Power Lever
         ModelPart power = controls.getChild("p_ctrl_4").getChild("bone41").getChild("lever2").getChild("bone43");
         float powerTarget = tardis.fuel().hasPower() ? 0 : 1.5f;
         float power2Target = tardis.fuel().hasPower() ? 0 : 0.5f;
-        this.powerAngle = MathHelper.lerp(delta, this.powerAngle, powerTarget);
-        this.power2Angle = MathHelper.lerp(delta, this.power2Angle, power2Target);
-        power.roll = this.powerAngle - 0.5f;
+        power.roll = getAngle(console, "power", powerTarget, delta) - 0.5f;
         ModelPart power2 = controls.getChild("p_ctrl_4").getChild("bone41").getChild("lever2").getChild("bone42");
-        power2.roll = this.power2Angle - 0.5f;
+        power2.roll = getAngle(console, "power2", power2Target, delta) - 0.5f;
 
         // Throttle
         ModelPart throttle = controls.getChild("p_ctrl_5").getChild("bone49").getChild("lever3").getChild("bone52");
         float throttleTarget = tardis.travel().maxSpeed().get() > 0 ? (float) tardis.travel().speed() / (float) tardis.travel().maxSpeed().get() : 0f;
-        this.throttleAngle = MathHelper.lerp(delta, this.throttleAngle, throttleTarget);
-        throttle.roll = this.throttleAngle;
+        throttle.roll = getAngle(console, "throttle", throttleTarget, delta);
 
         // Increment
         ModelPart increment = controls.getChild("p_ctrl_2").getChild("bone33").getChild("bone31").getChild("crank2");
@@ -2507,17 +2487,13 @@ public class CoralConsoleModel extends SimpleConsoleModel {
             targetTwo = 0.5f;
         }
 
-        this.incrementAngle = MathHelper.lerp(delta, this.incrementAngle, targetOne);
-        this.increment2Angle = MathHelper.lerp(delta, this.increment2Angle, targetTwo);
-
-        increment.yaw = this.incrementAngle;
-        incrementTwo.pivotY = this.increment2Angle;
+        increment.yaw = getAngle(console, "increment", targetOne, delta);
+        incrementTwo.pivotY = getAngle(console, "increment2", targetTwo, delta);
 
         // Refueler
         ModelPart refueler = controls.getChild("p_ctrl_5").getChild("bone49").getChild("ring2").getChild("switch30");
         float refuelerTarget = tardis.isRefueling() ? -1 : 0;
-        this.refuelerAngle = MathHelper.lerp(delta, this.refuelerAngle, refuelerTarget);
-        refueler.pivotY = this.refuelerAngle;
+        refueler.pivotY = getAngle(console, "refueler", refuelerTarget, delta);
 
         // Waypoint
         controls.getChild("ctrl_1").getChild("bone13").getChild("insert").getChild("bone96").visible = tardis
@@ -2527,38 +2503,31 @@ public class CoralConsoleModel extends SimpleConsoleModel {
         ModelPart handbrake = controls.getChild("p_ctrl_6").getChild("bone62").getChild("handbrake2")
                 .getChild("bone102");
         float handbrakeTarget = !tardis.travel().handbrake() ? 0.829F : 0.829F + 0.75f;
-        this.handbrakeAngle = MathHelper.lerp(delta, this.handbrakeAngle, handbrakeTarget);
-        handbrake.yaw = this.handbrakeAngle;
+        handbrake.yaw = getAngle(console, "handbrake", handbrakeTarget, delta);
 
         // Siege Mode
         ModelPart siege = controls.getChild("p_ctrl_3").getChild("bone36").getChild("handbrake");
         float siegeTarget = tardis.siege().isActive() ? 0.45f : 0;
-        this.siegeAngle = MathHelper.lerp(delta, this.siegeAngle, siegeTarget);
-        siege.roll = this.siegeAngle;
+        siege.roll = getAngle(console, "siege", siegeTarget, delta);
 
         // Shields
         ModelPart shield = controls.getChild("p_ctrl_4").getChild("bone41").getChild("pully").getChild("bone47");
         float shieldTarget = tardis.shields().shielded().get() ? tardis.shields().visuallyShielded().get() ? -4f : -1.55f : -2.5f;
-        this.shieldAngle = MathHelper.lerp(delta, this.shieldAngle, shieldTarget);
-        shield.pivotX = this.shieldAngle;
+        shield.pivotX = getAngle(console, "shields", shieldTarget, delta);
 
         // Autopilot
         ModelPart autopilot = controls.getChild("ctrl_4").getChild("bone15").getChild("switch24").getChild("bone19");
         float autopilotTarget = tardis.travel().autopilot() ? 1 : 0;
-        this.autopilotAngle = MathHelper.lerp(delta, this.autopilotAngle, autopilotTarget);
-        autopilot.pivotY = this.autopilotAngle;
-
+        autopilot.pivotY = getAngle(console, "autopilot", autopilotTarget, delta);
 
         ModelPart security = controls.getChild("ctrl_4").getChild("bone15").getChild("switch25").getChild("bone20");
         float securityTarget = tardis.stats().security().get() ? 1 : 0;
-        this.securityAngle = MathHelper.lerp(delta, this.securityAngle, securityTarget);
-        security.pivotY = this.securityAngle;
+        security.pivotY = getAngle(console, "security", securityTarget, delta);
 
         // Ground Searching
         ModelPart groundSearch = controls.getChild("p_ctrl_6").getChild("bone62").getChild("bow").getChild("bone68");
         float groundSearchTarget = tardis.travel().horizontalSearch().get() ? 0.2182F - 0.5f : 0.2182F;
-        this.groundSearchAngle = MathHelper.lerp(delta, this.groundSearchAngle, groundSearchTarget);
-        groundSearch.pitch = this.groundSearchAngle;
+        groundSearch.pitch = getAngle(console, "ground_search", groundSearchTarget, delta);
 
         // Hammer
         ModelPart hammer = controls.getChild("p_ctrl_6").getChild("bone62").getChild("hammer").getChild("bone40");

--- a/src/main/java/dev/amble/ait/client/models/consoles/CrystallineConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/CrystallineConsoleModel.java
@@ -1209,58 +1209,48 @@ public class CrystallineConsoleModel extends SimpleConsoleModel {
         console.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
     }
 
-    private float throttleAngle = 0f;
-    private float handbrakeAngle = 0f;
-    private float powerAngle = 0f;
-    private float incrementAngle = 0f;
-    private float directionAngle = 0f;
-    private float refuelerAngle = 0f;
-    private float antiGravAngle = 0f;
-
     @Override
     public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices, VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        float delta = 0.1f * MinecraftClient.getInstance().getTickDelta();
+        float delta = 0.1f * client.getTickDelta();
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
+        // Throttle Control
         ModelPart throttle = this.console.getChild("pannel2").getChild("pillars2").getChild("pillars3").getChild("leveer2");
         float throttleTarget = -(tardis.travel().speed() / (float) tardis.travel().maxSpeed().get());
-        this.throttleAngle = MathHelper.lerp(delta, this.throttleAngle, throttleTarget);
-        throttle.pitch = this.throttleAngle;
+        throttle.pitch = getAngle(console, "throttle", throttleTarget, delta);
 
+        // Handbrake Control
         ModelPart handbrake = this.console.getChild("pannel2").getChild("pillars2").getChild("pillars3").getChild("leveer");
         float handbrakeTarget = tardis.travel().handbrake() ? 1.0f : 0f;
-        this.handbrakeAngle = MathHelper.lerp(delta, this.handbrakeAngle, handbrakeTarget);
-        handbrake.pitch = this.handbrakeAngle;
+        handbrake.pitch = getAngle(console, "handbrake", handbrakeTarget, delta);
 
+        // Power Control
         ModelPart power = this.console.getChild("pannel3").getChild("rolly");
         float powerTarget = tardis.fuel().hasPower() ? 0f : -1.55f;
-        this.powerAngle = MathHelper.lerp(delta, this.powerAngle, powerTarget);
-        power.roll = this.powerAngle;
+        power.roll = getAngle(console, "power", powerTarget, delta);
 
+        // Anti-Grav Control
         ModelPart antigravs = this.console.getChild("pannel7").getChild("panels7").getChild("cube1");
         float antigravTarget = tardis.travel().antigravs().get() ? -1.58f : 0f;
-        this.antiGravAngle = MathHelper.lerp(delta, this.antiGravAngle, antigravTarget);
-        antigravs.yaw = this.antiGravAngle;
+        antigravs.yaw = getAngle(console, "antigravs", antigravTarget, delta);
 
+        // Increment Control
         ModelPart increment = this.console.getChild("pannel7").getChild("panels7").getChild("bone4");
         float incrementTarget = -(IncrementManager.increment(tardis) / 1000f);
-        this.incrementAngle = MathHelper.lerp(delta, this.incrementAngle, incrementTarget);
-        increment.roll = this.incrementAngle;
+        increment.roll = getAngle(console, "increment", incrementTarget, delta);
 
+        // Fuel Gauge
         ModelPart fuelGauge = this.console.getChild("pannel3").getChild("panels3").getChild("button");
         fuelGauge.pivotX += 0.25f;
         fuelGauge.pivotZ += 0.25f;
         float fuelGaugeTarget = (float) ((tardis.getFuel() / FuelHandler.TARDIS_MAX_FUEL) * 2f) - 1f;
-        this.refuelerAngle = MathHelper.lerp(delta, this.refuelerAngle, fuelGaugeTarget);
-        fuelGauge.yaw = this.refuelerAngle;
+        fuelGauge.yaw = getAngle(console, "fuel_gauge", fuelGaugeTarget, delta);
 
+        // Direction Control
         ModelPart direction = this.console.getChild("pannel7").getChild("pillars56").getChild("pillars57").getChild("spinnio");
         float directionTargetDegrees = tardis.travel().destination().getRotation() * 22.5f;
-        float currentDirectionDegrees = (float) Math.toDegrees(this.directionAngle);
-        float nextDirectionDegrees = MathHelper.lerpAngleDegrees(delta, currentDirectionDegrees, directionTargetDegrees);
-        this.directionAngle = (float) Math.toRadians(nextDirectionDegrees);
-        direction.roll = this.directionAngle;
+        direction.roll = getLerpedDegrees(console, "direction", directionTargetDegrees, delta);
 
         super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();

--- a/src/main/java/dev/amble/ait/client/models/consoles/HartnellConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/HartnellConsoleModel.java
@@ -1382,29 +1382,10 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         bone.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
     }
 
-    private float throttleAngle = 0f;
-    private float handbrakeAngle = 0f;
-    private float powerAngle = 0f;
-    private float rotorAngle = 0f;
-    private float doorControlAngle = 0f;
-    private float doorLockAngle = 0f;
-    private float incrementAngle = 0f;
-    private float directionAngle = 0f;
-    private float refuelerAngle = 0f;
-    private float cloakAngle = 0f;
-    private float groundSearchAngle = 0f;
-    private float hailMaryAngle = 0f;
-    private float alarmAngle = 0f;
-    private float securityAngle = 0f;
-    private float antiGravAngle = 0f;
-    private float shieldAngle = 0f;
-    private float siegeAngle = 0f;
-    private float autopilotAngle = 0f;
-
     @Override
     public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        float delta = 0.1f * MinecraftClient.getInstance().getTickDelta();
+        float delta = 0.1f * client.getTickDelta();
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
@@ -1457,26 +1438,26 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         ModelPart throttle = this.bone.getChild("panels").getChild("p_1").getChild("bone38").getChild("bone36")
                 .getChild("bone37").getChild("m_lever_1").getChild("bone45");
         float throttleTarget = tardis.travel().maxSpeed().get() > 0 ? (float) tardis.travel().speed() / (float) tardis.travel().maxSpeed().get() : 0f;
-        this.throttleAngle = MathHelper.lerp(delta, this.throttleAngle, throttleTarget);
-        throttle.roll = this.throttleAngle - 0.5f;
+        float throttleAngle = getAngle(console, "throttle", throttleTarget, delta);
+        throttle.roll = throttleAngle - 0.5f;
 
         // Handbrake Control Movements
         ModelPart handbrake = this.bone.getChild("panels").getChild("p_1").getChild("bone38").getChild("bone36")
                 .getChild("bone37").getChild("m_lever_2").getChild("bone46");
         float handbrakeTarget = tardis.travel().handbrake() ? 1f : 0f;
-        this.handbrakeAngle =  MathHelper.lerp(delta, this.handbrakeAngle, handbrakeTarget);
-        handbrake.roll = this.handbrakeAngle - 0.5f;
+        float handbrakeAngle =  getAngle(console, "handbrake", handbrakeTarget, delta);
+        handbrake.roll = handbrakeAngle - 0.5f;
 
         // Power Control Movements
         ModelPart powerControl = this.bone.getChild("panels").getChild("p_6").getChild("bone132").getChild("bone133")
                 .getChild("bone134").getChild("m_lever_3").getChild("bone142");
         ModelPart rotor = this.bone.getChild("rotor");
         float powerTarget = tardis.fuel().hasPower() ? 1f : 0f;
-        this.powerAngle = MathHelper.lerp(delta, this.powerAngle, powerTarget);
-        powerControl.roll = this.powerAngle - 0.5f;
+        float powerAngle = getAngle(console, "power", powerTarget, delta);
+        powerControl.roll = powerAngle - 0.5f;
         float rotorTarget = !tardis.fuel().hasPower() ? rotor.pivotY + 5 : -19.5f;
-        this.rotorAngle = MathHelper.lerp(delta, this.rotorAngle, rotorTarget);
-        if (tardis.travel().isLanded()) rotor.pivotY = this.rotorAngle;
+        float rotorAngle = getAngle(console, "rotor", rotorTarget, delta);
+        if (tardis.travel().isLanded()) rotor.pivotY = rotorAngle;
 
         // Door Control Movements
         ModelPart doorControl = this.bone.getChild("panels").getChild("p_5").getChild("bone112").getChild("bone113")
@@ -1484,8 +1465,8 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         ModelPart doorControlLight = this.bone.getChild("panels").getChild("p_5").getChild("bone112")
                 .getChild("bone113").getChild("bone114").getChild("ind_lamp_20").getChild("bone117");
         float doorControlTarget = tardis.door().isLeftOpen() ? 2.075f : tardis.door().areBothOpen() ? 3.15f : 0.5f;
-        this.doorControlAngle = MathHelper.lerp(delta, this.doorControlAngle, doorControlTarget);
-        doorControl.yaw = this.doorControlAngle - 0.5f;
+        float doorControlAngle = getAngle(console, "door_control", doorControlTarget, delta);
+        doorControl.yaw = doorControlAngle - 0.5f;
         if (tardis.door().isLeftOpen()) {
             doorControlLight.pivotY = doorControlLight.pivotY + 1;
         } else if (tardis.door().isRightOpen()) {
@@ -1498,8 +1479,8 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         ModelPart doorLockLight = this.bone.getChild("panels").getChild("p_5").getChild("bone112").getChild("bone113")
                 .getChild("bone114").getChild("ind_lamp_21").getChild("bone118");
         float doorLockTarget = tardis.door().locked() ? 2.075f : 0.5f;
-        this.doorLockAngle = MathHelper.lerp(delta, this.doorLockAngle, doorLockTarget);
-        doorLock.yaw = this.doorLockAngle - 0.5f;
+        float doorLockAngle = getAngle(console, "door_lock", doorLockTarget, delta);
+        doorLock.yaw = doorLockAngle - 0.5f;
         doorLockLight.pivotY = tardis.door().locked() ? doorLockLight.pivotY + 1 : doorLockLight.pivotY;
 
         // Refueler Control Movements
@@ -1508,8 +1489,8 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         ModelPart refuelerLight = this.bone.getChild("panels").getChild("p_4").getChild("bone98").getChild("bone99")
                 .getChild("bone100").getChild("ind_lamp_16").getChild("bone111");
         float refuelerTarget = tardis.isRefueling() ? 2.075f : 0.5f;
-        this.refuelerAngle = MathHelper.lerp(delta, this.refuelerAngle, refuelerTarget);
-        refueler.yaw = this.refuelerAngle - 0.5f;
+        float refuelerAngle = getAngle(console, "refueler", refuelerTarget, delta);
+        refueler.yaw = refuelerAngle - 0.5f;
         refuelerLight.pivotY = tardis.isRefueling() ? refuelerLight.pivotY : refuelerLight.pivotY + 1;
 
         ModelPart cloak = this.bone.getChild("panels").getChild("p_4").getChild("bone98").getChild("bone99")
@@ -1519,8 +1500,8 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         float cloakTarget = tardis.<CloakHandler>handler(TardisComponent.Id.CLOAK).cloaked().get()
                 ? 2.075f
                 : 0.5f;
-        this.cloakAngle = MathHelper.lerp(delta, this.cloakAngle, cloakTarget);
-        cloak.yaw = this.cloakAngle - 0.5f;
+        float cloakAngle = getAngle(console, "cloak", cloakTarget, delta);
+        cloak.yaw = cloakAngle - 0.5f;
         cloakLight.pivotY = tardis.<CloakHandler>handler(TardisComponent.Id.CLOAK).cloaked().get()
                 ? cloakLight.pivotY
                 : cloakLight.pivotY + 1;
@@ -1529,18 +1510,15 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         ModelPart groundSearch = this.bone.getChild("panels").getChild("p_4").getChild("bone98").getChild("bone99")
                 .getChild("bone100").getChild("s_knob");
         float groundSearchTarget = tardis.travel().horizontalSearch().get() ? 1.0f : -1.5f;
-        this.groundSearchAngle = MathHelper.lerp(delta, this.groundSearchAngle, groundSearchTarget);
-        groundSearch.pivotZ = this.groundSearchAngle - 0.5f;
-        /*groundSearch.pivotZ = !tardis.travel().horizontalSearch().get()
-                ? groundSearch.pivotZ - 1.5f
-                : groundSearch.pivotZ; // FIXME use TravelHandler#horizontalSearch/#verticalSearch*/
+        float groundSearchAngle = getAngle(console, "ground_search", groundSearchTarget, delta);
+        groundSearch.pivotZ = groundSearchAngle - 0.5f;
 
         // Hail Mary Control Movements
         ModelPart hailMary = this.bone.getChild("panels").getChild("p_2").getChild("bone48").getChild("bone49")
                 .getChild("bone50").getChild("s_lever").getChild("bone61");
         float hailMaryTarget = tardis.stats().hailMary().get() ? 3.0f : 1.5f;
-        this.hailMaryAngle = MathHelper.lerp(delta, this.hailMaryAngle, hailMaryTarget);
-        hailMary.roll = this.hailMaryAngle - 0.5f;
+        float hailMaryAngle = getAngle(console, "hail_mary", hailMaryTarget, delta);
+        hailMary.roll = hailMaryAngle - 0.5f;
         ModelPart hailMaryWarningLight = this.bone.getChild("panels").getChild("p_2").getChild("bone48")
                 .getChild("bone49").getChild("bone50").getChild("sym_lamp").getChild("bone97");
         hailMaryWarningLight.pivotY = tardis.stats().hailMary().get()
@@ -1555,8 +1533,8 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         ModelPart hadsAlarmsLightsTwo = this.bone.getChild("panels").getChild("p_6").getChild("bone132")
                 .getChild("bone133").getChild("bone134").getChild("sym_lamp5").getChild("bone141");
         float alarmTarget = tardis.alarm().isEnabled() ? 3.0f : 1.5f;
-        this.alarmAngle = MathHelper.lerp(delta, this.alarmAngle, alarmTarget);
-        hadsAlarms.roll = this.alarmAngle - 0.5f;
+        float alarmAngle = getAngle(console, "alarm", alarmTarget, delta);
+        hadsAlarms.roll = alarmAngle - 0.5f;
         if (!tardis.alarm().isEnabled()) {
             hadsAlarmsLightsOne.pivotY = hadsAlarmsLightsOne.pivotY + 1;
             hadsAlarmsLightsTwo.pivotY = hadsAlarmsLightsTwo.pivotY + 1;
@@ -1565,8 +1543,8 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         ModelPart security = this.bone.getChild("panels").getChild("p_6").getChild("bone132").getChild("bone133")
                 .getChild("bone134").getChild("s_lever_7").getChild("bone144");
         float securityTarget = (tardis.stats().security().get()) ? 3.0f : 1.5f;
-        this.securityAngle = MathHelper.lerp(delta, this.securityAngle, securityTarget);
-        security.roll = this.securityAngle - 0.5f;
+        float securityAngle = getAngle(console, "security", securityTarget, delta);
+        security.roll = securityAngle - 0.5f;
 
         ModelPart increment = this.bone.getChild("panels").getChild("p_3").getChild("bone67")
                 .getChild("bone68").getChild("bone69").getChild("s_crank_3").getChild("bone74");
@@ -1584,25 +1562,21 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
             incrementTarget = 0.5f;
         }
 
-        this.incrementAngle = MathHelper.lerp(delta, this.incrementAngle, incrementTarget);
-        increment.yaw = this.incrementAngle - 0.5f;
+        float incrementAngle = getAngle(console, "increment", incrementTarget, delta);
+        increment.yaw = incrementAngle - 0.5f;
 
         // Direction Control Movements
         ModelPart direction = this.bone.getChild("panels").getChild("p_2").getChild("bone48").getChild("bone49")
                 .getChild("bone50").getChild("s_crank_1").getChild("bone59");
         float directionTargetDegrees = (0.3927f * tardis.travel().destination().getRotation()) * (180f / (float) Math.PI);
-        float currentAngleDegrees = this.directionAngle * (180f / (float) Math.PI);
-        float nextAngleDegrees = MathHelper.lerpAngleDegrees(delta, currentAngleDegrees, directionTargetDegrees);
-
-        this.directionAngle = nextAngleDegrees * ((float) Math.PI / 180f);
-        direction.yaw = this.directionAngle;
+        direction.yaw = getLerpedDegrees(console, "increment", directionTargetDegrees, delta);
 
         // Anti Grav Control Movements
         ModelPart antiGrav = this.bone.getChild("panels").getChild("p_1").getChild("bone38").getChild("bone36")
                 .getChild("bone37").getChild("sl_switch_1").getChild("bone33");
         float antiGravTarget = !tardis.travel().antigravs().get() ? 15.4f : 16.4f;
-        this.antiGravAngle = MathHelper.lerp(delta, this.antiGravAngle, antiGravTarget);
-        antiGrav.pivotX = this.antiGravAngle - 0.5f;
+        float antiGravAngle = getAngle(console, "antigravs", antiGravTarget, delta);
+        antiGrav.pivotX = antiGravAngle - 0.5f;
 
         ModelPart shield = this.bone.getChild("panels").getChild("p_2").getChild("bone48").getChild("bone49")
                 .getChild("bone50").getChild("sl_switch_6").getChild("bone57");
@@ -1611,21 +1585,21 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
                         ? 13.9f
                         : 13.4f
                 : 14.4f;
-        this.shieldAngle = MathHelper.lerp(delta, this.shieldAngle, shieldTarget);
-        shield.pivotX = this.shieldAngle - 0.5f;
+        float shieldAngle = getAngle(console, "shields", shieldTarget, delta);
+        shield.pivotX = shieldAngle - 0.5f;
 
         ModelPart siegeProtocol = this.bone.getChild("panels").getChild("p_2").getChild("bone48").getChild("bone49")
                 .getChild("bone50").getChild("sl_switch_5").getChild("bone56");
         float siegeTarget = !tardis.siege().isActive() ? 9.9f : 10.9f;
-        this.siegeAngle = MathHelper.lerp(delta, this.siegeAngle, siegeTarget);
-        siegeProtocol.pivotX = this.siegeAngle - 0.5f;
+        float siegeAngle = getAngle(console, "siege", siegeTarget, delta);
+        siegeProtocol.pivotX = siegeAngle - 0.5f;
 
         // Auto Pilot Control Movements
         ModelPart autoPilot = this.bone.getChild("panels").getChild("p_1").getChild("bone38").getChild("bone36")
                 .getChild("bone37").getChild("st_switch").getChild("bone26");
         float autopilotTarget = !tardis.travel().autopilot() ? 1 : 0f;
-        this.autopilotAngle = MathHelper.lerp(delta, this.autopilotAngle, autopilotTarget);
-        autoPilot.yaw = this.autopilotAngle - 0.5f;
+        float autopilotAngle = getAngle(console, "autopilot", autopilotTarget, delta);
+        autoPilot.yaw = autopilotAngle - 0.5f;
 
         super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();

--- a/src/main/java/dev/amble/ait/client/models/consoles/HartnellConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/HartnellConsoleModel.java
@@ -1569,7 +1569,7 @@ public class HartnellConsoleModel extends SimpleConsoleModel {
         ModelPart direction = this.bone.getChild("panels").getChild("p_2").getChild("bone48").getChild("bone49")
                 .getChild("bone50").getChild("s_crank_1").getChild("bone59");
         float directionTargetDegrees = (0.3927f * tardis.travel().destination().getRotation()) * (180f / (float) Math.PI);
-        direction.yaw = getLerpedDegrees(console, "increment", directionTargetDegrees, delta);
+        direction.yaw = getLerpedDegrees(console, "direction", directionTargetDegrees, delta);
 
         // Anti Grav Control Movements
         ModelPart antiGrav = this.bone.getChild("panels").getChild("p_1").getChild("bone38").getChild("bone36")

--- a/src/main/java/dev/amble/ait/client/models/consoles/HudolinConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/HudolinConsoleModel.java
@@ -1694,105 +1694,75 @@ public class HudolinConsoleModel extends SimpleConsoleModel {
         matrices.pop();
     }
 
-    private float throttleAngle = 0f;
-    private float handbrakeAngle = 0f;
-    private float powerAngle = 0f;
-    private float doorControlAngle = 0f;
-    private float doorLockAngle = 0f;
-    private float incrementAngle = 0f;
-    private float increment2Angle = 0f;
-    private float directionAngle = 0f;
-    private float cloakAngle = 0f;
-    private float hailMaryAngle = 0f;
-    private float alarmAngle = 0f;
-    private float securityAngle = 0f;
-    private float shieldAngle = 0f;
-    private float siegeAngle = 0f;
-
     @Override
     public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        float delta = 0.1f * MinecraftClient.getInstance().getTickDelta();
+        float delta = 0.1f * client.getTickDelta();
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
-
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180f));
 
         // Throttle Control
         ModelPart throttle = this.dematleveryay;
         float throttleTarget = tardis.travel().maxSpeed().get() > 0 ? (float) tardis.travel().speed() / (float) tardis.travel().maxSpeed().get() : 0f;
-        this.throttleAngle = MathHelper.lerp(delta, this.throttleAngle, throttleTarget);
-        throttle.roll = -this.throttleAngle;
+        throttle.roll = -getAngle(console, "throttle", throttleTarget, delta);
 
-        // Handbrake Control and Lights
+        // Handbrake Control
         ModelPart handbrake = this.console.getChild("fix6");
         float handbrakeTarget = !tardis.travel().handbrake() ? 1.2f : 0f;
-        this.handbrakeAngle =  MathHelper.lerp(delta, this.handbrakeAngle, handbrakeTarget);
-        handbrake.pitch = this.handbrakeAngle - 0.5f;
+        handbrake.pitch = getAngle(console, "handbrake", handbrakeTarget, delta) - 0.5f;
 
-
-        // Power Switch and Lights
+        // Power Switch
         ModelPart power = this.console.getChild("pannel4").getChild("spin2").getChild("bone2");
         float powerTarget = tardis.fuel().hasPower() ? 0 : -1.55f;
-        this.powerAngle = MathHelper.lerp(delta, this.powerAngle, powerTarget);
-        power.yaw = this.powerAngle;
+        power.yaw = getAngle(console, "power", powerTarget, delta);
 
         // Door Locking Mechanism Control
         ModelPart doorlock = this.fix9;
         float doorLockTarget = tardis.door().locked() ? -1.55f : 0;
-        this.doorLockAngle = MathHelper.lerp(delta, this.doorLockAngle, doorLockTarget);
-        doorlock.pitch = this.doorLockAngle;
+        doorlock.pitch = getAngle(console, "door_lock", doorLockTarget, delta);
 
         // Door Control
         ModelPart doorControl = this.fix11;
         float doorControlTarget = tardis.door().isRightOpen() ? -1.55f : tardis.door().isLeftOpen() ? -1f : 0;
-        this.doorControlAngle = MathHelper.lerp(delta, this.doorControlAngle, doorControlTarget);
-        doorControl.pitch = this.doorControlAngle;
+        doorControl.pitch = getAngle(console, "door_control", doorControlTarget, delta);
 
-        // Alarm Control and Lights
+        // Alarm Control
         ModelPart alarms = this.dial2;
         float alarmTarget = tardis.alarm().isEnabled() ? 1f : -0.9f;
-        this.alarmAngle = MathHelper.lerp(delta, this.alarmAngle, alarmTarget);
-        alarms.yaw = this.alarmAngle;
+        alarms.yaw = getAngle(console, "alarm", alarmTarget, delta);
 
         // Hail Mary
         ModelPart hailmary = this.dial3;
         float hailMaryTarget = tardis.stats().hailMary().get() ? 1f : -0.9f;
-        this.hailMaryAngle = MathHelper.lerp(delta, this.hailMaryAngle, hailMaryTarget);
-        hailmary.yaw = this.hailMaryAngle;
+        hailmary.yaw = getAngle(console, "hail_mary", hailMaryTarget, delta);
 
         // Cloak
         ModelPart cloak = this.dial5;
         float cloakTarget = tardis.<CloakHandler>handler(TardisComponent.Id.CLOAK).cloaked().get() ? 1f : -0.9f;
-        this.cloakAngle = MathHelper.lerp(delta, this.cloakAngle, cloakTarget);
-        cloak.yaw = this.cloakAngle;
+        cloak.yaw = getAngle(console, "cloak", cloakTarget, delta);
 
         // Siege Mode
         ModelPart siege = this.dial6;
         float siegeTarget = tardis.siege().isActive() ? 1f : -0.9f;
-        this.siegeAngle = MathHelper.lerp(delta, this.siegeAngle, siegeTarget);
-        siege.yaw = this.siegeAngle;
+        siege.yaw = getAngle(console, "siege", siegeTarget, delta);
 
         // Shields
         ModelPart shields = this.dial4;
         float shieldTarget = tardis.areVisualShieldsActive() ? 1f : tardis.areShieldsActive() ? 0 : -0.9f;
-        this.shieldAngle = MathHelper.lerp(delta, this.shieldAngle, shieldTarget);
-        shields.yaw = this.shieldAngle;
+        shields.yaw = getAngle(console, "shields", shieldTarget, delta);
 
+        // Security
         ModelPart security = this.flick5;
         float securityTarget = tardis.stats().security().get() ? -1f : 0.85f;
-        this.securityAngle = MathHelper.lerp(delta, this.securityAngle, securityTarget);
-        security.pitch = this.securityAngle;
+        security.pitch = getAngle(console, "security", securityTarget, delta);
 
         // Direction Control
         ModelPart direction = this.dialfix;
         float directionTargetDegrees = (0.3927f * tardis.travel().destination().getRotation()) * (180f / (float) Math.PI);
-        float currentAngleDegrees = this.directionAngle * (180f / (float) Math.PI);
-        float nextAngleDegrees = MathHelper.lerpAngleDegrees(delta, currentAngleDegrees, directionTargetDegrees);
+        direction.yaw = getLerpedDegrees(console, "direction", directionTargetDegrees, delta);
 
-        this.directionAngle = nextAngleDegrees * ((float) Math.PI / 180f);
-        direction.yaw = this.directionAngle;
-
+        // Increments
         ModelPart increment = this.slide2;
         ModelPart increment2 = this.slide;
 
@@ -1817,11 +1787,8 @@ public class HudolinConsoleModel extends SimpleConsoleModel {
             targetTwo = 1.3f;
         }
 
-        this.incrementAngle = MathHelper.lerp(delta, this.incrementAngle,  targetOne);
-        this.increment2Angle = MathHelper.lerp(delta, this.increment2Angle, targetTwo);
-
-        increment.pivotX = this.incrementAngle - 2.75f;
-        increment2.pivotX = this.increment2Angle -4.75f;
+        increment.pivotX = getAngle(console, "increment_1", targetOne, delta) - 2.75f;
+        increment2.pivotX = getAngle(console, "increment_2", targetTwo, delta) - 4.75f;
 
         // Hammer
         ModelPart hammer = this.toolbox.getChild("hammer");

--- a/src/main/java/dev/amble/ait/client/models/consoles/RenaissanceConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/RenaissanceConsoleModel.java
@@ -1357,50 +1357,37 @@ public class RenaissanceConsoleModel extends SimpleConsoleModel {
         console.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
     }
 
-    private float throttleAngle = 0f;
-    private float handbrakeAngle = 0f;
-    private float refueler2Angle = 0f;
-    private float doorControlAngle = 0f;
-    private float doorLockAngle = 0f;
-    private float incrementAngle = 0f;
-    private float directionAngle = 0f;
-    private float refuelerAngle = 0f;
-    private float alarmAngle = 0f;
-    private float antiGravAngle = 0f;
-    private float shieldAngle = 0f;
-    private float antiGrav2Angle = 0f;
-
     @Override
     public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        float delta = 0.1f * MinecraftClient.getInstance().getTickDelta();
+        float delta = 0.1f * client.getTickDelta();
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180f));
 
+        // Throttle
         ModelPart throttle = this.console.getChild("bone53").getChild("throttle");
         float throttleTarget = (tardis.travel().speed() / (float) tardis.travel().maxSpeed().get()) * 1.5f;
-        this.throttleAngle = MathHelper.lerp(delta, this.throttleAngle, throttleTarget);
-        throttle.pitch = this.throttleAngle;
+        throttle.pitch = getAngle(console, "throttle", throttleTarget, delta);
 
+        // Handbrake
         ModelPart handbrake = this.console.getChild("panelf").getChild("handbrake");
         float handbrakeTarget = !tardis.travel().handbrake() ? 0.57f : 0f;
-        this.handbrakeAngle = MathHelper.lerp(delta, this.handbrakeAngle, handbrakeTarget);
-        handbrake.pitch = this.handbrakeAngle;
+        handbrake.pitch = getAngle(console, "handbrake", handbrakeTarget, delta);
 
+        // Antigravs
         ModelPart antigravs = this.console.getChild("panelf4").getChild("antigravs");
         float antiGravTargetYaw = tardis.travel().antigravs().get() ? 1.0f : 0f;
         float antiGravTargetRoll = tardis.travel().antigravs().get() ? 0.2f : 0f;
-        this.antiGravAngle = MathHelper.lerp(delta, this.antiGravAngle, antiGravTargetYaw);
-        this.antiGrav2Angle = MathHelper.lerp(delta, this.antiGrav2Angle, antiGravTargetRoll);
-        antigravs.yaw = this.antiGravAngle;
-        antigravs.roll = this.antiGrav2Angle;
+        antigravs.yaw = getAngle(console, "antigravs_yaw", antiGravTargetYaw, delta);
+        antigravs.roll = getAngle(console, "antigravs_roll", antiGravTargetRoll, delta);
 
+        // Door Lock
         ModelPart doorlock = this.console.getChild("panelf5").getChild("door_lock");
         float doorLockTarget = tardis.door().locked() ? 0.5f : 0f;
-        this.doorLockAngle = MathHelper.lerp(delta, this.doorLockAngle, doorLockTarget);
-        doorlock.pitch = this.doorLockAngle;
+        doorlock.pitch = getAngle(console, "door_lock", doorLockTarget, delta);
 
+        // Door Control
         ModelPart doorControl = this.console.getChild("panelf5").getChild("doors");
         float doorControlTarget = 0f;
         if (tardis.door().isLeftOpen()) {
@@ -1408,38 +1395,34 @@ public class RenaissanceConsoleModel extends SimpleConsoleModel {
         } else if (tardis.door().isRightOpen()) {
             doorControlTarget = -1.55f;
         }
-        this.doorControlAngle = MathHelper.lerp(delta, this.doorControlAngle, doorControlTarget);
-        doorControl.pitch = this.doorControlAngle;
+        doorControl.pitch = getAngle(console, "door_control", doorControlTarget, delta);
 
+        // Alarms
         ModelPart alarms = this.console.getChild("panelf5").getChild("alarms");
         float alarmTarget = tardis.alarm().isEnabled() ? 0.2f : 0f;
-        this.alarmAngle = MathHelper.lerp(delta, this.alarmAngle, alarmTarget);
-        alarms.yaw = this.alarmAngle;
+        alarms.yaw = getAngle(console, "alarm", alarmTarget, delta);
 
+        // Shields
         ModelPart shields = this.console.getChild("panelf5").getChild("rwf").getChild("bone56");
         float shieldTarget = tardis.shields().shielded().get() ? 1.85f : 0f;
-        this.shieldAngle = MathHelper.lerp(delta, this.shieldAngle, shieldTarget);
-        shields.yaw = this.shieldAngle;
+        shields.yaw = getAngle(console, "shields", shieldTarget, delta);
 
+        // Refuel
         ModelPart refuel = this.console.getChild("bone53").getChild("refueler");
         float refuelTargetRoll = tardis.isRefueling() ? 0.6f : 0f;
         float refuelTargetYaw = tardis.isRefueling() ? 0.1f : 0f;
-        this.refuelerAngle = MathHelper.lerp(delta, this.refuelerAngle, refuelTargetRoll);
-        this.refueler2Angle = MathHelper.lerp(delta, this.refueler2Angle, refuelTargetYaw);
-        refuel.roll = this.refuelerAngle;
-        refuel.yaw = this.refueler2Angle;
+        refuel.roll = getAngle(console, "refuel_roll", refuelTargetRoll, delta);
+        refuel.yaw = getAngle(console, "refuel_yaw", refuelTargetYaw, delta);
 
+        // Direction
         ModelPart direction = this.console.getChild("panelf").getChild("rotation");
         float directionTargetDegrees = tardis.travel().destination().getRotation() * 22.5f;
-        float currentDirectionDegrees = (float) Math.toDegrees(this.directionAngle);
-        float nextDirectionDegrees = MathHelper.lerpAngleDegrees(delta, currentDirectionDegrees, directionTargetDegrees);
-        this.directionAngle = (float) Math.toRadians(nextDirectionDegrees);
-        direction.pitch = this.directionAngle;
+        direction.pitch = getLerpedDegrees(console, "direction", directionTargetDegrees, delta);
 
+        // Increment
         ModelPart increment = this.console.getChild("panelf5").getChild("increment");
         float incrementTarget = IncrementManager.increment(tardis) > 0 ? 0.5f : 0f;
-        this.incrementAngle = MathHelper.lerp(delta, this.incrementAngle, incrementTarget);
-        increment.pitch = this.incrementAngle;
+        increment.pitch = getAngle(console, "increment", incrementTarget, delta);
 
         super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();

--- a/src/main/java/dev/amble/ait/client/models/consoles/SimpleConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/SimpleConsoleModel.java
@@ -27,12 +27,13 @@ import net.minecraft.util.math.MathHelper;
 @SuppressWarnings("rawtypes")
 public abstract class SimpleConsoleModel extends SinglePartEntityModel implements ConsoleModel {
 
+    // Using a map actually is the worst way to do this - DO NOT REPLICATE. - Loqor
     protected static final Map<BlockEntity, Map<String, Float>> ANIMATION_CACHE = new WeakHashMap<>();
 
     protected static final MinecraftClient client = MinecraftClient.getInstance();
 
     protected float getAngle(BlockEntity console, String key, float target, float delta) {
-        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, HashMap::new);
+        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new HashMap<>());
         float current = state.getOrDefault(key, 0f);
         float next = MathHelper.lerp(delta, current, target);
         state.put(key, next);
@@ -40,7 +41,7 @@ public abstract class SimpleConsoleModel extends SinglePartEntityModel implement
     }
 
     protected float getLerpedDegrees(BlockEntity console, String key, float targetDegrees, float delta) {
-        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, HashMap::new);
+        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new HashMap<>());
         float currentRadians = state.getOrDefault(key, 0f);
         float currentDegrees = currentRadians * (180f / (float) Math.PI);
         float nextDegrees = MathHelper.lerpAngleDegrees(delta, currentDegrees, targetDegrees);
@@ -59,12 +60,6 @@ public abstract class SimpleConsoleModel extends SinglePartEntityModel implement
 
     @Override
     public void animateBlockEntity(ConsoleBlockEntity console, TravelHandlerBase.State state, boolean hasPower) {
-        // fyi, this is directly referencing camel animation code, its just specific
-        // according to
-        // the
-        // block entity that
-        // is being used
-        // to detect different states. - Loqor
         this.getPart().traverse().forEach(ModelPart::resetTransform);
 
         if (hasPower && AITModClient.CONFIG.animateConsole)

--- a/src/main/java/dev/amble/ait/client/models/consoles/SimpleConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/SimpleConsoleModel.java
@@ -32,7 +32,7 @@ public abstract class SimpleConsoleModel extends SinglePartEntityModel implement
     protected static final MinecraftClient client = MinecraftClient.getInstance();
 
     protected float getAngle(BlockEntity console, String key, float target, float delta) {
-        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new HashMap<>());
+        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, HashMap::new);
         float current = state.getOrDefault(key, 0f);
         float next = MathHelper.lerp(delta, current, target);
         state.put(key, next);
@@ -40,7 +40,7 @@ public abstract class SimpleConsoleModel extends SinglePartEntityModel implement
     }
 
     protected float getLerpedDegrees(BlockEntity console, String key, float targetDegrees, float delta) {
-        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new HashMap<>());
+        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, HashMap::new);
         float currentRadians = state.getOrDefault(key, 0f);
         float currentDegrees = currentRadians * (180f / (float) Math.PI);
         float nextDegrees = MathHelper.lerpAngleDegrees(delta, currentDegrees, targetDegrees);

--- a/src/main/java/dev/amble/ait/client/models/consoles/SimpleConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/SimpleConsoleModel.java
@@ -1,7 +1,11 @@
 package dev.amble.ait.client.models.consoles;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.function.Function;
 
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.model.ModelPart;
 import net.minecraft.client.render.RenderLayer;
@@ -23,6 +27,28 @@ import net.minecraft.util.math.MathHelper;
 @SuppressWarnings("rawtypes")
 public abstract class SimpleConsoleModel extends SinglePartEntityModel implements ConsoleModel {
 
+    protected static final Map<BlockEntity, Map<String, Float>> ANIMATION_CACHE = new WeakHashMap<>();
+
+    protected static final MinecraftClient client = MinecraftClient.getInstance();
+
+    protected float getAngle(BlockEntity console, String key, float target, float delta) {
+        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new HashMap<>());
+        float current = state.getOrDefault(key, 0f);
+        float next = MathHelper.lerp(delta, current, target);
+        state.put(key, next);
+        return next;
+    }
+
+    protected float getLerpedDegrees(BlockEntity console, String key, float targetDegrees, float delta) {
+        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new HashMap<>());
+        float currentRadians = state.getOrDefault(key, 0f);
+        float currentDegrees = currentRadians * (180f / (float) Math.PI);
+        float nextDegrees = MathHelper.lerpAngleDegrees(delta, currentDegrees, targetDegrees);
+        float nextRadians = nextDegrees * ((float) Math.PI / 180f);
+        state.put(key, nextRadians);
+        return nextRadians;
+    }
+
     public SimpleConsoleModel() {
         this(RenderLayer::getEntityCutoutNoCull);
     }
@@ -42,7 +68,7 @@ public abstract class SimpleConsoleModel extends SinglePartEntityModel implement
         this.getPart().traverse().forEach(ModelPart::resetTransform);
 
         if (hasPower && AITModClient.CONFIG.animateConsole)
-            this.updateAnimation(console.ANIM_STATE, this.getAnimationForState(state), MinecraftClient.getInstance().getTickDelta() + console.getAge());
+            this.updateAnimation(console.ANIM_STATE, this.getAnimationForState(state), client.getTickDelta() + console.getAge());
     }
 
     @Override
@@ -65,11 +91,6 @@ public abstract class SimpleConsoleModel extends SinglePartEntityModel implement
 
     public void renderMonitorText(Tardis tardis, ConsoleBlockEntity entity, MatrixStack matrices,
                                   VertexConsumerProvider vertexConsumers, int light, int overlay) {
-        // do nothing !! (i fucking hate programming) todo - @Loqor you added this feature ur implementing it for the rest
-    }
-
-    public float interpol(float current, float target, float speed) {
-        float delta = MinecraftClient.getInstance().getTickDelta() * speed;
-        return MathHelper.lerp(delta, current, target);
+        // no op
     }
 }

--- a/src/main/java/dev/amble/ait/client/models/consoles/SimpleConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/SimpleConsoleModel.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.function.Function;
 
+import it.unimi.dsi.fastutil.objects.Object2FloatMap;
+import it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.model.ModelPart;
@@ -28,12 +30,12 @@ import net.minecraft.util.math.MathHelper;
 public abstract class SimpleConsoleModel extends SinglePartEntityModel implements ConsoleModel {
 
     // Using a map actually is the worst way to do this - DO NOT REPLICATE. - Loqor
-    protected static final Map<BlockEntity, Map<String, Float>> ANIMATION_CACHE = new WeakHashMap<>();
+    protected static final Map<BlockEntity, Object2FloatMap<String>> ANIMATION_CACHE = new WeakHashMap<>();
 
     protected static final MinecraftClient client = MinecraftClient.getInstance();
 
     protected float getAngle(BlockEntity console, String key, float target, float delta) {
-        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new HashMap<>());
+        Object2FloatMap<String> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new Object2FloatOpenHashMap<>());
         float current = state.getOrDefault(key, 0f);
         float next = MathHelper.lerp(delta, current, target);
         state.put(key, next);
@@ -41,7 +43,7 @@ public abstract class SimpleConsoleModel extends SinglePartEntityModel implement
     }
 
     protected float getLerpedDegrees(BlockEntity console, String key, float targetDegrees, float delta) {
-        Map<String, Float> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new HashMap<>());
+        Object2FloatMap<String> state = ANIMATION_CACHE.computeIfAbsent(console, k -> new Object2FloatOpenHashMap<>());
         float currentRadians = state.getOrDefault(key, 0f);
         float currentDegrees = currentRadians * (180f / (float) Math.PI);
         float nextDegrees = MathHelper.lerpAngleDegrees(delta, currentDegrees, targetDegrees);

--- a/src/main/java/dev/amble/ait/client/models/consoles/SteamConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/SteamConsoleModel.java
@@ -1,5 +1,7 @@
 package dev.amble.ait.client.models.consoles;
 
+import dev.amble.ait.api.tardis.TardisComponent;
+import dev.amble.ait.core.tardis.handler.CloakHandler;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.model.*;
 import net.minecraft.client.render.VertexConsumer;
@@ -1478,138 +1480,113 @@ public class SteamConsoleModel extends SimpleConsoleModel {
         steam.render(matrices, vertexConsumer, light, overlay, red, green, blue, alpha);
     }
 
-    private float throttleAngle = 0f;
-    private float handbrakeAngle = 0f;
-    private float powerAngle = 0f;
-    private float doorControlAngle = 0f;
-    private float doorLockAngle = 0f;
-    private float incrementAngle = 0f;
-    private float directionAngle = 0f;
-    private float refuelerAngle = 0f;
-    private float cloakAngle = 0f;
-    private float groundSearchAngle = 0f;
-    private float alarmAngle = 0f;
-    private float securityAngle = 0f;
-    private float antiGravAngle = 0f;
-    private float shieldAngle = 0f;
-    private float autopilotAngle = 0f;
-
     @Override
     public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        float delta = 0.1f * MinecraftClient.getInstance().getTickDelta();
+        float delta = 0.1f * client.getTickDelta();
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
 
+        // Throttle Control
         ModelPart throttle = steam.getChild("controls").getChild("panel_6").getChild("rot6").getChild("lever9")
                 .getChild("bone50");
-        float throttleTarget = tardis.travel().maxSpeed().get() > 0 ? ((float) tardis.travel().speed() / (float) tardis.travel().maxSpeed().get()): 0f;
-        this.throttleAngle = MathHelper.lerp(delta, this.throttleAngle, throttleTarget);
-        throttle.roll = this.throttleAngle - 0.5f;
-        //throttle.roll = throttle.roll - ((tardis.travel().speed() / (float) tardis.travel().maxSpeed().get()) * 1.5f);
+        float throttleTarget = tardis.travel().maxSpeed().get() > 0 ? ((float) tardis.travel().speed() / (float) tardis.travel().maxSpeed().get()) : 0f;
+        throttle.roll = getAngle(console, "throttle", throttleTarget, delta) - 0.5f;
 
+        // Increment Control
         ModelPart increment = steam.getChild("controls").getChild("panel_6").getChild("rot6").getChild("lever10").getChild("bone54");
-
         int incrementVal = IncrementManager.increment(tardis);
         float targetOffset = 0f;
-
-        if (incrementVal < 10) {
-            targetOffset = 0f;
-        } else if (incrementVal < 100) {
-            targetOffset = -0.69815F;
-        } else if (incrementVal < 1000) {
-            targetOffset = -(0.69815F * 2);
-        } else if (incrementVal < 10000) {
-            targetOffset = -(1.047225F * 2);
-        } else {
+        if (incrementVal >= 10000) {
             targetOffset = -(1.3963F * 2);
+        } else if (incrementVal >= 1000) {
+            targetOffset = -(1.047225F * 2);
+        } else if (incrementVal >= 100) {
+            targetOffset = -(0.69815F * 2);
+        } else if (incrementVal >= 10) {
+            targetOffset = -0.69815F;
         }
+        increment.roll = getAngle(console, "increment", targetOffset, delta) + 1.5f;
 
-        this.incrementAngle = MathHelper.lerp(delta, this.incrementAngle, targetOffset);
-        increment.roll = this.incrementAngle + 1.5f;
-
+        // Alarm Control
         ModelPart alarms = steam.getChild("controls").getChild("panel_1").getChild("rot").getChild("lever4")
                 .getChild("bone22");
         float alarmTarget = tardis.alarm().isEnabled() ? 0.4363F : -0.5672F;
-        this.alarmAngle = MathHelper.lerp(delta, this.alarmAngle, alarmTarget);
-        alarms.roll = this.alarmAngle;
+        alarms.roll = getAngle(console, "alarm", alarmTarget, delta);
 
+        // Security Control
         ModelPart security = steam.getChild("controls").getChild("panel_1").getChild("rot").getChild("lever2")
                 .getChild("bone20");
         float securityTarget = tardis.stats().security().get() ? 0.4363F : -0.5672F;
-        this.securityAngle = MathHelper.lerp(delta, this.securityAngle, securityTarget);
-        security.roll = this.securityAngle;
+        security.roll = getAngle(console, "security", securityTarget, delta);
 
+        // Anti Grav Control
         ModelPart antigrav = steam.getChild("controls").getChild("panel_1").getChild("rot").getChild("lever3")
                 .getChild("bone19");
         float antigravTarget = tardis.travel().antigravs().get() ? 0.4363F : -0.5672F;
-        this.antiGravAngle = MathHelper.lerp(delta, this.antiGravAngle, antigravTarget);
-        antigrav.roll = this.antiGravAngle;
+        antigrav.roll = getAngle(console, "antigravs", antigravTarget, delta);
 
+        // Shields Control
         ModelPart shields = steam.getChild("controls").getChild("panel_1").getChild("rot").getChild("lever5")
                 .getChild("bone21");
         float shieldsTarget = tardis.shields().shielded().get()
-                ? tardis.shields().visuallyShielded().get() ? 0.0F : 0.4363F
+                ? (tardis.shields().visuallyShielded().get() ? 0.0F : 0.4363F)
                 : -0.5672F;
-        this.shieldAngle = MathHelper.lerp(delta, this.shieldAngle, shieldsTarget);
-        shields.roll = this.shieldAngle;
+        shields.roll = getAngle(console, "shields", shieldsTarget, delta);
 
+        // Refueling Control
         ModelPart refueling = steam.getChild("controls").getChild("panel_1").getChild("rot").getChild("lever")
                 .getChild("bone23");
         float refuelerTarget = tardis.isRefueling() ? 0.4363F : -0.5672F;
-        this.refuelerAngle = MathHelper.lerp(delta, this.refuelerAngle, refuelerTarget);
-        refueling.roll = this.refuelerAngle;
+        refueling.roll = getAngle(console, "refueler", refuelerTarget, delta);
 
+        // Handbrake Control
         ModelPart handbrake = steam.getChild("controls").getChild("panel_4").getChild("rot4").getChild("lever6")
                 .getChild("bone41");
-        float handbrakeTarget = tardis.travel().handbrake() ? 0 : 1.5f;
-        this.handbrakeAngle = MathHelper.lerp(delta, this.handbrakeAngle, handbrakeTarget);
-        handbrake.roll = this.handbrakeAngle - 0.5f;
+        float handbrakeTarget = tardis.travel().handbrake() ? 1.5f : 0;
+        handbrake.roll = getAngle(console, "handbrake", handbrakeTarget, delta) - 0.5f;
 
+        // Power Control
         ModelPart power = steam.getChild("controls").getChild("panel_5").getChild("rot5").getChild("lever7")
                 .getChild("bone45");
         float powerTarget = tardis.fuel().hasPower() ? 0f : 1.5f;
-        this.powerAngle = MathHelper.lerp(delta, this.powerAngle, powerTarget);
-        power.roll = this.powerAngle - 0.75f;
+        power.roll = getAngle(console, "power", powerTarget, delta) - 0.75f;
 
+        // Ground Search Control
         ModelPart landType = steam.getChild("controls").getChild("panel_1").getChild("rot").getChild("valve")
                 .getChild("bone9");
         float groundSearchTarget = tardis.travel().horizontalSearch().get() ? 0.5f : 0;
-        this.groundSearchAngle = MathHelper.lerp(delta, this.groundSearchAngle, groundSearchTarget);
-        landType.pivotY = this.groundSearchAngle;
+        landType.pivotY = getAngle(console, "ground_search", groundSearchTarget, delta);
 
+        // Direction Control
         ModelPart direction = steam.getChild("controls").getChild("panel_4").getChild("rot4").getChild("crank")
                 .getChild("bone42");
         float directionTargetDegrees = (0.3927f * tardis.travel().destination().getRotation()) * (180f / (float) Math.PI);
-        float currentAngleDegrees = this.directionAngle * (180f / (float) Math.PI);
-        float nextAngleDegrees = MathHelper.lerpAngleDegrees(delta, currentAngleDegrees, directionTargetDegrees);
+        direction.yaw = getLerpedDegrees(console, "direction", directionTargetDegrees, delta);
 
-        this.directionAngle = nextAngleDegrees * ((float) Math.PI / 180f);
-        direction.yaw = this.directionAngle;
-
+        // Door Control
         ModelPart doorControl = steam.getChild("controls").getChild("panel_5").getChild("rot5").getChild("crank2")
                 .getChild("bone18");
-        float doorControlTarget = tardis.door().isOpen() ? tardis.door().isRightOpen() ? 1.5708f * 2f : 1.5708f : 0;
-        this.doorControlAngle = MathHelper.lerp(delta, this.doorControlAngle, doorControlTarget);
-        doorControl.yaw = this.doorControlAngle;
+        float doorControlTarget = tardis.door().isLeftOpen() ? 1.5708f : (tardis.door().areBothOpen() ? 1.5708f * 2f : 0);
+        doorControl.yaw = getAngle(console, "door_control", doorControlTarget, delta);
 
+        // Cloak Control
         ModelPart cloak = steam.getChild("controls").getChild("panel_5").getChild("rot5").getChild("lever8")
                 .getChild("bone46");
         float cloakTarget = tardis.cloak().cloaked().get() ? 1.35f : 0;
-        this.cloakAngle = MathHelper.lerp(delta, this.cloakAngle, cloakTarget);
-        cloak.roll = this.cloakAngle - 0.5f;
+        cloak.roll = getAngle(console, "cloak", cloakTarget, delta) - 0.5f;
 
+        // Door Lock Control
         ModelPart doorLock = steam.getChild("controls").getChild("panel_5").getChild("rot5").getChild("lever8")
                 .getChild("bone47");
         float doorLockTarget = tardis.door().locked() ? 1.35f : 0;
-        this.doorLockAngle = MathHelper.lerp(delta, this.doorLockAngle, doorLockTarget);
-        doorLock.roll = this.doorLockAngle - 0.5f;
+        doorLock.roll = getAngle(console, "door_lock", doorLockTarget, delta) - 0.5f;
 
+        // Auto Pilot Control
         ModelPart autopilot = steam.getChild("controls").getChild("panel_5").getChild("rot5").getChild("lever8")
                 .getChild("bone48");
         float autopilotTarget = tardis.travel().autopilot() ? 1.35f : 0;
-        this.autopilotAngle = MathHelper.lerp(delta, this.autopilotAngle, autopilotTarget);
-        autopilot.roll = this.autopilotAngle - 0.5f;
+        autopilot.roll = getAngle(console, "autopilot", autopilotTarget, delta) - 0.5f;
 
         super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();

--- a/src/main/java/dev/amble/ait/client/models/consoles/ToyotaConsoleModel.java
+++ b/src/main/java/dev/amble/ait/client/models/consoles/ToyotaConsoleModel.java
@@ -1640,64 +1640,49 @@ public class ToyotaConsoleModel extends SimpleConsoleModel {
         matrices.pop();
     }
 
-    private float throttleAngle = 0f;
-    private float handbrakeAngle = 0f;
-    private float powerAngle = 0f;
-    private float doorControlAngle = 0f;
-    private float doorLockAngle = 0f;
-    private float incrementAngle = 0f;
-    private float directionAngle = 0f;
-    private float groundSearchAngle = 0f;
-    private float alarmAngle = 0f;
-    private float securityAngle = 0f;
-    private float antiGravAngle = 0f;
-    private float shieldAngle = 0f;
-    private float siegeAngle = 0f;
-    private float autopilotAngle = 0f;
-    private float fuelGaugeAngle = 0f;
-
     @Override
     public void renderWithAnimations(ConsoleBlockEntity console, ClientTardis tardis, ModelPart root, MatrixStack matrices,
                                      VertexConsumer vertices, int light, int overlay, float red, float green, float blue, float pAlpha) {
-        float delta = 0.1f * MinecraftClient.getInstance().getTickDelta();
+        float delta = 0.1f * client.getTickDelta();
         matrices.push();
         matrices.translate(0.5f, -1.5f, -0.5f);
         matrices.multiply(RotationAxis.NEGATIVE_Y.rotationDegrees(180f));
 
+        // Throttle
         ModelPart throttle = this.toyota.getChild("panel4").getChild("controls4").getChild("throttle");
         ModelPart throttleLights = this.toyota.getChild("panel4").getChild("flightlights").getChild("flightlights2");
         float throttleTarget = (tardis.travel().speed() / (float) tardis.travel().maxSpeed().get()) * 1.5f;
-        this.throttleAngle = MathHelper.lerp(delta, this.throttleAngle, throttleTarget);
-        throttle.pitch += this.throttleAngle;
+        throttle.pitch = getAngle(console, "throttle", throttleTarget, delta) - 0.5f;
         throttleLights.pivotY = !(tardis.travel().speed() > 0) ? throttleLights.pivotY + 1 : throttleLights.pivotY;
 
+        // Handbrake
         ModelPart handbrake = this.toyota.getChild("panel4").getChild("controls4").getChild("handbrake").getChild("pivot");
         ModelPart handbrakeLights = this.toyota.getChild("panel4").getChild("flightlights").getChild("handbrakelights").getChild("handbrakelights2");
         float handbrakeTarget = !tardis.travel().handbrake() ? -1.57f : 0f;
-        this.handbrakeAngle = MathHelper.lerp(delta, this.handbrakeAngle, handbrakeTarget);
-        handbrake.yaw += this.handbrakeAngle;
+        handbrake.yaw = getAngle(console, "handbrake", handbrakeTarget, delta);
         handbrakeLights.pivotY = !tardis.travel().handbrake() ? handbrakeLights.pivotY + 1 : handbrakeLights.pivotY;
 
+        // Power
         ModelPart power = this.toyota.getChild("panel1").getChild("controls").getChild("dooropen");
         float powerTarget = tardis.fuel().hasPower() ? 0f : -1.55f;
-        this.powerAngle = MathHelper.lerp(delta, this.powerAngle, powerTarget);
-        power.pitch += this.powerAngle;
+        power.pitch = getAngle(console, "power", powerTarget, delta);
 
+        // Antigravs
         ModelPart antigravs = this.toyota.getChild("panel1").getChild("controls").getChild("faucettaps1").getChild("pivot2");
         float antigravTarget = tardis.travel().antigravs().get() ? -1.58f : 0f;
-        this.antiGravAngle = MathHelper.lerp(delta, this.antiGravAngle, antigravTarget);
-        antigravs.yaw += this.antiGravAngle;
+        antigravs.yaw = getAngle(console, "antigravs", antigravTarget, delta);
 
+        // Shield
         ModelPart shield = this.toyota.getChild("panel1").getChild("controls").getChild("faucettaps2");
         float shieldTarget = tardis.shields().shielded().get() ? -1.58f : 0f;
-        this.shieldAngle = MathHelper.lerp(delta, this.shieldAngle, shieldTarget);
-        shield.yaw += this.shieldAngle;
+        shield.yaw = getAngle(console, "shield", shieldTarget, delta);
 
+        // Door Lock
         ModelPart doorlock = this.toyota.getChild("panel1").getChild("controls").getChild("smalllockernob").getChild("pivot3");
         float doorLockTarget = tardis.door().locked() ? 0.5f : 0f;
-        this.doorLockAngle = MathHelper.lerp(delta, this.doorLockAngle, doorLockTarget);
-        doorlock.yaw += this.doorLockAngle;
+        doorlock.yaw = getAngle(console, "door_lock", doorLockTarget, delta);
 
+        // Door Control
         ModelPart doorControl = this.toyota.getChild("panel1").getChild("controls").getChild("power");
         ModelPart doorControlLights = this.toyota.getChild("panel1").getChild("controls").getChild("powerlights").getChild("powerlights2");
         float doorControlTarget = 0f;
@@ -1706,56 +1691,55 @@ public class ToyotaConsoleModel extends SimpleConsoleModel {
         } else if (tardis.door().isRightOpen()) {
             doorControlTarget = -1.55f;
         }
-        this.doorControlAngle = MathHelper.lerp(delta, this.doorControlAngle, doorControlTarget);
-        doorControl.pitch += this.doorControlAngle;
+        doorControl.pitch = getAngle(console, "door_control", doorControlTarget, delta);
         doorControlLights.pivotY = !(tardis.door().isOpen()) ? doorControlLights.pivotY : doorControlLights.pivotY + 1;
 
+        // Alarms
         ModelPart alarms = this.toyota.getChild("panel4").getChild("controls4").getChild("coloredlever2");
         ModelPart alarmsLight = this.toyota.getChild("panel4").getChild("yellow3");
         float alarmTarget = tardis.alarm().isEnabled() ? 1.0f : 0f;
-        this.alarmAngle = MathHelper.lerp(delta, this.alarmAngle, alarmTarget);
-        alarms.pitch += this.alarmAngle;
+        alarms.pitch = getAngle(console, "alarms", alarmTarget, delta);
         alarmsLight.pivotY = (tardis.alarm().isEnabled()) ? alarmsLight.pivotY : alarmsLight.pivotY + 1;
 
+        // Security
         ModelPart security = this.toyota.getChild("panel4").getChild("controls4").getChild("coloredlever5");
         float securityTarget = tardis.stats().security().get() ? 1.0f : 0f;
-        this.securityAngle = MathHelper.lerp(delta, this.securityAngle, securityTarget);
-        security.pitch += this.securityAngle;
+        security.pitch = getAngle(console, "security", securityTarget, delta);
 
+        // Autopilot
         ModelPart autopilot = this.toyota.getChild("panel4").getChild("controls4").getChild("tinyswitch2");
         ModelPart autopilotLight = this.toyota.getChild("panel4").getChild("yellow4");
         float autopilotTarget = tardis.travel().autopilot() ? 1.0f : -1.0f;
-        this.autopilotAngle = MathHelper.lerp(delta, this.autopilotAngle, autopilotTarget);
-        autopilot.pitch += this.autopilotAngle;
+        autopilot.pitch = getAngle(console, "autopilot", autopilotTarget, delta);
         autopilotLight.pivotY = tardis.travel().autopilot() ? autopilotLight.pivotY : autopilotLight.pivotY + 1;
 
+        // Siege Mode
         ModelPart siegeMode = this.toyota.getChild("panel2").getChild("controls3").getChild("siegemode").getChild("siegemodehandle");
         float siegeTarget = tardis.siege().isActive() ? 1.55f : 0f;
-        this.siegeAngle = MathHelper.lerp(delta, this.siegeAngle, siegeTarget);
-        siegeMode.pitch += this.siegeAngle;
+        siegeMode.pitch = getAngle(console, "siege_mode", siegeTarget, delta);
 
+        // Fuel Gauge
         ModelPart fuelGauge = this.toyota.getChild("panel1").getChild("controls").getChild("geigercounter").getChild("needle");
         fuelGauge.pivotX += 0.25f;
         fuelGauge.pivotZ += 0.25f;
         float fuelGaugeTarget = (float) (((tardis.getFuel() / FuelHandler.TARDIS_MAX_FUEL) * 2f) - 1f);
-        this.fuelGaugeAngle = MathHelper.lerp(delta, this.fuelGaugeAngle, fuelGaugeTarget);
-        fuelGauge.yaw = this.fuelGaugeAngle;
+        fuelGauge.yaw = getAngle(console, "fuel_gauge", fuelGaugeTarget, delta);
 
+        // Fuel Warning
         ModelPart fuelWarning = this.toyota.getChild("panel4").getChild("yellow5");
         fuelWarning.pivotY = !(tardis.getFuel() > (tardis.getFuel() / 10)) ? fuelWarning.pivotY : fuelWarning.pivotY + 1;
 
+        // Ground Search
         ModelPart groundSearch = this.toyota.getChild("panel1").getChild("controls").getChild("smallswitch");
         float groundSearchTarget = tardis.travel().horizontalSearch().get() ? 1.0f : -0.75f;
-        this.groundSearchAngle = MathHelper.lerp(delta, this.groundSearchAngle, groundSearchTarget);
-        groundSearch.pitch += this.groundSearchAngle;
+        groundSearch.pitch = getAngle(console, "ground_search", groundSearchTarget, delta);
 
+        // Direction
         ModelPart direction = this.toyota.getChild("panel6").getChild("controls2").getChild("smallnob2");
         float directionTargetDegrees = tardis.travel().destination().getRotation() * 22.5f;
-        float currentDirectionDegrees = (float) Math.toDegrees(this.directionAngle);
-        float nextDirectionDegrees = MathHelper.lerpAngleDegrees(delta, currentDirectionDegrees, directionTargetDegrees);
-        this.directionAngle = (float) Math.toRadians(nextDirectionDegrees);
-        direction.yaw += this.directionAngle;
+        direction.yaw = getLerpedDegrees(console, "direction", directionTargetDegrees, delta);
 
+        // Increment
         ModelPart increment = this.toyota.getChild("panel2").getChild("controls3").getChild("gears").getChild("largegear2");
         int incrementVal = IncrementManager.increment(tardis);
         float incrementTarget = 0f;
@@ -1770,16 +1754,15 @@ public class ToyotaConsoleModel extends SimpleConsoleModel {
         } else {
             incrementTarget = 1.5f;
         }
-        this.incrementAngle = MathHelper.lerp(delta, this.incrementAngle, incrementTarget);
-        increment.yaw += this.incrementAngle;
+        increment.yaw = getAngle(console, "increment", incrementTarget, delta);
 
+        // Refuel Light
         ModelPart refuelLight = this.toyota.getChild("panel4").getChild("yellow6");
         refuelLight.pivotY = tardis.isRefueling() ? refuelLight.pivotY : refuelLight.pivotY + 1;
 
         super.renderWithAnimations(console, tardis, root, matrices, vertices, light, overlay, red, green, blue, pAlpha);
         matrices.pop();
     }
-
 
     @Override
     public ModelPart getPart() {

--- a/src/main/java/dev/amble/ait/client/renderers/consoles/ConsoleRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/consoles/ConsoleRenderer.java
@@ -58,10 +58,12 @@ public class ConsoleRenderer<T extends ConsoleBlockEntity> implements BlockEntit
         ClientTardis tardis = entity.tardis().get().asClient();
         Profiler profiler = entity.getWorld().getProfiler();
 
+        profiler.push("console");
         this.renderConsole(profiler, tardis, entity, matrices, vertexConsumers, light, overlay, tickDelta);
 
         if (variant instanceof ClientCrystallineVariant)
             this.renderPanes(tardis, entity, matrices, vertexConsumers, light, overlay);
+        profiler.pop();
     }
 
     private void renderPanes(ClientTardis tardis, T entity, MatrixStack matrices, VertexConsumerProvider vertexConsumers, int light, int overlay) {

--- a/src/main/java/dev/amble/ait/client/renderers/machines/GenericSubSystemRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/GenericSubSystemRenderer.java
@@ -18,6 +18,7 @@ import dev.amble.ait.core.engine.block.generic.GenericStructureSystemBlockEntity
 
 public class GenericSubSystemRenderer<T extends GenericStructureSystemBlockEntity> implements BlockEntityRenderer<T> {
     private final GenericSubSystemModel model;
+    public static final MinecraftClient client = MinecraftClient.getInstance();
 
     public GenericSubSystemRenderer(BlockEntityRendererFactory.Context ctx) {
         this.model = new GenericSubSystemModel();
@@ -47,11 +48,11 @@ public class GenericSubSystemRenderer<T extends GenericStructureSystemBlockEntit
 
             matrices.translate(0, -1.15f + (offset / 2), 0);
 
-            Vector3f scale = MinecraftClient.getInstance().getItemRenderer().getModel(stack, entity.getWorld(), null, 0).getTransformation().firstPersonRightHand.scale;
+            Vector3f scale = client.getItemRenderer().getModel(stack, entity.getWorld(), null, 0).getTransformation().firstPersonRightHand.scale;
             matrices.scale(0.9f, 0.9f, 0.9f);
             matrices.scale(scale.x, scale.y, scale.z);
 
-            MinecraftClient.getInstance().getItemRenderer().renderItem(stack, ModelTransformationMode.GROUND, light,
+            client.getItemRenderer().renderItem(stack, ModelTransformationMode.GROUND, light,
                     overlay, matrices, vertexConsumers, entity.getWorld(), 0);
             matrices.pop();
         }

--- a/src/main/java/dev/amble/ait/client/renderers/machines/GenericSubSystemRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/GenericSubSystemRenderer.java
@@ -18,7 +18,7 @@ import dev.amble.ait.core.engine.block.generic.GenericStructureSystemBlockEntity
 
 public class GenericSubSystemRenderer<T extends GenericStructureSystemBlockEntity> implements BlockEntityRenderer<T> {
     private final GenericSubSystemModel model;
-    public static final MinecraftClient client = MinecraftClient.getInstance();
+    private static final MinecraftClient client = MinecraftClient.getInstance();
 
     public GenericSubSystemRenderer(BlockEntityRendererFactory.Context ctx) {
         this.model = new GenericSubSystemModel();

--- a/src/main/java/dev/amble/ait/client/util/FoggyUtils.java
+++ b/src/main/java/dev/amble/ait/client/util/FoggyUtils.java
@@ -21,8 +21,9 @@ import dev.amble.ait.module.planet.core.space.planet.PlanetRegistry;
 import dev.amble.ait.module.planet.core.space.system.Space;
 
 public class FoggyUtils {
+    public static final MinecraftClient mc = MinecraftClient.getInstance();
+
     public static void overrideFog() {
-        MinecraftClient mc = MinecraftClient.getInstance();
         Tardis tardis = ClientTardisUtil.getCurrentTardis();
 
         if (mc.player != null && !mc.player.isSpectator() && mc.world != null && mc.world.getRegistryKey().equals(AITDimensions.SPACE)) {
@@ -34,13 +35,13 @@ public class FoggyUtils {
                     stack.translate(0, 0, -2);
                     stack.scale(2000, 20000, 1);
                     for (int i = 0; i < 7; i++) {
-                        MinecraftClient.getInstance().getItemRenderer().renderItem(new ItemStack(Items.WHITE_STAINED_GLASS_PANE),
-                                ModelTransformationMode.GROUND, 0xf, OverlayTexture.DEFAULT_UV, stack, MinecraftClient.getInstance().getBufferBuilders().getEntityVertexConsumers(), mc.world, 0);
+                        mc.getItemRenderer().renderItem(new ItemStack(Items.WHITE_STAINED_GLASS_PANE),
+                                ModelTransformationMode.GROUND, 0xf, OverlayTexture.DEFAULT_UV, stack, mc.getBufferBuilders().getEntityVertexConsumers(), mc.world, 0);
                     }
                     stack.pop();
                     RenderSystem
-                            .setShaderFogStart(MathHelper.lerp(MinecraftClient.getInstance().getTickDelta() / 100f, 1, 1));
-                    RenderSystem.setShaderFogEnd(MathHelper.lerp(MinecraftClient.getInstance().getTickDelta() / 100f, 1, 1));
+                            .setShaderFogStart(MathHelper.lerp(mc.getTickDelta() / 100f, 1, 1));
+                    RenderSystem.setShaderFogEnd(MathHelper.lerp(mc.getTickDelta() / 100f, 1, 1));
                     RenderSystem.setShaderFogShape(FogShape.SPHERE);
                     RenderSystem.setShaderFogColor(planet.render().color().x(),
                             planet.render().color().y(),
@@ -58,7 +59,7 @@ public class FoggyUtils {
             RenderSystem.setShaderFogEnd(MathHelper.lerp(ClientTardisUtil.getAlarmDeltaForLerp(), 11, 32));
             RenderSystem.setShaderFogShape(FogShape.SPHERE);
             RenderSystem.setShaderFogColor(0.5f, 0, 0, 0.5f);
-            MinecraftClient.getInstance().gameRenderer.getCamera().getSubmersionType();
+            mc.gameRenderer.getCamera().getSubmersionType();
         }
 
         if (tardis.isGrowth()
@@ -71,8 +72,8 @@ public class FoggyUtils {
         }
         if (tardis.crash().isToxic() && tardis.fuel().hasPower()) {
             RenderSystem
-                    .setShaderFogStart(MathHelper.lerp(MinecraftClient.getInstance().getTickDelta() / 100f, -8, 24));
-            RenderSystem.setShaderFogEnd(MathHelper.lerp(MinecraftClient.getInstance().getTickDelta() / 100f, 11, 32));
+                    .setShaderFogStart(MathHelper.lerp(mc.getTickDelta() / 100f, -8, 24));
+            RenderSystem.setShaderFogEnd(MathHelper.lerp(mc.getTickDelta() / 100f, 11, 32));
             RenderSystem.setShaderFogShape(FogShape.SPHERE);
 
             ItemStack stack = mc.player.getEquippedStack(EquipmentSlot.HEAD);
@@ -86,10 +87,9 @@ public class FoggyUtils {
                 || !tardis.extra().getInsertedDisc().isEmpty())) {
 
             final float[] rgb = ClientTardisUtil.getPartyColors();
-            MinecraftClient minecraftClient = MinecraftClient.getInstance();
 
-            RenderSystem.setShaderFogStart(MathHelper.lerp(minecraftClient.getTickDelta() / 100f, -8, 24));
-            RenderSystem.setShaderFogEnd(MathHelper.lerp(minecraftClient.getTickDelta() / 100f, 20, 40));
+            RenderSystem.setShaderFogStart(MathHelper.lerp(mc.getTickDelta() / 100f, -8, 24));
+            RenderSystem.setShaderFogEnd(MathHelper.lerp(mc.getTickDelta() / 100f, 20, 40));
             RenderSystem.setShaderFogShape(FogShape.SPHERE);
             RenderSystem.setShaderFogColor(rgb[0], rgb[1], rgb[2], 0.25f);
         }

--- a/src/main/java/dev/amble/ait/client/util/FoggyUtils.java
+++ b/src/main/java/dev/amble/ait/client/util/FoggyUtils.java
@@ -21,7 +21,7 @@ import dev.amble.ait.module.planet.core.space.planet.PlanetRegistry;
 import dev.amble.ait.module.planet.core.space.system.Space;
 
 public class FoggyUtils {
-    public static final MinecraftClient mc = MinecraftClient.getInstance();
+    private static final MinecraftClient mc = MinecraftClient.getInstance();
 
     public static void overrideFog() {
         Tardis tardis = ClientTardisUtil.getCurrentTardis();

--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -172,7 +172,7 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
 
                     Vec3d pos = directed.getPos().toCenterPos().offset(directed.toMinecraftDirection(), 0.5f);
 
-                    float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.08f: 0.05f;
+                    float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.1f: 0.08f;
                     Vec3d motion = pos.subtract(entity.getPos()).normalize().multiply(suckValue);
 
                     // Apply the motion to the entity

--- a/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/DoorHandler.java
@@ -172,7 +172,7 @@ public class DoorHandler extends KeyedTardisComponent implements TardisTickable 
 
                     Vec3d pos = directed.getPos().toCenterPos().offset(directed.toMinecraftDirection(), 0.5f);
 
-                    float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.1f: 0.08f;
+                    float suckValue = tardis.travel().position().getDimension().equals(AITDimensions.SPACE) ? 0.08f: 0.05f;
                     Vec3d motion = pos.subtract(entity.getPos()).normalize().multiply(suckValue);
 
                     // Apply the motion to the entity

--- a/src/main/java/dev/amble/ait/registry/impl/SequenceRegistry.java
+++ b/src/main/java/dev/amble/ait/registry/impl/SequenceRegistry.java
@@ -76,12 +76,6 @@ public class SequenceRegistry {
                     missedTardis.removeFuel(-random.nextBetween(45, 125));
                     missedTardis.door().openDoors();
 
-                    Scheduler.get().runTaskLater(() ->
-                                    missedTardis.door().closeDoors(),
-                            TaskStage.END_SERVER_TICK,
-                            TimeUnit.SECONDS,
-                            3);
-
                     List<Explosion> explosions = new ArrayList<>();
                     ServerWorld world = missedTardis.asServer().world();
 
@@ -113,12 +107,6 @@ public class SequenceRegistry {
                     finishedTardis.travel().decreaseFlightTime(60);
                 }), (missedTardis -> {
                     missedTardis.door().openDoors();
-
-                    Scheduler.get().runTaskLater(() ->
-                                    missedTardis.door().closeDoors(),
-                            TaskStage.END_SERVER_TICK,
-                            TimeUnit.SECONDS,
-                            3);
                 }), 90L, Text.translatable("sequence.ait.dimensional_breach").formatted(Formatting.ITALIC, Formatting.YELLOW),
                         new DimensionControl(), new DoorControl()));
 

--- a/src/main/java/dev/amble/ait/registry/impl/SequenceRegistry.java
+++ b/src/main/java/dev/amble/ait/registry/impl/SequenceRegistry.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.amble.lib.data.DirectedBlockPos;
+import dev.drtheo.scheduler.api.TimeUnit;
+import dev.drtheo.scheduler.api.common.Scheduler;
+import dev.drtheo.scheduler.api.common.TaskStage;
 import net.fabricmc.fabric.api.event.registry.FabricRegistryBuilder;
 
 import net.minecraft.entity.EntityType;
@@ -73,6 +76,12 @@ public class SequenceRegistry {
                     missedTardis.removeFuel(-random.nextBetween(45, 125));
                     missedTardis.door().openDoors();
 
+                    Scheduler.get().runTaskLater(() ->
+                                    missedTardis.door().closeDoors(),
+                            TaskStage.END_SERVER_TICK,
+                            TimeUnit.SECONDS,
+                            3);
+
                     List<Explosion> explosions = new ArrayList<>();
                     ServerWorld world = missedTardis.asServer().world();
 
@@ -104,7 +113,13 @@ public class SequenceRegistry {
                     finishedTardis.travel().decreaseFlightTime(60);
                 }), (missedTardis -> {
                     missedTardis.door().openDoors();
-                }), 80L, Text.translatable("sequence.ait.dimensional_breach").formatted(Formatting.ITALIC, Formatting.YELLOW),
+
+                    Scheduler.get().runTaskLater(() ->
+                                    missedTardis.door().closeDoors(),
+                            TaskStage.END_SERVER_TICK,
+                            TimeUnit.SECONDS,
+                            3);
+                }), 90L, Text.translatable("sequence.ait.dimensional_breach").formatted(Formatting.ITALIC, Formatting.YELLOW),
                         new DimensionControl(), new DoorControl()));
 
         ENERGY_DRAIN = register(
@@ -122,7 +137,7 @@ public class SequenceRegistry {
                 }), (missedTardis -> {
                     missedTardis.removeFuel(random.nextBetween(45, 125));
                     missedTardis.fuel().disablePower();
-                }), 110L, Text.translatable("sequence.ait.power_drain_imminent").formatted(Formatting.ITALIC, Formatting.YELLOW),
+                }), 140L, Text.translatable("sequence.ait.power_drain_imminent").formatted(Formatting.ITALIC, Formatting.YELLOW),
                         new PowerControl(), new RefuelerControl(), new RandomiserControl()));
 
         SHIP_COMPUTER_OFFLINE = register(


### PR DESCRIPTION
## About the PR
In the first commit, I replaced all calls of `MinecraftClient.getInstance()` with a static final field version as that causes some overhead. In the second, I ended up rewriting the way that consoles do their smooth animations. 

## Why / Balance
Smooth control animations give weight to a more solid feeling experience, as opposed to the previous snappy controls. This PR fixes the previous attempt at this, where the entire console would freak out if another console with a different model was present. This was fixed.

## Technical details
- Replace calls of `MinecraftClient.getInstance()` with a static final field.
- In `SimpleConsoleModel`, add a new `WeakHashMap` that stores the `ConsoleBlockEntity` along with another map, `Map<String, Float>` which stores the "id" of an "animation" with its lerped value, as they typically are just floats (and have been)

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- feat: Smooth control animation across all consoles!