### PR TITLE
fix: hudolin and exile missing texture in biomes

### DIFF
--- a/src/main/java/dev/amble/ait/data/schema/exterior/variant/classic/client/ClientClassicBoxExileVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/exterior/variant/classic/client/ClientClassicBoxExileVariant.java
@@ -1,7 +1,14 @@
 package dev.amble.ait.data.schema.exterior.variant.classic.client;
 
+import dev.amble.ait.data.datapack.exterior.BiomeOverrides;
+
 public class ClientClassicBoxExileVariant extends ClientClassicBoxVariant {
     public ClientClassicBoxExileVariant() {
         super("exile");
+    }
+
+    @Override
+    public BiomeOverrides overrides() {
+        return BiomeOverrides.EMPTY; // Requires an artist to make biome textures.
     }
 }

--- a/src/main/java/dev/amble/ait/data/schema/exterior/variant/classic/client/ClientClassicBoxHudolinVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/exterior/variant/classic/client/ClientClassicBoxHudolinVariant.java
@@ -2,6 +2,7 @@ package dev.amble.ait.data.schema.exterior.variant.classic.client;
 
 import dev.amble.ait.client.models.exteriors.ClassicHudolinExteriorModel;
 import dev.amble.ait.client.models.exteriors.SimpleExteriorModel;
+import dev.amble.ait.data.datapack.exterior.BiomeOverrides;
 
 public class ClientClassicBoxHudolinVariant extends ClientClassicBoxVariant {
 
@@ -12,5 +13,10 @@ public class ClientClassicBoxHudolinVariant extends ClientClassicBoxVariant {
     @Override
     public SimpleExteriorModel model() {
         return new ClassicHudolinExteriorModel(ClassicHudolinExteriorModel.getTexturedModelData().createModel());
+    }
+
+    @Override
+    public BiomeOverrides overrides() {
+        return BiomeOverrides.EMPTY; // Requires an artist to make biome textures.
     }
 }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
I made biome override for Hudolin and Exile empty.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Missing textures
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
fix: hudolin and exile missing texture in biomes