### PR TITLE
fix: fast travel autopilot behavior

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelUtil.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelUtil.java
@@ -78,7 +78,7 @@ public class TravelUtil {
         boolean hasDimChanged = !source.getDimension().equals(destination.getDimension());
         
         if (distance < 128 && !hasDimChanged)
-            return 0; // fast travel
+            return 1; // fast travel
 
         return (int) (BASE_FLIGHT_TICKS + (distance / 10f) + (hasDirChanged ? 100 : 0) + (hasDimChanged ? 600 : 0));
     }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This PR fixes fast travel on autopilot (e.g. with stat remote or sonic).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
TARDIS would hang at 100% flight completion and not land.

## Technical details
<!-- Summary of code changes for easier review. -->
Idk really, travel code complicated but most likely it sees that the target ticks are 0 and tries to reconsider going into a loop and never landing. Either way, this fix just makes it so fast travel returns target ticks as 1 instead of 0.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->