### PR TITLE
Fix Assorted Rift Rendering Issues

### DIFF
--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -646,7 +646,7 @@ public class AITModClient implements ClientModInitializer {
             stack.push();
             stack.translate(pos.getX() - context.camera().getPos().getX(),
                     pos.getY() - context.camera().getPos().getY(), pos.getZ() - context.camera().getPos().getZ());
-            stack.translate(0, 2, 0);
+            stack.translate(0, 1.5f, 0);
             stack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(rift.getYaw()));
             stack.multiply(RotationAxis.POSITIVE_X.rotationDegrees(rift.getPitch()));
             RiftModel riftModel = new RiftModel(RiftModel.getTexturedModelData().createModel());

--- a/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
@@ -50,7 +50,7 @@ public class RiftEntityRenderer
                 vertexConsumerProvider.getBuffer(RenderLayer.getEndGateway()),
                 0xf000f0,
                 OverlayTexture.DEFAULT_UV,
-                0.6f, 0.0f, 1.0f, 1.0f,
+                1, 1, 1, 1,
                 4.5f
         );
 
@@ -61,7 +61,7 @@ public class RiftEntityRenderer
                 vertexConsumerProvider.getBuffer(RenderLayer.getEndGateway()),
                 0xf000f0,
                 OverlayTexture.DEFAULT_UV,
-                0.6f, 0.0f, 1.0f, 1.0f,
+                1, 1, 1.0f, 1.0f,
                 4.5f
         );
 

--- a/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
@@ -6,6 +6,7 @@ import net.fabricmc.api.Environment;
 
 import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.EntityRendererFactory;
@@ -18,6 +19,8 @@ import dev.amble.ait.client.AITModClient;
 import dev.amble.ait.client.boti.BOTI;
 import dev.amble.ait.client.models.decoration.PaintingFrameModel;
 import dev.amble.ait.core.entities.RiftEntity;
+import org.joml.Matrix3f;
+import org.joml.Matrix4f;
 
 @Environment(value=EnvType.CLIENT)
 public class RiftEntityRenderer
@@ -39,10 +42,43 @@ public class RiftEntityRenderer
 
         matrixStack.push();
         matrixStack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(riftEntity.getYaw() + 180));
-        matrixStack.translate(0, -0.9, 0.05);
+        matrixStack.translate(0, 0.3, 0);
         matrixStack.scale(1, 1, 1);
-        frame.render(matrixStack, vertexConsumerProvider.getBuffer(RenderLayer.getEntityTranslucentCull(CIRCLE_TEXTURE)), 0xf000f0, OverlayTexture.DEFAULT_UV, 0.6f, 0.0f, 1, 1);
+
+        renderCircleQuad(
+                matrixStack,
+                vertexConsumerProvider.getBuffer(RenderLayer.getEndGateway()),
+                0xf000f0,
+                OverlayTexture.DEFAULT_UV,
+                0.6f, 0.0f, 1.0f, 1.0f,
+                4.5f
+        );
+
+        // The endGateway renderLayer culls the backface so rendering it twice is fine
+        matrixStack.multiply(RotationAxis.POSITIVE_Y.rotationDegrees(180f));
+        renderCircleQuad(
+                matrixStack,
+                vertexConsumerProvider.getBuffer(RenderLayer.getEndGateway()),
+                0xf000f0,
+                OverlayTexture.DEFAULT_UV,
+                0.6f, 0.0f, 1.0f, 1.0f,
+                4.5f
+        );
+
         matrixStack.pop();
+    }
+
+    private static void renderCircleQuad(MatrixStack matrixStack, VertexConsumer vertexConsumer, int light, int overlay, float red, float green, float blue, float alpha, float size) {
+        MatrixStack.Entry entry = matrixStack.peek();
+        Matrix4f positionMatrix = entry.getPositionMatrix();
+        Matrix3f normalMatrix = entry.getNormalMatrix();
+
+        float half = size / 2.0f;
+
+        vertexConsumer.vertex(positionMatrix, -half, -half, 0).color(red, green, blue, alpha).texture(0.0f, 0.5f).overlay(overlay).light(light).normal(normalMatrix, 0.0f, 0.0f, 1.0f).next();
+        vertexConsumer.vertex(positionMatrix, half, -half, 0).color(red, green, blue, alpha).texture(0.5f, 0.5f).overlay(overlay).light(light).normal(normalMatrix, 0.0f, 0.0f, 1.0f).next();
+        vertexConsumer.vertex(positionMatrix, half, half, 0).color(red, green, blue, alpha).texture(0.5f, 0.0f).overlay(overlay).light(light).normal(normalMatrix, 0.0f, 0.0f, 1.0f).next();
+        vertexConsumer.vertex(positionMatrix, -half, half, 0).color(red, green, blue, alpha).texture(0.0f, 0.0f).overlay(overlay).light(light).normal(normalMatrix, 0.0f, 0.0f, 1.0f).next();
     }
 
     @Override


### PR DESCRIPTION
## About the PR
Just rendering stuff, namely just shifting the rendering of the rift down by a few, and making the placeholder for non-BOTI users/IP users be an end gateway.

## Why / Balance
So you can actually see the rift if you have optional settings off.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: rifts now have a proper placeholder instead of a slightly magenta "crack"