### PR TITLE
fix: rift scanner now plays a bling sound when you enter a rift chunk fix: rifts now have more artron in them

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/RiftScannerItem.java
+++ b/src/main/java/dev/amble/ait/core/item/RiftScannerItem.java
@@ -2,11 +2,14 @@ package dev.amble.ait.core.item;
 
 import java.util.function.Consumer;
 
+import dev.amble.ait.core.AITSounds;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.sound.SoundCategory;
 import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
@@ -34,6 +37,7 @@ public class RiftScannerItem extends Item {
 
         user.getItemCooldownManager().set(this, 100);
         findNearestRift(serverWorld, new ChunkPos(user.getBlockPos()), (chunk) -> setTarget(user.getStackInHand(hand), chunk));
+        ding = false;
 
         user.sendMessage(Text.translatable("riftchunk.ait.tracking"), true);
         return TypedActionResult.success(user.getStackInHand(hand));
@@ -105,5 +109,20 @@ public class RiftScannerItem extends Item {
             return ChunkPos.ORIGIN;
 
         return new ChunkPos(nbt.getInt("X"), nbt.getInt("Z"));
+    }
+
+    private boolean ding = false;
+
+    @Override
+    public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
+        super.inventoryTick(stack, world, entity, slot, selected);
+        if (RiftScannerItem.getTarget(stack) != null && !ding) {
+
+            ChunkPos pos = RiftScannerItem.getTarget(stack);
+            if (entity.getChunkPos().equals(pos)) {
+                world.playSound(null, entity.getBlockPos(), AITSounds.TARDIS_BLING, SoundCategory.MASTER, 3f, 1f);
+                ding = true;
+            }
+        }
     }
 }

