### PR TITLE
fix: rift rendering falls back if IP is installed now

### DIFF
--- a/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/RiftEntityRenderer.java
@@ -15,27 +15,26 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.RotationAxis;
 
 import dev.amble.ait.AITMod;
+import dev.amble.ait.compat.DependencyChecker;
 import dev.amble.ait.client.AITModClient;
 import dev.amble.ait.client.boti.BOTI;
-import dev.amble.ait.client.models.decoration.PaintingFrameModel;
 import dev.amble.ait.core.entities.RiftEntity;
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
 
-@Environment(value=EnvType.CLIENT)
-public class RiftEntityRenderer
-        extends EntityRenderer<RiftEntity> {
+@Environment(EnvType.CLIENT)
+public class RiftEntityRenderer extends EntityRenderer<RiftEntity> {
+
     public static final Identifier RIFT_TEXTURE = AITMod.id("textures/entity/rift/rift.png");
     public static final Identifier CIRCLE_TEXTURE = AITMod.id("textures/entity/rift/circle_rift.png");
-    PaintingFrameModel frame;
+
     public RiftEntityRenderer(EntityRendererFactory.Context context) {
         super(context);
-        frame = new PaintingFrameModel(PaintingFrameModel.getTexturedModelData().createModel());
     }
 
     @Override
     public void render(RiftEntity riftEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
-        if (AITModClient.CONFIG.enableTardisBOTI) {
+        if (AITModClient.CONFIG.enableTardisBOTI && !DependencyChecker.hasPortals()) {
             BOTI.RIFT_RENDERING_QUEUE.add(riftEntity);
             return;
         }
@@ -85,5 +84,4 @@ public class RiftEntityRenderer
     public Identifier getTexture(RiftEntity entity) {
         return null;
     }
-
 }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
This PR fixes a bug where rift rendering fallback wouldn't apply if you had IP installed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This would result in the rift being invisible. Yikes.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: rift rendering fallback if IP is installed