### PR TITLE
Fix ghost blocks during interior reconfiguration

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -64,6 +64,9 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
     private static final BoolProperty QUEUED = new BoolProperty("queued");
     private static final BoolProperty REGENERATING = new BoolProperty("regenerating");
     private static final int MIN_FUEL_COST = 5000;
+    private static final int FORCE_KILL_TICKS = 20 * 10;
+    private static final float INTERIOR_CHANGE_DAMAGE = 1000.0F;
+    private static final float FINAL_INTERIOR_CHANGE_DAMAGE = Float.MAX_VALUE;
 
     public static final int MAX_PLASMIC_MATERIAL_AMOUNT = 8;
     private static final Text HINT_TEXT = Text.translatable("tardis.message.growth.hint").formatted(Formatting.DARK_GRAY, Formatting.ITALIC);
@@ -78,6 +81,9 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
 
     @Exclude
     private boolean countdownStarted = false;
+
+    @Exclude
+    private int regeneratingTicks = 0;
 
     @Exclude
     private List<ItemStack> restorationChestContents;
@@ -366,35 +372,73 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         if (!this.canQueue()) {
             this.queued.set(false);
             this.regenerating.set(false);
+            this.countdownStarted = false;
+            this.regeneratingTicks = 0;
 
             tardis.alarm().disable();
             return;
         }
 
-        if (!TardisUtil.isInteriorEmpty(tardis.asServer())) {
-            if (this.regenerating.get()) {
-                PlayerEntity target = TardisUtil.getAnyPlayerInsideInterior(tardis.asServer().world());
+        if (this.regenerating.get()) {
+            this.regeneratingTicks++;
+            this.handlePlayersDuringRegeneration();
 
-                if (this.tardis().subsystems().lifeSupport().isEnabled()) {
-                    TardisUtil.teleportOutside(tardis.asServer(), target);
-                } else {
-                    target.damage(AITDamageTypes.of(target.getWorld(), AITDamageTypes.INTERIOR_CHANGE), Float.MAX_VALUE);
-                }
-            }
+            // Do not rewrite the interior while a client is still tracking the old chunks.
+            if (TardisUtil.isInteriorEmpty(tardis.asServer()) && !this.tardis.getDesktop().isChanging())
+                this.changeInterior();
+
+            return;
         }
 
-        if (!this.regenerating.get() && !this.countdownStarted) {
+        if (!this.countdownStarted) {
             this.startRegeneratingCountdown();
         }
+    }
+
+    private void handlePlayersDuringRegeneration() {
+        for (PlayerEntity target : new ArrayList<>(tardis.asServer().world().getPlayers())) {
+            if (this.shouldTeleportDuringRegeneration(target)) {
+                TardisUtil.teleportOutside(tardis.asServer(), target);
+                continue;
+            }
+
+            this.damageDuringRegeneration(target);
+        }
+    }
+
+    private boolean shouldTeleportDuringRegeneration(PlayerEntity target) {
+        return this.tardis().subsystems().lifeSupport().isEnabled()
+                || target.isCreative()
+                || target.isSpectator();
+    }
+
+    private void damageDuringRegeneration(PlayerEntity target) {
+        if (!target.isAlive())
+            return;
+
+        target.damage(AITDamageTypes.of(target.getWorld(), AITDamageTypes.INTERIOR_CHANGE), INTERIOR_CHANGE_DAMAGE);
+
+        if (!target.isAlive() || this.regeneratingTicks < FORCE_KILL_TICKS)
+            return;
+
+        target.damage(AITDamageTypes.of(target.getWorld(), AITDamageTypes.INTERIOR_CHANGE), FINAL_INTERIOR_CHANGE_DAMAGE);
+
+        if (!target.isAlive())
+            return;
+
+        target.damage(target.getDamageSources().outOfWorld(), FINAL_INTERIOR_CHANGE_DAMAGE);
+
+        if (target.isAlive())
+            target.kill();
     }
 
     private ServerAlarmHandler.Countdown startRegeneratingCountdown() {
         ServerAlarmHandler.Countdown cd = new ServerAlarmHandler.Countdown.Builder().bellTolls(15).message("tardis.message.interiorchange.regenerating").thenRun(() -> {
             tardis.getDesktop().startQueue(true);
-            Scheduler.get().runTaskLater(this::changeInterior, TaskStage.END_SERVER_TICK, TimeUnit.SECONDS, 15);
 
             this.regenerating.set(true);
             this.countdownStarted = false;
+            this.regeneratingTicks = 0;
         });
 
         this.tardis().alarm().enable(cd);

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1127,6 +1127,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
 
         // Death
         provider.addTranslation("death.attack.tardis_squash", "%1$s got squashed by a TARDIS!");
+        provider.addTranslation("death.attack.interior_change", "%1$s was reconfigured.");
         provider.addTranslation("death.attack.space_suffocation", "%1$s got blown up due to lack of Oxygen!");
 
         // Sonic Scanning Mode
@@ -1779,6 +1780,7 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
         provider.addTranslation(AITBlocks.EXTERIOR_BLOCK, "Exterior");
         provider.addTranslation(AITBlocks.CORAL_PLANT, "TARDIS Coral");
         provider.addTranslation("death.attack.tardis_squash", "%1$s got squashed by a TARDIS!");
+        provider.addTranslation("death.attack.interior_change", "%1$s fue reconfigurado.");
         provider.addTranslation("message.ait.riftscanner.info1", "Artron Chunk Info: ");
         provider.addTranslation("message.ait.riftscanner.info2", "Artron left in chunk: ");
         provider.addTranslation("message.ait.riftscanner.info3", "This is not a rift chunk");

--- a/src/main/resources/data/ait/damage_type/interior_change_damage_type.json
+++ b/src/main/resources/data/ait/damage_type/interior_change_damage_type.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.0,
+  "message_id": "interior_change",
+  "scaling": "when_caused_by_living_non_player"
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_armor.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_armor.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ait:interior_change_damage_type"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_invulnerability.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_invulnerability.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ait:interior_change_damage_type"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_resistance.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_resistance.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ait:interior_change_damage_type"
+  ]
+}


