### PR TITLE
Fix Exterior Ticking

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/ServerTardis.java
+++ b/src/main/java/dev/amble/ait/core/tardis/ServerTardis.java
@@ -109,10 +109,7 @@ public class ServerTardis extends Tardis {
     }
 
     public boolean shouldTick() {
-        if (world == null)
-            return false;
-
-        return !this.travel().isLanded() || world.shouldTick() || this.shouldTickExterior();
+        return !this.travel().isLanded() || (world != null && world.shouldTick()) || this.shouldTickExterior();
     }
 
     public boolean shouldTickExterior() {


### PR DESCRIPTION
## About the PR
in the `#shouldTick` method in `ServerTardis`, it was checking if the world was null prior to doing any of the other checks, when only one of them needed the world. This caused it to return early, meaning it would always return false.

## Why / Balance
The exterior now ticks when loaded on relog!

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: exteriors get properly loaded on relog
