### PR TITLE
Fix Exterior Duping On Crash Land

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/CrashableTardisTravel.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/CrashableTardisTravel.java
@@ -90,10 +90,10 @@ public sealed interface CrashableTardisTravel permits TravelHandler {
         tardis.door().setLocked(true);
         tardis.alarm().enable(ServerAlarmHandler.AlarmType.CRASHING);
         this.antigravs().set(false);
-        this.speed(0);
         tardis.removeFuel(700 * power);
         this.resetHammerUses();
         this.setCrashing(true);
+        this.speed(0);
         this.forceRemat();
 
         int repairTicks = 1200 * power;

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandler.java
@@ -11,7 +11,6 @@ import dev.amble.ait.core.lock.LockedDimension;
 import dev.amble.ait.core.lock.LockedDimensionRegistry;
 import dev.amble.ait.core.tardis.animation.v2.TardisAnimation;
 import dev.amble.ait.core.tardis.animation.v2.datapack.TardisAnimationRegistry;
-import dev.amble.ait.core.tardis.control.impl.DirectionControl;
 import dev.amble.ait.core.tardis.control.impl.EngineOverloadControl;
 import dev.amble.ait.core.tardis.control.impl.SecurityControl;
 import dev.amble.ait.core.tardis.handler.TardisCrashHandler;
@@ -216,7 +215,7 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
         if (this.tardis.crash().getState() == TardisCrashHandler.State.UNSTABLE)
             this.forceDestination(cached -> TravelUtil.jukePos(cached, 1, 10));
 
-        if (this.getState() != State.LANDED)
+        if (this.getState() != State.LANDED && !this.isCrashing())
             this.rematerialize();
     }
 
@@ -416,13 +415,12 @@ public final class TravelHandler extends AnimatedTravelHandler implements Crasha
     }
 
     public void finishDemat() {
-        this.crashing.set(false);
+        this.setCrashing(false);
         this.previousPosition.set(this.position);
         this.setState(State.FLIGHT);
 
         TardisEvents.ENTER_FLIGHT.invoker().onFlight(this.tardis);
         this.deleteExterior();
-
 
         if (tardis.stats().security().get() || !tardis.waypoint().canContainPlayers()) {
             SecurityControl.runSecurityProtocols(this.tardis);


### PR DESCRIPTION
## About the PR
Fixed exterior duping on crash!

## Why / Balance
No more duping!

## Technical details
On crash, it set the speed to 0 which tried making it take off again. This caused `#rematerialize` to get called which didn't respect `#isCrashing`. 

Changing the `#rematerialize` condition for `#tryFly` to respect `#isCrashing` and moving the speed modification to be done after setting crashing state.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: exterior duping on crash!