### PR TITLE
chore: replaced RedstoneControlBlock sound

### DIFF
--- a/src/main/java/dev/amble/ait/core/AITSounds.java
+++ b/src/main/java/dev/amble/ait/core/AITSounds.java
@@ -210,7 +210,7 @@ public class AITSounds {
     public static final SoundEvent DING = register("tools/goes_ding");
     public static final SoundEvent STASER = register("tools/staser");
     public static final SoundEvent REMOTE = register("tools/remote");
-    public static final SoundEvent REDSTONE_CONTROL_SWITCHAROO = register("tools/redstone_control_switcharoo");
+   // public static final SoundEvent REDSTONE_CONTROL_SWITCHAROO = register("tools/redstone_control_switcharoo");
     public static final SoundEvent HAMMER_HIT = register("tools/hammer_hit");
     public static final SoundEvent COFFEE_MACHINE = register("tardis/coffee_machine");
 

--- a/src/main/java/dev/amble/ait/core/AITSounds.java
+++ b/src/main/java/dev/amble/ait/core/AITSounds.java
@@ -210,7 +210,6 @@ public class AITSounds {
     public static final SoundEvent DING = register("tools/goes_ding");
     public static final SoundEvent STASER = register("tools/staser");
     public static final SoundEvent REMOTE = register("tools/remote");
-   // public static final SoundEvent REDSTONE_CONTROL_SWITCHAROO = register("tools/redstone_control_switcharoo");
     public static final SoundEvent HAMMER_HIT = register("tools/hammer_hit");
     public static final SoundEvent COFFEE_MACHINE = register("tardis/coffee_machine");
 

--- a/src/main/java/dev/amble/ait/core/blocks/control/RedstoneControlBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/control/RedstoneControlBlock.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.core.blocks.control;
 
+import net.minecraft.sound.SoundEvents;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -99,7 +100,7 @@ public class RedstoneControlBlock extends ControlBlock {
         }
 
         world.setBlockState(pos, Mode.set(state, Mode.get(state).next())); // set to next mode
-        world.playSound(null, pos, AITSounds.REDSTONE_CONTROL_SWITCHAROO, SoundCategory.BLOCKS, 0.1f, 0f);
+        world.playSound(null, pos, SoundEvents.BLOCK_STONE_BUTTON_CLICK_ON, SoundCategory.BLOCKS, 0.1f, 0.5f);
 
         return ActionResult.SUCCESS;
     }


### PR DESCRIPTION
## About the PR
changed the RedstoneControlBlock interaction sound with the Button click on sound https://minecraft.wiki/w/File:Stone_button_press.ogg

## Why / Balance
because the sound was lowkey kinda bad

## Technical details
- replaced `AITSounds.REDSTONE_CONTROL_SWITCHAROO` with `SoundEvents.BLOCK_STONE_BUTTON_CLICK_ON`
- removed `public static final SoundEvent REDSTONE_CONTROL_SWITCHAROO = register("tools/redstone_control_switcharoo");`

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- chore: replaced RedstoneControlBlock sound