### PR TITLE
View The Interior Detector's State With the Sonic

### DIFF
--- a/src/main/java/dev/amble/ait/client/overlays/SonicOverlay.java
+++ b/src/main/java/dev/amble/ait/client/overlays/SonicOverlay.java
@@ -21,6 +21,9 @@ import dev.amble.ait.core.AITTags;
 import dev.amble.ait.core.item.SonicItem;
 
 public class SonicOverlay implements HudRenderCallback {
+
+    public static final Identifier OVERLAY = AITMod.id("textures/gui/overlay/sonic_can_interact.png");
+
     @Override
     public void onHudRender(DrawContext drawContext, float v) {
         MinecraftClient mc = MinecraftClient.getInstance();
@@ -34,8 +37,7 @@ public class SonicOverlay implements HudRenderCallback {
         if ((mc.player.getEquippedStack(EquipmentSlot.MAINHAND).getItem() == AITItems.SONIC_SCREWDRIVER
                 || mc.player.getEquippedStack(EquipmentSlot.OFFHAND).getItem() == AITItems.SONIC_SCREWDRIVER)
                 && playerIsLookingAtSonicInteractable(mc.crosshairTarget, mc.player)) {
-            this.renderOverlay(drawContext,
-                    AITMod.id("textures/gui/overlay/sonic_can_interact.png"));
+            this.renderOverlay(drawContext, OVERLAY);
         }
     }
 

--- a/src/main/java/dev/amble/ait/client/renderers/SonicRendering.java
+++ b/src/main/java/dev/amble/ait/client/renderers/SonicRendering.java
@@ -1,7 +1,10 @@
 package dev.amble.ait.client.renderers;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import dev.amble.ait.core.blockentities.DetectorBlockEntity;
+import dev.amble.ait.core.blocks.DetectorBlock;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import net.minecraft.client.world.ClientWorld;
 import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.lwjgl.opengl.GL11;
@@ -182,6 +185,8 @@ public class SonicRendering {
         renderRedstone(context, state, targetPos);
         profiler.swap("subsystem_info");
         renderSubSystemInfo(context, targetPos);
+        profiler.swap("detector_type");
+        renderDetectorState(context, targetPos);
 
         profiler.pop();
         profiler.pop();
@@ -198,6 +203,15 @@ public class SonicRendering {
         if (power == 0) return;
 
         context.drawCenteredTextWithShadow(client.textRenderer, "" + power, getCentreX(), (int) (getMaxY() * 0.4), Colors.WHITE);
+    }
+
+    private void renderDetectorState(DrawContext context, BlockPos pos) {
+        ClientWorld world = client.world;
+        if (world == null) return;
+        BlockState state = world.getBlockState(pos);
+        if (!(state.getBlock() instanceof DetectorBlock)) return;
+        DetectorBlock.Type type = state.get(DetectorBlock.TYPE);
+        context.drawCenteredTextWithShadow(client.textRenderer, type.name().toUpperCase(), getCentreX(), (int) (getMaxY() * 0.4), Colors.WHITE);
     }
 
     private void renderSubSystemInfo(DrawContext context, BlockPos pos) {

--- a/src/main/java/dev/amble/ait/core/blocks/ConsoleBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/ConsoleBlock.java
@@ -139,7 +139,7 @@ public class ConsoleBlock extends HorizontalDirectionalBlock implements BlockEnt
         BlockEntity blockEntity = world.getBlockEntity(pos);
         if (blockEntity instanceof ConsoleBlockEntity console && console.isLinked()) {
             Tardis tardis = console.tardis().get();
-            if (console.tardis().get().fuel().hasPower()) {
+            if (tardis.fuel().hasPower()) {
                 return 15;
             }
         }


### PR DESCRIPTION
## About the PR
The sonic now shows the interior detectors state/type if in scanning mode.

## Why / Balance
you can now more easily tell what state it is

## Technical details
literally just test if its an interior detector and then display its type.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- feat: see the interior detector's state with a scanning sonic screwdriver!