### PR TITLE
fix: random matrix energizer crash

### DIFF
--- a/src/main/java/dev/amble/ait/core/blocks/MatrixEnergizerBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/MatrixEnergizerBlock.java
@@ -135,8 +135,6 @@ public class MatrixEnergizerBlock extends Block implements BlockEntityProvider {
                 world.addParticle(AITMod.CORAL_PARTICLE, centre.getX(), centre.getY() - 0.65f, centre.getZ(), offsetX, offsetY, offsetZ);
                 world.addParticle(ParticleTypes.SCULK_SOUL, centre.getX(), centre.getY() - 0.65f, centre.getZ(), offsetX, offsetY, offsetZ);
                 world.addParticle(ParticleTypes.SOUL_FIRE_FLAME, centre.getX(), centre.getY() - 0.65f, centre.getZ(), offsetX, offsetY, offsetZ);
-
-
             }
         }
     }
@@ -167,7 +165,9 @@ public class MatrixEnergizerBlock extends Block implements BlockEntityProvider {
         if (world.getBlockEntity(pos) instanceof MatrixEnergizerBlockEntity mbe) {
             if (mbe.getVibrationCallback().accepts(serverWorld, pos, GameEvent.SHRIEK, GameEvent.Emitter.of(state))) {
                 mbe.getEventListener().forceListen(serverWorld, GameEvent.SHRIEK, GameEvent.Emitter.of(state), pos.down().toCenterPos());
-                if (this.getAge(state) < this.getMaxAge()) {
+                int i = this.getAge(state);
+                
+                if (i < this.getMaxAge()) {
                     world.setBlockState(pos, state.with(AGE, i + 1), 2);
                 } else {
                     tryCreate(world, pos, state);

--- a/src/main/java/dev/amble/ait/core/blocks/MatrixEnergizerBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/MatrixEnergizerBlock.java
@@ -152,29 +152,25 @@ public class MatrixEnergizerBlock extends Block implements BlockEntityProvider {
         shriekerShrieks(state, world, pos);
     }
 
-    public void shriekerShrieks(BlockState thisState, World world, BlockPos pos) {
-        if (world.isClient()) return;
-        if (!(world.getBlockState(pos.down()).getBlock() instanceof SculkShriekerBlock) || !world.getBlockState(pos.down())
-                .get(SculkShriekerBlock.CAN_SUMMON)) {
-            return;
-        }
+    public void shriekerShrieks(BlockState state, World world, BlockPos pos) {
+        if (!(world instanceof ServerWorld serverWorld)) return;
+        if (!hasPower(state)) return;
 
-        if (!world.getBlockState(pos.down()).get(SculkShriekerBlock.SHRIEKING)) {
+        BlockState shriekerState = world.getBlockState(pos.down());
+        
+        if (!(shriekerState.getBlock() instanceof SculkShriekerBlock))
             return;
-        }
 
-        if (!hasPower(world.getBlockState(pos))) return;
-        BlockEntity be = world.getBlockEntity(pos);
-        BlockState state = world.getBlockState(pos.down());
-        if (be instanceof MatrixEnergizerBlockEntity mbe) {
-            if (mbe.getVibrationCallback().accepts((ServerWorld) world, pos, GameEvent.SHRIEK, GameEvent.Emitter.of(thisState))) {
-                mbe.getEventListener().forceListen((ServerWorld) world, GameEvent.SHRIEK, GameEvent.Emitter.of(state),
-                        new Vec3d(pos.down().getX(), pos.down().getY(), pos.down().getZ()));
-                int i = this.getAge(thisState);
-                if (i < this.getMaxAge()) {
-                    world.setBlockState(pos, thisState.with(AGE, i + 1), 2);
+        if (!shriekerState.get(SculkShriekerBlock.CAN_SUMMON) || !shriekerState.get(SculkShriekerBlock.SHRIEKING))
+            return;
+
+        if (world.getBlockEntity(pos) instanceof MatrixEnergizerBlockEntity mbe) {
+            if (mbe.getVibrationCallback().accepts(serverWorld, pos, GameEvent.SHRIEK, GameEvent.Emitter.of(state))) {
+                mbe.getEventListener().forceListen(serverWorld, GameEvent.SHRIEK, GameEvent.Emitter.of(state), pos.down().toCenterPos());
+                if (this.getAge(state) < this.getMaxAge()) {
+                    world.setBlockState(pos, state.with(AGE, i + 1), 2);
                 } else {
-                    tryCreate(world, pos, thisState);
+                    tryCreate(world, pos, state);
                 }
             }
         }
@@ -214,6 +210,7 @@ public class MatrixEnergizerBlock extends Block implements BlockEntityProvider {
 
         return false;
     }
+
     @Override
     public void onPlaced(World world, BlockPos pos, BlockState state, @Nullable LivingEntity placer,
             ItemStack itemStack) {


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This PR fixes a very weird crash that happens mid-tick under a certain very rare condition.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Crash.

## Technical details
<!-- Summary of code changes for easier review. -->
Basically, whoever wrote this should be hanged. If `randomTick` gets called after the block was broken, the thing will crash because it will attempt to grab its own block state AGAIN (even though it has the state already bruh).

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: random matrix energizer crash