### PR TITLE
fix: all BOTI door issues

### DIFF
--- a/src/main/java/dev/amble/ait/data/schema/door/impl/CapsuleDoorVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/door/impl/CapsuleDoorVariant.java
@@ -34,6 +34,6 @@ public class CapsuleDoorVariant extends DoorSchema {
 
     @Override
     public @Nullable Vec3d getPortalPosition() {
-        return new Vec3d(0, 0.125, -0.5);
+        return new Vec3d(0, 0.125, -0.45);
     }
 }

--- a/src/main/java/dev/amble/ait/data/schema/exterior/variant/box/PoliceBoxCoralVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/exterior/variant/box/PoliceBoxCoralVariant.java
@@ -3,6 +3,8 @@ package dev.amble.ait.data.schema.exterior.variant.box;
 import dev.amble.ait.data.schema.door.DoorSchema;
 import dev.amble.ait.data.schema.door.impl.PoliceBoxCoralDoorVariant;
 import dev.amble.ait.registry.impl.door.DoorRegistry;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.Nullable;
 
 public class PoliceBoxCoralVariant extends PoliceBoxVariant {
     public PoliceBoxCoralVariant() {
@@ -15,7 +17,7 @@ public class PoliceBoxCoralVariant extends PoliceBoxVariant {
     }
 
     @Override
-    public double portalHeight() {
-        return 2.3;
+    public @Nullable Vec3d getPortalPosition() {
+        return new Vec3d(0, -0.02, -0.591);
     }
 }

--- a/src/main/java/dev/amble/ait/data/schema/exterior/variant/box/PoliceBoxRenaissanceVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/exterior/variant/box/PoliceBoxRenaissanceVariant.java
@@ -20,6 +20,11 @@ public class PoliceBoxRenaissanceVariant extends PoliceBoxVariant {
 
     @Override
     public @Nullable Vec3d getPortalPosition() {
-        return super.getPortalPosition().add(0, 0.03, 0);
+        return new Vec3d(0, 0.01, -0.591);
+    }
+
+    @Override
+    public double portalHeight() {
+        return 2.35d;
     }
 }

--- a/src/main/java/dev/amble/ait/data/schema/exterior/variant/classic/ClassicBoxHudolinVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/exterior/variant/classic/ClassicBoxHudolinVariant.java
@@ -20,6 +20,6 @@ public class ClassicBoxHudolinVariant extends ClassicBoxVariant {
 
     @Override
     public @Nullable Vec3d getPortalPosition() {
-        return new Vec3d(0, 0.125, -0.599);
+        return new Vec3d(0, 0, -0.599);
     }
 }

--- a/src/main/java/dev/amble/ait/data/schema/exterior/variant/geometric/GeometricVariant.java
+++ b/src/main/java/dev/amble/ait/data/schema/exterior/variant/geometric/GeometricVariant.java
@@ -36,7 +36,7 @@ public abstract class GeometricVariant extends ExteriorVariantSchema {
 
     @Override
     public @Nullable Vec3d getPortalPosition() {
-        return new Vec3d(0, 0.125, -0.025);
+        return new Vec3d(0, 0.125, -0.12);
     }
 
     @Override


### PR DESCRIPTION
## About the PR
fixed BOTI IP door issues

## Why / Balance
some were either offset or you couldnt walk out with blocks behind

## Technical details
adjusted door portal pos(s) for; capsule, policebox coral, policebox renaissance, geometric, classic hudolin

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
NOT REQUIRED AS THIS IS A FIX FOR A RECENT CHANGE