### PR TITLE
feat: fast travel

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelUtil.java
@@ -73,8 +73,12 @@ public class TravelUtil {
 
     public static int getFlightDuration(CachedDirectedGlobalPos source, CachedDirectedGlobalPos destination) {
         float distance = MathHelper.sqrt((float) source.getPos().getSquaredDistance(destination.getPos()));
-        boolean hasDirChanged = !(source.getRotation() == destination.getRotation());
-        boolean hasDimChanged = !(source.getDimension().equals(destination.getDimension()));
+
+        boolean hasDirChanged = source.getRotation() != destination.getRotation();
+        boolean hasDimChanged = !source.getDimension().equals(destination.getDimension());
+        
+        if (distance < 32 && !hasDimChanged)
+            return 0; // fast travel
 
         return (int) (BASE_FLIGHT_TICKS + (distance / 10f) + (hasDirChanged ? 100 : 0) + (hasDimChanged ? 600 : 0));
     }

--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelUtil.java
@@ -77,7 +77,7 @@ public class TravelUtil {
         boolean hasDirChanged = source.getRotation() != destination.getRotation();
         boolean hasDimChanged = !source.getDimension().equals(destination.getDimension());
         
-        if (distance < 32 && !hasDimChanged)
+        if (distance < 128 && !hasDimChanged)
             return 0; // fast travel
 
         return (int) (BASE_FLIGHT_TICKS + (distance / 10f) + (hasDirChanged ? 100 : 0) + (hasDimChanged ? 600 : 0));


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This PR adds fast travel. It applies automatically skipping the flight sequence if the destination is in less than 128 blocks away from your current position and the dimension is the same.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because it's annoying to spend `5*20+100=100t+100t=200t=10s` in flight when you only changed the direction.

## Technical details
<!-- Summary of code changes for easier review. -->
Just changing the target ticks calculation.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: fast travel - if your destination is less than 128 blocks the flight sequence will be skipped