### PR TITLE
fix: mallet no longer bypasses jammed controls

### DIFF
--- a/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
@@ -475,10 +475,10 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
         }
 
         if (state == DurabilityStates.JAMMED) {
-            if (!hasMallet) return false;
-
             if (random.nextBetween(0, 5) < 2)
                 tardis.subsystems().engine().removeDurability(random.nextBetween(0, 7));
+
+            return false;
         }
 
         if (state == DurabilityStates.SPARKY && random.nextBetween(0, 20) < 10) {

--- a/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
+++ b/src/main/java/dev/amble/ait/core/entities/ConsoleControlEntity.java
@@ -475,7 +475,7 @@ public class ConsoleControlEntity extends LinkableDummyEntity {
         }
 
         if (state == DurabilityStates.JAMMED) {
-            if (random.nextBetween(0, 5) < 2)
+            if (hasMallet && random.nextBetween(0, 5) < 2)
                 tardis.subsystems().engine().removeDurability(random.nextBetween(0, 7));
 
             return false;


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This PR makes it so mallet no longer bypasses the jammed control state (which is the lowest durability state).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is to avoid players abusing the mallet.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: mallet no longer bypasses jammed controls