### PR TITLE
fix: historic interior translation

### DIFF
--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1004,7 +1004,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation("desktop.ait.egyptian", "Egyptian");
         provider.addTranslation("desktop.ait.forest", "Forest");
         provider.addTranslation("desktop.ait.gothic", "Gothic");
-        provider.addTranslation("desktop.ait.Historic", "Historic");
+        provider.addTranslation("desktop.ait.historic", "Historic");
         provider.addTranslation("desktop.ait.laboratory", "Laboratory");
         provider.addTranslation("desktop.ait.steampunk", "Steampunk");
         provider.addTranslation("desktop.ait.trek", "Trek");


### PR DESCRIPTION
## About the PR
fixed the historic interior translation

## Why / Balance
cus im a dumb ass and accidentally put a `H` instead of `h`

## Technical details
replaced `provider.addTranslation("desktop.ait.Historic", "Historic");` with `provider.addTranslation("desktop.ait.historic", "Historic");`

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
