### PR TITLE
Fix Repair Time Increasing

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/travel/TravelHandlerBase.java
@@ -110,7 +110,7 @@ public abstract class TravelHandlerBase extends KeyedTardisComponent implements 
     public void tick(MinecraftServer server) {
         TardisCrashHandler crash = tardis.crash();
 
-        if (crash.getState() != TardisCrashHandler.State.NORMAL)
+        if (crash.getState() != TardisCrashHandler.State.NORMAL && !tardis.travel().isLanded())
             crash.addRepairTicks(2 * this.speed());
 
         if (server.getTicks() % 200 == 0 && this.hammerUses > 0)


### PR DESCRIPTION
## About the PR
Check if the TARDIS is landed before adding repair ticks.

## Why / Balance
Makes the repair time go up even when landed which is odd.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: repair time kept increasing even when landed when the throttle was active