### PR TITLE
fix: item rendering pos in new subsystem block

### DIFF
--- a/src/main/java/dev/amble/ait/client/renderers/machines/GenericSubSystemRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/machines/GenericSubSystemRenderer.java
@@ -43,7 +43,7 @@ public class GenericSubSystemRenderer<T extends GenericStructureSystemBlockEntit
             matrices.multiply(RotationAxis.POSITIVE_X.rotationDegrees(180));
             double offset = Math.sin((entity.getWorld().getTime() + tickDelta) / 8.0) / 18.0;
 
-            matrices.translate(0, -1.15f + (offset / 2), 0);
+            matrices.translate(0, -0.95f + (offset / 2), 0);
 
             Vector3f scale = client.getItemRenderer().getModel(stack, entity.getWorld(), null, 0).getTransformation().firstPersonRightHand.scale;
             matrices.scale(0.9f, 0.9f, 0.9f);


### PR DESCRIPTION
## About the PR
changed the postition of the rendered item to fix the new subsystem core block

## Why / Balance
they were wrong

## Technical details
set y offset to `-0.95f` in the `GenericSubSystemRenderer` class

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
non

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: item rendering pos in subsystem core block