### PR TITLE
Fix: Hypercube Crashing

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/HypercubeItem.java
+++ b/src/main/java/dev/amble/ait/core/item/HypercubeItem.java
@@ -2,6 +2,7 @@ package dev.amble.ait.core.item;
 
 import java.util.List;
 
+import net.minecraft.server.world.ServerWorld;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.client.MinecraftClient;
@@ -22,6 +23,9 @@ import dev.amble.ait.core.AITItems;
 import dev.amble.ait.core.tardis.handler.distress.DistressCall;
 
 public class HypercubeItem extends Item {
+
+    private static final String DISTRESS_CALL_KEY = "DistressCall";
+
     public HypercubeItem(Settings settings) {
         super(settings.maxDamageIfAbsent(100));
     }
@@ -36,13 +40,13 @@ public class HypercubeItem extends Item {
 
         ItemStack held = user.getMainHandStack();
 
-        if (user.getWorld().isClient()) {
+        if (!(world instanceof ServerWorld serverWorld)) {
             MinecraftClient.getInstance().gameRenderer.showFloatingItem(held);
 
             return TypedActionResult.success(user.getStackInHand(hand));
         }
 
-        DistressCall call = getCall(held, world.getServer().getTicks());
+        DistressCall call = getCall(held, serverWorld.getServer().getTicks());
         if (call == null) {
             call = DistressCall.create(user, held.hasCustomName() ? held.getName().getString() : "SOS", true);
             setCall(held, call);
@@ -52,16 +56,16 @@ public class HypercubeItem extends Item {
 
         user.getItemCooldownManager().set(this, 15 * 20);
 
-        return success ? TypedActionResult.success(user.getStackInHand(hand)) : TypedActionResult.fail(user.getStackInHand(hand));
+        return success ? TypedActionResult.success(held) : TypedActionResult.fail(held);
     }
 
     @Override
     public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
         super.inventoryTick(stack, world, entity, slot, selected);
 
-        if (world.isClient()) return;
+        if (!(world instanceof ServerWorld serverWorld)) return;
 
-        DistressCall call = getCall(stack, world.getServer().getTicks());
+        DistressCall call = getCall(stack, serverWorld.getServer().getTicks());
         if (call == null) return;
         if (call.isSourceCall()) return;
 
@@ -90,15 +94,16 @@ public class HypercubeItem extends Item {
 
     public static DistressCall getCall(ItemStack stack, int ticks) {
         NbtCompound data = stack.getOrCreateNbt();
-        if (!data.contains("DistressCall")) return null;
+        if (!data.contains(DISTRESS_CALL_KEY)) return null;
 
-        return DistressCall.fromNbt(data.getCompound("DistressCall"), ticks);
+        return DistressCall.fromNbt(data.getCompound(DISTRESS_CALL_KEY), ticks);
     }
+
     public static void setCall(ItemStack stack, DistressCall call) {
-        stack.getOrCreateNbt().put("DistressCall", call.toNbt());
+        stack.getOrCreateNbt().put(DISTRESS_CALL_KEY, call.toNbt());
 
         if (stack.hasCustomName()) {
-            stack.setCustomName(null);
+            stack.setCustomName(Text.literal(""));
         }
     }
 

--- a/src/main/java/dev/amble/ait/core/item/HypercubeItem.java
+++ b/src/main/java/dev/amble/ait/core/item/HypercubeItem.java
@@ -102,9 +102,7 @@ public class HypercubeItem extends Item {
     public static void setCall(ItemStack stack, DistressCall call) {
         stack.getOrCreateNbt().put(DISTRESS_CALL_KEY, call.toNbt());
 
-        if (stack.hasCustomName()) {
-            stack.setCustomName(Text.literal(""));
-        }
+        stack.removeCustomName();
     }
 
     public static ItemStack create(DistressCall call) {


### PR DESCRIPTION
## About the PR
hypercubes used to crash players on servers. BUT NO MORE I SAY! With these fixes (if you can even call them that) it shouldn't AT LEAST crash players anymore.

## Why / Balance
Crashing bad?

## Technical details
use `ItemStack#removeCustomName()` instead of setting the custom name to null.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: hypercubes no longer crash players