### PR TITLE
fix: re-create exterior model in snow globe and monitor

### DIFF
--- a/src/main/java/dev/amble/ait/client/renderers/decoration/SnowGlobeRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/decoration/SnowGlobeRenderer.java
@@ -39,7 +39,7 @@ public class SnowGlobeRenderer<T extends SnowGlobeBlockEntity> implements BlockE
         matrices.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(225f));
         matrices.scale(0.055f, 0.055f, 0.055f);
         ClientExteriorVariantSchema schema = ClientExteriorVariantRegistry.BOX_DEFAULT;
-        ExteriorModel model = schema.getCachedModel();
+        ExteriorModel model = schema.model();
 
         model.render(matrices, vertexConsumers.getBuffer(AITRenderLayers.getEntityTranslucentCull(schema.texture())), light, overlay, 1, 1, 1, 1);
         model.render(matrices, vertexConsumers.getBuffer(AITRenderLayers.tardisEmissiveCullZOffset(schema.emission(), true)), 0xf000f0, overlay, 1, 1, 1, 1);

--- a/src/main/java/dev/amble/ait/client/screens/MonitorScreen.java
+++ b/src/main/java/dev/amble/ait/client/screens/MonitorScreen.java
@@ -374,7 +374,7 @@ public class MonitorScreen extends ConsoleScreen {
                 (centerWidth + 70), (centerHeight + 34), 5636095);
 
         stack.pop();
-        ExteriorModel model = variant.getCachedModel();
+        ExteriorModel model = variant.model();
 
         stack.push();
         stack.translate(x, isPoliceBox || isHorriblyUnscaled ? y + 11 : y, 100f);
@@ -388,7 +388,7 @@ public class MonitorScreen extends ConsoleScreen {
         }
 
         // datapack models float for some reason
-        if (variant.getCachedModel() instanceof BedrockExteriorModel) {
+        if (model instanceof BedrockExteriorModel) {
             stack.translate(0, 1.25f, 0);
         }
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This PR fixes a regression introduced by #2080.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As per TODO.

## Technical details
<!-- Summary of code changes for easier review. -->
Everything else (I believe) is fine to use the cached model, but snow globe and monitor don't animate it, meaning they don't reset the bone positions. So the exterior may appear as having doors opened, etc.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->