### PR TITLE
Skip Rendering of In-Built BOTI in the Entity Renderers

### DIFF
--- a/src/main/java/dev/amble/ait/client/AITModClient.java
+++ b/src/main/java/dev/amble/ait/client/AITModClient.java
@@ -503,11 +503,11 @@ public class AITModClient implements ClientModInitializer {
         ParticleFactoryRegistry.getInstance().register(CORAL_PARTICLE, EndRodParticle.Factory::new);
     }
 
-    private boolean skipBuiltInBOTI() {
+    public static boolean skipBuiltInBOTI() {
         return (DependencyChecker.hasPortals() && CONFIG.allowPortalsBoti) || !CONFIG.enableTardisBOTI;
     }
 
-    private boolean skipPaintingBOTI() {
+    public static boolean skipPaintingBOTI() {
         return DependencyChecker.hasPortals() || !CONFIG.enableTardisBOTI;
     }
 

--- a/src/main/java/dev/amble/ait/client/renderers/doors/DoorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/doors/DoorRenderer.java
@@ -1,5 +1,6 @@
 package dev.amble.ait.client.renderers.doors;
 
+import dev.amble.ait.client.AITModClient;
 import org.joml.Vector3f;
 
 import net.minecraft.block.BlockState;
@@ -160,7 +161,7 @@ public class DoorRenderer<T extends DoorBlockEntity> implements BlockEntityRende
             }
         }
 
-        if ((tardis.door().getLeftRot() > 0 || this.variant.hasTransparentDoors()) && !tardis.isGrowth())
+        if ((tardis.door().getLeftRot() > 0 || this.variant.hasTransparentDoors()) && !tardis.isGrowth() && !AITModClient.skipBuiltInBOTI())
             BOTI.DOOR_RENDER_QUEUE.add(entity);
 
         matrices.pop();

--- a/src/main/java/dev/amble/ait/client/renderers/entities/GallifreyanPaintingEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/GallifreyanPaintingEntityRenderer.java
@@ -1,6 +1,7 @@
 package dev.amble.ait.client.renderers.entities;
 
 
+import dev.amble.ait.client.AITModClient;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
@@ -25,7 +26,7 @@ public class GallifreyanPaintingEntityRenderer
 
     @Override
     public void render(BOTIPaintingEntity paintingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
-        BOTI.GALLIFREYAN_RENDER_QUEUE.add(paintingEntity);
+        if (!AITModClient.skipPaintingBOTI()) BOTI.GALLIFREYAN_RENDER_QUEUE.add(paintingEntity);
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/client/renderers/entities/TrenzalorePaintingEntityRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/entities/TrenzalorePaintingEntityRenderer.java
@@ -1,6 +1,7 @@
 package dev.amble.ait.client.renderers.entities;
 
 
+import dev.amble.ait.client.AITModClient;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
@@ -25,7 +26,7 @@ public class TrenzalorePaintingEntityRenderer
 
     @Override
     public void render(BOTIPaintingEntity paintingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int i) {
-        BOTI.TRENZALORE_PAINTING_QUEUE.add(paintingEntity);
+        if (!AITModClient.skipPaintingBOTI()) BOTI.TRENZALORE_PAINTING_QUEUE.add(paintingEntity);
     }
 
     @Override

--- a/src/main/java/dev/amble/ait/client/renderers/exteriors/ExteriorRenderer.java
+++ b/src/main/java/dev/amble/ait/client/renderers/exteriors/ExteriorRenderer.java
@@ -1,6 +1,7 @@
 package dev.amble.ait.client.renderers.exteriors;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+import dev.amble.ait.client.AITModClient;
 import org.joml.Vector3f;
 
 import net.minecraft.block.BlockState;
@@ -82,7 +83,7 @@ public class ExteriorRenderer<T extends ExteriorBlockEntity> implements BlockEnt
 
         if (!tardis.travel().isLanded() || tardis.siege().isActive()) return;
 
-        if (variant.parent().hasPortals()) BOTI.EXTERIOR_RENDER_QUEUE.add(entity);
+        if (variant.parent().hasPortals() || !AITModClient.skipBuiltInBOTI()) BOTI.EXTERIOR_RENDER_QUEUE.add(entity);
     }
 
     private boolean awesomeIPEmissionHack(Tardis tardis) {


### PR DESCRIPTION
## About the PR
use `#skipBuiltInBoti` in the entity renderers.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
see above

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: in built boti gets ignored if the immersive portals stuff is active