--- a/src/main/java/dev/amble/ait/core/item/RiftScannerItem.java
+++ b/src/main/java/dev/amble/ait/core/item/RiftScannerItem.java
@@ -57,11 +57,11 @@ public class RiftScannerItem extends Item {
 
         if (entity.getChunkPos().equals(target)) {
             if (!hasDinged) {
-                world.playSound(null, entity.getBlockPos(), AITSounds.TARDIS_BLING, SoundCategory.MASTER, 3f, 1f);
+                // Bling sound is kinda quiet so it should be set to about a volume of 3
+                world.playSound(null, entity.getBlockPos(), AITSounds.TARDIS_BLING, SoundCategory.PLAYERS, 3f, 1f);
                 stack.getOrCreateNbt().putBoolean(NBT_DINGED, true);
             }
         } else {
-            // Reset dinged status if the player leaves the target chunk
             if (hasDinged) {
                 stack.getOrCreateNbt().putBoolean(NBT_DINGED, false);
             }

--- a/src/main/java/dev/amble/ait/core/item/RiftScannerItem.java
+++ b/src/main/java/dev/amble/ait/core/item/RiftScannerItem.java
@@ -1,8 +1,8 @@
 package dev.amble.ait.core.item;
 
-import java.util.function.Consumer;
-
 import dev.amble.ait.core.AITSounds;
+import dev.amble.ait.core.world.RiftChunkManager;
+import dev.amble.ait.core.world.TardisServerWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
@@ -17,11 +17,13 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
-import dev.amble.ait.core.world.RiftChunkManager;
-import dev.amble.ait.core.world.TardisServerWorld;
+import java.util.function.Consumer;
 
 public class RiftScannerItem extends Item {
     private static final int MAX_ITERATIONS = 32;
+    private static final String NBT_X = "X";
+    private static final String NBT_Z = "Z";
+    private static final String NBT_DINGED = "Dinged";
 
     public RiftScannerItem(Settings settings) {
         super(settings);
@@ -35,41 +37,49 @@ public class RiftScannerItem extends Item {
         if (TardisServerWorld.isTardisDimension(serverWorld))
             return TypedActionResult.fail(user.getStackInHand(hand));
 
+        ItemStack stack = user.getStackInHand(hand);
         user.getItemCooldownManager().set(this, 100);
-        findNearestRift(serverWorld, new ChunkPos(user.getBlockPos()), (chunk) -> setTarget(user.getStackInHand(hand), chunk));
-        ding = false;
+
+        findNearestRift(serverWorld, new ChunkPos(user.getBlockPos()), (chunk) -> setTarget(stack, chunk));
 
         user.sendMessage(Text.translatable("riftchunk.ait.tracking"), true);
-        return TypedActionResult.success(user.getStackInHand(hand));
+        return TypedActionResult.success(stack);
     }
 
-    /**
-     * Searches for a target block with artron levels > 0 within a range.
-     *
-     * @param world
-     *            The world object.
-     * @param source
-     *            The current chunk
-     */
+    @Override
+    public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
+        if (world.isClient) return;
+
+        ChunkPos target = getTarget(stack);
+        if (target == null || target.equals(ChunkPos.ORIGIN)) return;
+
+        boolean hasDinged = stack.getOrCreateNbt().getBoolean(NBT_DINGED);
+
+        if (entity.getChunkPos().equals(target)) {
+            if (!hasDinged) {
+                world.playSound(null, entity.getBlockPos(), AITSounds.TARDIS_BLING, SoundCategory.MASTER, 3f, 1f);
+                stack.getOrCreateNbt().putBoolean(NBT_DINGED, true);
+            }
+        } else {
+            // Reset dinged status if the player leaves the target chunk
+            if (hasDinged) {
+                stack.getOrCreateNbt().putBoolean(NBT_DINGED, false);
+            }
+        }
+    }
+
     public static void findNearestRift(ServerWorld world, ChunkPos source, Consumer<ChunkPos> found) {
         int steps = 1;
         RiftChunkManager manager = RiftChunkManager.getInstance(world);
 
         for (int i = 0; i < MAX_ITERATIONS; i++) {
             if (steps % 2 != 0) {
-                if (trySearch(manager, steps, source, Direction.EAST, found))
-                    return;
-
-                if (trySearch(manager, steps, source, Direction.SOUTH, found))
-                    return;
+                if (trySearch(manager, steps, source, Direction.EAST, found)) return;
+                if (trySearch(manager, steps, source, Direction.SOUTH, found)) return;
             } else {
-                if (trySearch(manager, steps, source, Direction.WEST, found))
-                    return;
-
-                if (trySearch(manager, steps, source, Direction.NORTH, found))
-                    return;
+                if (trySearch(manager, steps, source, Direction.WEST, found)) return;
+                if (trySearch(manager, steps, source, Direction.NORTH, found)) return;
             }
-
             steps++;
         }
     }
@@ -77,13 +87,11 @@ public class RiftScannerItem extends Item {
     private static boolean trySearch(RiftChunkManager manager, int limit, ChunkPos source, Direction direction, Consumer<ChunkPos> found) {
         for (int b = 0; b <= limit; b++) {
             source = getChunkInDirection(source, direction);
-
             if (isConsumable(manager, source)) {
                 found.accept(source);
                 return true;
             }
         }
-
         return false;
     }
 
@@ -97,32 +105,15 @@ public class RiftScannerItem extends Item {
 
     private static void setTarget(ItemStack stack, ChunkPos pos) {
         NbtCompound nbt = stack.getOrCreateNbt();
-
-        nbt.putInt("X", pos.x);
-        nbt.putInt("Z", pos.z);
+        nbt.putInt(NBT_X, pos.x);
+        nbt.putInt(NBT_Z, pos.z);
+        nbt.putBoolean(NBT_DINGED, false);
     }
 
     public static ChunkPos getTarget(ItemStack stack) {
         NbtCompound nbt = stack.getOrCreateNbt();
-
-        if (!(nbt.contains("X") && nbt.contains("Z")))
+        if (!(nbt.contains(NBT_X) && nbt.contains(NBT_Z)))
             return ChunkPos.ORIGIN;
-
-        return new ChunkPos(nbt.getInt("X"), nbt.getInt("Z"));
-    }
-
-    private boolean ding = false;
-
-    @Override
-    public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
-        super.inventoryTick(stack, world, entity, slot, selected);
-        if (RiftScannerItem.getTarget(stack) != null && !ding) {
-
-            ChunkPos pos = RiftScannerItem.getTarget(stack);
-            if (entity.getChunkPos().equals(pos)) {
-                world.playSound(null, entity.getBlockPos(), AITSounds.TARDIS_BLING, SoundCategory.MASTER, 3f, 1f);
-                ding = true;
-            }
-        }
+        return new ChunkPos(nbt.getInt(NBT_X), nbt.getInt(NBT_Z));
     }
 }

--- a/src/main/java/dev/amble/ait/core/world/RiftChunkManager.java
+++ b/src/main/java/dev/amble/ait/core/world/RiftChunkManager.java
@@ -1,47 +1,38 @@
 package dev.amble.ait.core.world;
 
 import com.mojang.serialization.Codec;
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.events.ServerChunkEvents;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentRegistry;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
-
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.random.ChunkRandom;
-import net.minecraft.world.ServerWorldAccess;
 import net.minecraft.world.StructureWorldAccess;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
-import net.minecraft.world.chunk.ProtoChunk;
-
-import dev.amble.ait.AITMod;
-import dev.amble.ait.core.events.ServerChunkEvents;
 
 @SuppressWarnings("UnstableApiUsage")
 public record RiftChunkManager(ServerWorld world) {
 
-    private static final AttachmentType<Double> ARTRON = AttachmentRegistry.createPersistent(
-            AITMod.id("artron"), Codec.DOUBLE
-    );
-
-    private static final AttachmentType<Double> MAX_ARTRON = AttachmentRegistry.createPersistent(
-            AITMod.id("max_artron"), Codec.DOUBLE
-    );
+    private static final AttachmentType<Double> ARTRON = AttachmentRegistry.createPersistent(AITMod.id("artron"), Codec.DOUBLE);
+    private static final AttachmentType<Double> MAX_ARTRON = AttachmentRegistry.createPersistent(AITMod.id("max_artron"), Codec.DOUBLE);
 
     public static void init() {
         ServerChunkEvents.TICK.register((world, chunk) -> {
-            if (world.getServer().getTicks() % 20 != 0)
-                return;
+            if (world.getServer().getTicks() % 20 != 0) return;
 
-            RiftChunkManager manager = RiftChunkManager.getInstance(world);
             ChunkPos pos = chunk.getPos();
+            if (!isRiftChunk(world, pos)) return;
 
-            if (!manager.isRiftChunk(pos))
-                return;
+            double current = getArtron(world, pos);
+            double max = getMaxArtron(world, pos);
 
-            if (manager.getMaxArtron(pos) < manager.getArtron(pos))
-                manager.addFuel(chunk.getPos(), 1);
+            if (current < max) {
+                addFuel(world, pos, 1.0);
+            }
         });
     }
 
@@ -49,111 +40,53 @@ public record RiftChunkManager(ServerWorld world) {
         return new RiftChunkManager(world);
     }
 
-    public double getArtron(ChunkPos pos) {
-        if (!this.isRiftChunk(pos))
-            return 0;
-
-        Chunk shouldBeProtoChunk = this.world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
-
-        if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
-            return 0;
-
-        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(1000, 2000));
+    public static double getArtron(ServerWorld world, ChunkPos pos) {
+        if (!isRiftChunk(world, pos)) return 0;
+        return getChunkAttachment(world, pos, ARTRON, () -> (double) world.getRandom().nextBetween(1000, 2000));
     }
 
-    public double getMaxArtron(ChunkPos pos) {
-        if (!this.isRiftChunk(pos))
-            return 0;
-
-        Chunk shouldBeProtoChunk = this.world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
-
-        if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
-            return 0;
-
-        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(1500, 3000));
+    public static double getMaxArtron(ServerWorld world, ChunkPos pos) {
+        if (!isRiftChunk(world, pos)) return 0;
+        return getChunkAttachment(world, pos, MAX_ARTRON, () -> (double) world.getRandom().nextBetween(1500, 3000));
     }
 
-    public double removeFuel(ChunkPos pos, double amount) {
-        if (!this.isRiftChunk(pos))
-            return 0;
+    public static void addFuel(ServerWorld world, ChunkPos pos, double amount) {
+        if (!isRiftChunk(world, pos)) return;
+        modifyAttachment(world, pos, ARTRON, d -> d + amount);
+    }
 
-        double artron = this.getArtron(pos);
-        artron -= artron < amount ? 0 : amount;
+    public static void setCurrentFuel(ServerWorld world, ChunkPos pos, double amount) {
+        if (!isRiftChunk(world, pos)) return;
+        modifyAttachment(world, pos, ARTRON, d -> amount);
+    }
 
-        Chunk shouldBeProtoChunk = this.world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
-        if (shouldBeProtoChunk instanceof ProtoChunk protoChunk) {
-            protoChunk.setAttached(ARTRON, artron);
+    private static <T> T getChunkAttachment(ServerWorld world, ChunkPos pos, AttachmentType<T> type, java.util.function.Supplier<T> defaultValue) {
+        Chunk chunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
+        return chunk != null ? chunk.getAttachedOrCreate(type, defaultValue) : defaultValue.get();
+    }
+
+    private static void modifyAttachment(ServerWorld world, ChunkPos pos, AttachmentType<Double> type, java.util.function.UnaryOperator<Double> modifier) {
+        Chunk chunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
+        if (chunk != null) {
+            chunk.modifyAttached(type, modifier);
         }
-        return artron - amount;
-    }
-
-    public void addFuel(ChunkPos pos, double amount) {
-        if (!this.isRiftChunk(pos))
-            return;
-
-        RiftChunkManager.addFuel(this.world, pos, amount);
-    }
-
-    public void setCurrentFuel(ChunkPos pos, double amount) {
-        Chunk shouldBeProtoChunk = this.world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
-
-        if (shouldBeProtoChunk instanceof ProtoChunk protoChunk) {
-            protoChunk.modifyAttached(ARTRON, d -> amount);
-        }
-    }
-
-    public boolean isRiftChunk(ChunkPos chunkPos) {
-        return RiftChunkManager.isRiftChunk(this.world, chunkPos);
-    }
-
-    public boolean isRiftChunk(BlockPos pos) {
-        return RiftChunkManager.isRiftChunk(world, pos);
     }
 
     public static boolean isRiftChunk(CachedDirectedGlobalPos cached) {
         return isRiftChunk(cached.getWorld(), cached.getPos());
     }
 
+    public static boolean isRiftChunk(StructureWorldAccess world, ChunkPos pos) {
+        return world != null && ChunkRandom.getSlimeRandom(pos.x, pos.z, world.getSeed(), 987234910L).nextInt(8) == 0;
+    }
+
     public static boolean isRiftChunk(StructureWorldAccess world, BlockPos pos) {
         return isRiftChunk(world, new ChunkPos(pos));
     }
 
-    public static boolean isRiftChunk(StructureWorldAccess world, ChunkPos pos) {
-        if (world == null) return false;
-        return ChunkRandom.getSlimeRandom(pos.x, pos.z,
-                world.getSeed(), 987234910L
-        ).nextInt(8) == 0;
-    }
-
-    private static void addFuel(ServerWorldAccess world, ChunkPos pos, double amount) {
-        Chunk shouldBeProtoChunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
-
-        if (shouldBeProtoChunk instanceof ProtoChunk protoChunk) {
-            protoChunk.modifyAttached(ARTRON, d -> d + amount);
-        }
-    }
-
-    public static double getFuel(ServerWorld world, ChunkPos pos) {
-        if (!isRiftChunk(world, pos))
-            return 0;
-
-        Chunk shouldBeProtoChunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
-
-        if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
-            return 0;
-
-        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(100, 800));
-    }
-
-    public static double getMaxFuel(ServerWorld world, ChunkPos pos) {
-        if (!isRiftChunk(world, pos))
-            return 0;
-
-        Chunk shouldBeProtoChunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
-
-        if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
-            return 0;
-
-        return protoChunk.getAttachedOrCreate(MAX_ARTRON, () -> (double) world.getRandom().nextBetween(300, 1000));
-    }
+    public double getArtron(ChunkPos pos) { return getArtron(this.world, pos); }
+    public double getMaxArtron(ChunkPos pos) { return getMaxArtron(this.world, pos); }
+    public void addFuel(ChunkPos pos, double amount) { addFuel(this.world, pos, amount); }
+    public boolean isRiftChunk(ChunkPos pos) { return isRiftChunk(this.world, pos); }
+    public boolean isRiftChunk(BlockPos pos) { return isRiftChunk(this.world, pos); }
 }

--- a/src/main/java/dev/amble/ait/core/world/RiftChunkManager.java
+++ b/src/main/java/dev/amble/ait/core/world/RiftChunkManager.java
@@ -58,7 +58,7 @@ public record RiftChunkManager(ServerWorld world) {
         if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
             return 0;
 
-        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(100, 800));
+        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(1000, 2000));
     }
 
     public double getMaxArtron(ChunkPos pos) {
@@ -70,7 +70,7 @@ public record RiftChunkManager(ServerWorld world) {
         if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
             return 0;
 
-        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(300, 1000));
+        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(1500, 3000));
     }
 
     public double removeFuel(ChunkPos pos, double amount) {

--- a/src/main/java/dev/amble/ait/core/world/RiftChunkManager.java
+++ b/src/main/java/dev/amble/ait/core/world/RiftChunkManager.java
@@ -1,38 +1,50 @@
 package dev.amble.ait.core.world;
 
 import com.mojang.serialization.Codec;
-import dev.amble.ait.AITMod;
-import dev.amble.ait.core.events.ServerChunkEvents;
 import dev.amble.lib.data.CachedDirectedGlobalPos;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentRegistry;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
+
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.random.ChunkRandom;
+import net.minecraft.world.ServerWorldAccess;
 import net.minecraft.world.StructureWorldAccess;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.chunk.ProtoChunk;
+
+import dev.amble.ait.AITMod;
+import dev.amble.ait.core.events.ServerChunkEvents;
 
 @SuppressWarnings("UnstableApiUsage")
 public record RiftChunkManager(ServerWorld world) {
 
-    private static final AttachmentType<Double> ARTRON = AttachmentRegistry.createPersistent(AITMod.id("artron"), Codec.DOUBLE);
-    private static final AttachmentType<Double> MAX_ARTRON = AttachmentRegistry.createPersistent(AITMod.id("max_artron"), Codec.DOUBLE);
+    private static final int MIN_ARTRON_AMOUNT = 2000;
+    private static final int MAX_ARTRON_AMOUNT = 4000;
+
+    private static final AttachmentType<Double> ARTRON = AttachmentRegistry.createPersistent(
+            AITMod.id("artron"), Codec.DOUBLE
+    );
+
+    private static final AttachmentType<Double> MAX_ARTRON = AttachmentRegistry.createPersistent(
+            AITMod.id("max_artron"), Codec.DOUBLE
+    );
 
     public static void init() {
         ServerChunkEvents.TICK.register((world, chunk) -> {
-            if (world.getServer().getTicks() % 20 != 0) return;
+            if (world.getServer().getTicks() % 20 != 0)
+                return;
 
+            RiftChunkManager manager = RiftChunkManager.getInstance(world);
             ChunkPos pos = chunk.getPos();
-            if (!isRiftChunk(world, pos)) return;
 
-            double current = getArtron(world, pos);
-            double max = getMaxArtron(world, pos);
+            if (!manager.isRiftChunk(pos))
+                return;
 
-            if (current < max) {
-                addFuel(world, pos, 1.0);
-            }
+            if (manager.getMaxArtron(pos) < manager.getArtron(pos))
+                manager.addFuel(chunk.getPos(), 1);
         });
     }
 
@@ -40,53 +52,111 @@ public record RiftChunkManager(ServerWorld world) {
         return new RiftChunkManager(world);
     }
 
-    public static double getArtron(ServerWorld world, ChunkPos pos) {
-        if (!isRiftChunk(world, pos)) return 0;
-        return getChunkAttachment(world, pos, ARTRON, () -> (double) world.getRandom().nextBetween(1000, 2000));
+    public double getArtron(ChunkPos pos) {
+        if (!this.isRiftChunk(pos))
+            return 0;
+
+        Chunk shouldBeProtoChunk = this.world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
+
+        if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
+            return 0;
+
+        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(MIN_ARTRON_AMOUNT, MAX_ARTRON_AMOUNT));
     }
 
-    public static double getMaxArtron(ServerWorld world, ChunkPos pos) {
-        if (!isRiftChunk(world, pos)) return 0;
-        return getChunkAttachment(world, pos, MAX_ARTRON, () -> (double) world.getRandom().nextBetween(1500, 3000));
+    public double getMaxArtron(ChunkPos pos) {
+        if (!this.isRiftChunk(pos))
+            return 0;
+
+        Chunk shouldBeProtoChunk = this.world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
+
+        if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
+            return 0;
+
+        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(MIN_ARTRON_AMOUNT, MAX_ARTRON_AMOUNT));
     }
 
-    public static void addFuel(ServerWorld world, ChunkPos pos, double amount) {
-        if (!isRiftChunk(world, pos)) return;
-        modifyAttachment(world, pos, ARTRON, d -> d + amount);
-    }
+    public double removeFuel(ChunkPos pos, double amount) {
+        if (!this.isRiftChunk(pos))
+            return 0;
 
-    public static void setCurrentFuel(ServerWorld world, ChunkPos pos, double amount) {
-        if (!isRiftChunk(world, pos)) return;
-        modifyAttachment(world, pos, ARTRON, d -> amount);
-    }
+        double artron = this.getArtron(pos);
+        artron -= artron < amount ? 0 : amount;
 
-    private static <T> T getChunkAttachment(ServerWorld world, ChunkPos pos, AttachmentType<T> type, java.util.function.Supplier<T> defaultValue) {
-        Chunk chunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
-        return chunk != null ? chunk.getAttachedOrCreate(type, defaultValue) : defaultValue.get();
-    }
-
-    private static void modifyAttachment(ServerWorld world, ChunkPos pos, AttachmentType<Double> type, java.util.function.UnaryOperator<Double> modifier) {
-        Chunk chunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
-        if (chunk != null) {
-            chunk.modifyAttached(type, modifier);
+        Chunk shouldBeProtoChunk = this.world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
+        if (shouldBeProtoChunk instanceof ProtoChunk protoChunk) {
+            protoChunk.setAttached(ARTRON, artron);
         }
+        return artron - amount;
+    }
+
+    public void addFuel(ChunkPos pos, double amount) {
+        if (!this.isRiftChunk(pos))
+            return;
+
+        RiftChunkManager.addFuel(this.world, pos, amount);
+    }
+
+    public void setCurrentFuel(ChunkPos pos, double amount) {
+        Chunk shouldBeProtoChunk = this.world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
+
+        if (shouldBeProtoChunk instanceof ProtoChunk protoChunk) {
+            protoChunk.modifyAttached(ARTRON, d -> amount);
+        }
+    }
+
+    public boolean isRiftChunk(ChunkPos chunkPos) {
+        return RiftChunkManager.isRiftChunk(this.world, chunkPos);
+    }
+
+    public boolean isRiftChunk(BlockPos pos) {
+        return RiftChunkManager.isRiftChunk(world, pos);
     }
 
     public static boolean isRiftChunk(CachedDirectedGlobalPos cached) {
         return isRiftChunk(cached.getWorld(), cached.getPos());
     }
 
-    public static boolean isRiftChunk(StructureWorldAccess world, ChunkPos pos) {
-        return world != null && ChunkRandom.getSlimeRandom(pos.x, pos.z, world.getSeed(), 987234910L).nextInt(8) == 0;
-    }
-
     public static boolean isRiftChunk(StructureWorldAccess world, BlockPos pos) {
         return isRiftChunk(world, new ChunkPos(pos));
     }
 
-    public double getArtron(ChunkPos pos) { return getArtron(this.world, pos); }
-    public double getMaxArtron(ChunkPos pos) { return getMaxArtron(this.world, pos); }
-    public void addFuel(ChunkPos pos, double amount) { addFuel(this.world, pos, amount); }
-    public boolean isRiftChunk(ChunkPos pos) { return isRiftChunk(this.world, pos); }
-    public boolean isRiftChunk(BlockPos pos) { return isRiftChunk(this.world, pos); }
+    public static boolean isRiftChunk(StructureWorldAccess world, ChunkPos pos) {
+        if (world == null) return false;
+        return ChunkRandom.getSlimeRandom(pos.x, pos.z,
+                world.getSeed(), 987234910L
+        ).nextInt(8) == 0;
+    }
+
+    private static void addFuel(ServerWorldAccess world, ChunkPos pos, double amount) {
+        Chunk shouldBeProtoChunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
+
+        if (shouldBeProtoChunk instanceof ProtoChunk protoChunk) {
+            protoChunk.modifyAttached(ARTRON, d -> d + amount);
+        }
+    }
+
+    public static double getFuel(ServerWorld world, ChunkPos pos) {
+        if (!isRiftChunk(world, pos))
+            return 0;
+
+        Chunk shouldBeProtoChunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
+
+        if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
+            return 0;
+
+        return protoChunk.getAttachedOrCreate(ARTRON, () -> (double) world.getRandom().nextBetween(MIN_ARTRON_AMOUNT, MAX_ARTRON_AMOUNT));
+    }
+
+    public static double getMaxFuel(ServerWorld world, ChunkPos pos) {
+        if (!isRiftChunk(world, pos))
+            return 0;
+
+        Chunk shouldBeProtoChunk = world.getChunkManager().getChunk(pos.x, pos.z, ChunkStatus.STRUCTURE_STARTS, true);
+
+        if (!(shouldBeProtoChunk instanceof ProtoChunk protoChunk))
+            return 0;
+
+        return protoChunk.getAttachedOrCreate(MAX_ARTRON, () -> (double) world.getRandom().nextBetween(MIN_ARTRON_AMOUNT, MAX_ARTRON_AMOUNT));
+    }
 }


### PR DESCRIPTION
## About the PR
I made the rift scanner ding when you enter a rift chunk, and increased artron amounts per chunk.

## Why / Balance
it goes ding. and more artron means the rift ripper can actually work correctly now.

## Technical details
ding when inventory tick enter rift chunk, increase magic numbers in rift chunk manager.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: rift scanner now dings when entering a rift chunk
- tweak: rift chunks now have about 2.5x-3.5x the artron