### PR DESCRIPTION
## About the PR

Fixes TARDIS interior reconfiguration being applied while players are still inside after the countdown.

The countdown still starts as before, but once it finishes the interior is only rewritten once the old interior is clear. Players with life support are evacuated as before. Creative and spectator players are also evacuated when life support is missing, because they can otherwise survive the reconfiguration and keep tracking the old chunks. Survival/adventure players without life support keep the lethal behaviour and are removed by reconfiguration damage.

## Why / Balance

This keeps the current design intent: no life support remains lethal for survival players, while life support saves players by moving them outside.

The missing case was players that the damage path could not remove, especially creative players. Without removing those players first, `changeInterior()` can rewrite the desktop while the client is still inside it, which causes ghost blocks.

## Technical details

- Removed the fixed delayed `changeInterior()` call after the regeneration countdown.
- While `regenerating`, the handler now evacuates or damages players and only calls `changeInterior()` once the interior is empty and the desktop is no longer changing.
- Takes a snapshot of the interior player list before teleporting, so evacuation does not mutate the iterated list.
- Teleports players outside when life support is enabled, or when the player is creative/spectator.
- Applies repeated `ait:interior_change_damage_type` damage to survival/adventure players without life support for 10 seconds.
- If the player is still alive after that, applies one final `interior_change` hit with `Float.MAX_VALUE`, then falls back to out-of-world damage and `kill()`.
- Added damage type tags for armor, resistance, and invulnerability bypass.
- The out-of-world damage and `kill()` fallback should not normally be reached in vanilla because `ait:interior_change_damage_type` uses the bypass tags, but it is kept as a compatibility path for mods that hardcode immortality or invulnerability behaviour without respecting those tags.
- Added English and Spanish death translations.

## Media

N/A

## Requirements

- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

N/A

**Changelog**
:cl:
- fix: prevent TARDIS interior reconfiguration from rewriting the interior while creative or otherwise non-killable players are still inside