### PR TITLE
Interior Reconfiguration Issues

### DIFF
--- a/src/main/java/dev/amble/ait/core/tardis/Tardis.java
+++ b/src/main/java/dev/amble/ait/core/tardis/Tardis.java
@@ -106,7 +106,6 @@ public abstract class Tardis extends Initializable<TardisComponent.InitContext> 
         return this.handler(TardisComponent.Id.STATS);
     }
 
-    @Deprecated(forRemoval = true)
     public InteriorChangingHandler interiorChangingHandler() {
         return interiorChanging();
     }

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -3,12 +3,14 @@ package dev.amble.ait.core.tardis.handler;
 import java.util.ArrayList;
 import java.util.List;
 
+import dev.amble.ait.core.AITSounds;
 import dev.drtheo.scheduler.api.TimeUnit;
 import dev.drtheo.scheduler.api.common.Scheduler;
 import dev.drtheo.scheduler.api.common.TaskStage;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 
 import net.minecraft.block.Blocks;
+import net.minecraft.block.entity.ChestBlockEntity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -133,7 +135,6 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
                     if (tardis == null || desktop == null)
                         return;
 
-                    // nuh uh no interior changing during flight
                     if (tardis.travel().getState() != TravelHandler.State.LANDED)
                         return;
 
@@ -159,7 +160,6 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         hasCage.set(value);
     }
 
-    // unused but here for parity
     public void setPlasmicMaterialAmount(int amount) {
         plasmicMaterialAmount.set(amount);
     }
@@ -235,7 +235,6 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
 
                         travel.autopilot(true);
 
-                        // Should unlock the world the TARDIS is grown in, reducing PR #1908 to ashes. - Loqor
                         LockedDimension worldID = LockedDimensionRegistry.getInstance().get(travel.position().getWorld());
                         if (worldID != null) {
                             tardis.stats().unlock(worldID);
@@ -250,11 +249,20 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
                     TardisUtil.sendMessageToLinked(tardis.asServer(), Text.translatable("tardis.message.interiorchange.success", tardis.stats().getName(), tardis.getDesktop().getSchema().name()));
 
                     this.restoreSubsystemsToConsole();
+                    this.playReconfigureCompleteSound();
 
                     ParticleEffect particle = ParticleTypes.CLOUD;
                     tardis.door().setDoorParticles(particle);
                     Scheduler.get().runTaskLater(() -> tardis.door().setDoorParticles(null), TaskStage.END_SERVER_TICK, TimeUnit.SECONDS, 3);
                 }).execute();
+    }
+
+    private void playReconfigureCompleteSound() {
+        ServerWorld world = tardis.asServer().world();
+        DirectedGlobalPos position = tardis.travel().position();
+        BlockPos pos = position != null ? position.getPos() : tardis.getDesktop().getDoorPos().getPos();
+
+        world.playSound(null, pos, AITSounds.TARDIS_BLING, SoundCategory.BLOCKS, 10.0F, 1.0F);
     }
 
     private void restoreSubsystemsToConsole() {

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -4,13 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.amble.ait.core.AITSounds;
+import dev.amble.lib.data.CachedDirectedGlobalPos;
 import dev.drtheo.scheduler.api.TimeUnit;
 import dev.drtheo.scheduler.api.common.Scheduler;
 import dev.drtheo.scheduler.api.common.TaskStage;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 
 import net.minecraft.block.Blocks;
-import net.minecraft.block.entity.ChestBlockEntity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -63,7 +63,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
     public static final int MAX_PLASMIC_MATERIAL_AMOUNT = 8;
     private static final Text HINT_TEXT = Text.translatable("tardis.message.growth.hint").formatted(Formatting.DARK_GRAY, Formatting.ITALIC);
 
-    private static final int EMPTY_LOCK_DELAY_TICKS = 60; // 3 seconds
+    private static final int EMPTY_LOCK_DELAY_TICKS = 60;
 
     private final Value<Identifier> queuedInterior = QUEUED_INTERIOR_PROPERTY.create(this);
     private static final IntProperty PLASMIC_MATERIAL_AMOUNT = new IntProperty("plasmic_material_amount");
@@ -229,6 +229,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
                 .thenRun(() -> {
                     this.queued.set(false);
                     this.regenerating.set(false);
+                    this.countdownStarted = false;
 
                     if (tardis.hasGrowthExterior()) {
                         TravelHandler travel = tardis.travel();
@@ -253,14 +254,15 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
 
                     ParticleEffect particle = ParticleTypes.CLOUD;
                     tardis.door().setDoorParticles(particle);
+                    tardis.door().setLocked(false);
                     Scheduler.get().runTaskLater(() -> tardis.door().setDoorParticles(null), TaskStage.END_SERVER_TICK, TimeUnit.SECONDS, 3);
                 }).execute();
     }
 
     private void playReconfigureCompleteSound() {
-        ServerWorld world = tardis.asServer().world();
-        DirectedGlobalPos position = tardis.travel().position();
-        BlockPos pos = position != null ? position.getPos() : tardis.getDesktop().getDoorPos().getPos();
+        CachedDirectedGlobalPos position = tardis.travel().position();
+        ServerWorld world = position.getWorld();
+        BlockPos pos = position.getPos();
 
         world.playSound(null, pos, AITSounds.TARDIS_BLING, SoundCategory.BLOCKS, 10.0F, 1.0F);
     }
@@ -281,10 +283,6 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         });
     }
 
-    /**
-     * Replaces the console with air, and places soul sand beneath it.
-     * @param cPos The position of the console to replace.
-     */
     private void replaceConsoleWithGrowth(BlockPos cPos) {
         ServerWorld world = tardis.asServer().world();
 
@@ -297,10 +295,6 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         console.onBroken();
     }
 
-    /**
-     * Replaces all consoles with growth.
-     * @see #replaceConsoleWithGrowth(BlockPos)
-     */
     private void replaceAllConsolesWithGrowth() {
         for (BlockPos cPos : tardis.getDesktop().getConsolePos()) {
             replaceConsoleWithGrowth(cPos);
@@ -310,31 +304,43 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
     @Override
     public void tick(MinecraftServer server) {
         this.tickGrowth(server);
-        this.tickAutoLock();
 
-        if (!this.queued.get())
+        if (!this.queued.get()) {
+            this.emptyInteriorTicks = 0;
+            this.countdownStarted = false;
             return;
+        }
 
         if (!this.canQueue()) {
             this.queued.set(false);
             this.regenerating.set(false);
-
+            this.countdownStarted = false;
             tardis.alarm().disable();
             return;
         }
 
-        if (!TardisUtil.isInteriorEmpty(tardis.asServer()) && this.regenerating.get()) {
-            PlayerEntity target = TardisUtil.getAnyPlayerInsideInterior(tardis.asServer().world());
+        if (!TardisUtil.isInteriorEmpty(tardis.asServer())) {
+            this.emptyInteriorTicks = 0;
 
-            if (this.tardis().subsystems().lifeSupport().isEnabled()) {
-                TardisUtil.teleportOutside(tardis.asServer(), target);
-            } else {
-                target.damage(AITDamageTypes.of(target.getWorld(), AITDamageTypes.INTERIOR_CHANGE), Float.MAX_VALUE);
+            if (this.regenerating.get()) {
+                PlayerEntity target = TardisUtil.getAnyPlayerInsideInterior(tardis.asServer().world());
+                if (this.tardis().subsystems().lifeSupport().isEnabled()) {
+                    TardisUtil.teleportOutside(tardis.asServer(), target);
+                } else {
+                    target.damage(AITDamageTypes.of(target.getWorld(), AITDamageTypes.INTERIOR_CHANGE), Float.MAX_VALUE);
+                }
             }
+            return;
         }
 
-        if (!this.regenerating.get() && !this.countdownStarted) {
-            this.startRegeneratingCountdown();
+        this.emptyInteriorTicks++;
+
+        if (this.emptyInteriorTicks >= EMPTY_LOCK_DELAY_TICKS) {
+            this.tardis.door().setLocked(true);
+
+            if (!this.countdownStarted && !this.regenerating.get()) {
+                this.startRegeneratingCountdown();
+            }
         }
     }
 
@@ -357,34 +363,11 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         }
     }
 
-    /**
-     * Locks the interior doors once no player has been inside the
-     * interior dimension for {@link #EMPTY_LOCK_DELAY_TICKS} ticks, then
-     * performs the queued interior change, if any.
-     */
-    private void tickAutoLock() {
-        if (this.tardis.isGrowth())
-            return;
-
-        if (TardisUtil.isInteriorEmpty(tardis.asServer())) {
-            if (++this.emptyInteriorTicks == EMPTY_LOCK_DELAY_TICKS) {
-                this.tardis.door().setLocked(true);
-
-                if (this.queued.get())
-                    this.changeInterior();
-            }
-        } else {
-            this.emptyInteriorTicks = 0;
-        }
-    }
-
     private ServerAlarmHandler.Countdown startRegeneratingCountdown() {
         ServerAlarmHandler.Countdown cd = new ServerAlarmHandler.Countdown.Builder().bellTolls(15).message("tardis.message.interiorchange.regenerating").thenRun(() -> {
             tardis.getDesktop().startQueue(true);
             Scheduler.get().runTaskLater(this::changeInterior, TaskStage.END_SERVER_TICK, TimeUnit.SECONDS, 15);
-
             this.regenerating.set(true);
-            this.countdownStarted = false;
         });
 
         this.tardis().alarm().enable(cd);

--- a/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
+++ b/src/main/java/dev/amble/ait/core/tardis/handler/InteriorChangingHandler.java
@@ -8,10 +8,7 @@ import dev.drtheo.scheduler.api.common.Scheduler;
 import dev.drtheo.scheduler.api.common.TaskStage;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
-import net.minecraft.block.ChestBlock;
-import net.minecraft.block.entity.ChestBlockEntity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
@@ -26,7 +23,6 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Direction;
 
 import dev.amble.ait.AITMod;
 import dev.amble.ait.api.tardis.KeyedTardisComponent;
@@ -42,7 +38,6 @@ import dev.amble.ait.core.lock.LockedDimensionRegistry;
 import dev.amble.ait.core.tardis.handler.travel.TravelHandler;
 import dev.amble.ait.core.tardis.manager.ServerTardisManager;
 import dev.amble.ait.core.tardis.util.TardisUtil;
-import dev.amble.ait.core.util.SafePosSearch;
 import dev.amble.ait.data.Exclude;
 import dev.amble.ait.data.properties.Property;
 import dev.amble.ait.data.properties.Value;
@@ -54,8 +49,6 @@ import dev.amble.ait.data.schema.desktop.TardisDesktopSchema;
 import dev.amble.ait.registry.impl.CategoryRegistry;
 import dev.amble.ait.registry.impl.DesktopRegistry;
 import dev.amble.ait.registry.impl.exterior.ExteriorVariantRegistry;
-import dev.amble.lib.data.CachedDirectedGlobalPos;
-import dev.amble.lib.data.DirectedBlockPos;
 import dev.amble.lib.data.DirectedGlobalPos;
 
 public class InteriorChangingHandler extends KeyedTardisComponent implements TardisTickable {
@@ -67,6 +60,8 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
 
     public static final int MAX_PLASMIC_MATERIAL_AMOUNT = 8;
     private static final Text HINT_TEXT = Text.translatable("tardis.message.growth.hint").formatted(Formatting.DARK_GRAY, Formatting.ITALIC);
+
+    private static final int EMPTY_LOCK_DELAY_TICKS = 60; // 3 seconds
 
     private final Value<Identifier> queuedInterior = QUEUED_INTERIOR_PROPERTY.create(this);
     private static final IntProperty PLASMIC_MATERIAL_AMOUNT = new IntProperty("plasmic_material_amount");
@@ -82,6 +77,9 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
     @Exclude
     private List<ItemStack> restorationChestContents;
 
+    @Exclude
+    private int emptyInteriorTicks = 0;
+
     public InteriorChangingHandler() {
         super(Id.INTERIOR);
     }
@@ -94,16 +92,17 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         queued.of(this, QUEUED);
         regenerating.of(this, REGENERATING);
 
-        if (this.isServer() && this.regenerating.get()) {
-            this.regenerating.set(false);
+        if (!this.isServer() || !this.regenerating.get())
+            return;
 
-            TardisDesktopSchema queued = this.getQueuedInterior();
+        this.regenerating.set(false);
 
-            if (queued == null)
-                return;
+        TardisDesktopSchema queuedSchema = this.getQueuedInterior();
 
-            tardis.interiorChangingHandler().queueInteriorChange(queued);
-        }
+        if (queuedSchema == null)
+            return;
+
+        tardis.interiorChangingHandler().queueInteriorChange(queuedSchema);
     }
 
     static {
@@ -122,7 +121,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
             tardis.travel().autopilot(false);
             tardis.getExterior().setType(CategoryRegistry.CAPSULE);
             tardis.getExterior().setVariant(ExteriorVariantRegistry.CAPSULE_DEFAULT);
-            return TardisEvents.Interaction.SUCCESS; // force mat even if checks fail
+            return TardisEvents.Interaction.SUCCESS;
         });
 
         TardisEvents.LOSE_POWER.register(tardis -> tardis.interiorChangingHandler().queued.set(false));
@@ -160,6 +159,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         hasCage.set(value);
     }
 
+    // unused but here for parity
     public void setPlasmicMaterialAmount(int amount) {
         plasmicMaterialAmount.set(amount);
     }
@@ -181,14 +181,13 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
             return;
 
         if (tardis.fuel().getCurrentFuel() < (MIN_FUEL_COST * tardis.travel().instability())) {
-            tardis.asServer().world().getPlayers().forEach(player -> {
-                player.sendMessage(
-                        Text.translatable("tardis.message.interiorchange.not_enough_fuel").formatted(Formatting.RED),
-                        true);
-            });
+            tardis.asServer().world().getPlayers().forEach(player -> player.sendMessage(
+                    Text.translatable("tardis.message.interiorchange.not_enough_fuel").formatted(Formatting.RED),
+                    true));
 
             return;
         }
+
         if (tardis.subsystems().isEnabled()) {
             tardis.asServer().world().getPlayers().forEach(player -> {
                 int count = 0;
@@ -249,24 +248,29 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
                     }
 
                     TardisUtil.sendMessageToLinked(tardis.asServer(), Text.translatable("tardis.message.interiorchange.success", tardis.stats().getName(), tardis.getDesktop().getSchema().name()));
-                    this.tardis.getDesktop().getConsolePos().stream().findFirst().ifPresent(blockPos -> {
-                        if (restorationChestContents == null || restorationChestContents.isEmpty()) {
-                            AITMod.LOGGER.debug("No contents to save in recovery inventory in console for {}", this.tardis);
-                            return;
-                        }
-                        if (this.tardis.asServer().world().getBlockEntity(blockPos) instanceof ConsoleBlockEntity consoleBlockEntity) {
-                            for (int i = 0; i < restorationChestContents.size() && i < consoleBlockEntity.getInventory().size(); i++) {
-                                consoleBlockEntity.getInventory().set(i, restorationChestContents.get(i));
-                            }
-                        }
-                    });//createChestAtInteriorDoor(restorationChestContents);
+
+                    this.restoreSubsystemsToConsole();
 
                     ParticleEffect particle = ParticleTypes.CLOUD;
                     tardis.door().setDoorParticles(particle);
-                    Scheduler.get().runTaskLater(() -> {
-                        tardis.door().setDoorParticles(null);
-                    }, TaskStage.END_SERVER_TICK, TimeUnit.SECONDS, 3);
+                    Scheduler.get().runTaskLater(() -> tardis.door().setDoorParticles(null), TaskStage.END_SERVER_TICK, TimeUnit.SECONDS, 3);
                 }).execute();
+    }
+
+    private void restoreSubsystemsToConsole() {
+        if (restorationChestContents == null || restorationChestContents.isEmpty()) {
+            AITMod.LOGGER.debug("No contents to save in recovery inventory in console for {}", this.tardis);
+            return;
+        }
+
+        this.tardis.getDesktop().getConsolePos().stream().findFirst().ifPresent(blockPos -> {
+            if (!(this.tardis.asServer().world().getBlockEntity(blockPos) instanceof ConsoleBlockEntity consoleBlockEntity))
+                return;
+
+            for (int i = 0; i < restorationChestContents.size() && i < consoleBlockEntity.getInventory().size(); i++) {
+                consoleBlockEntity.getInventory().set(i, restorationChestContents.get(i));
+            }
+        });
     }
 
     /**
@@ -295,69 +299,12 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
         }
     }
 
-    private void createChestAtInteriorDoor(List<ItemStack> contents) {
-        if (contents == null || contents.isEmpty()) {
-            AITMod.LOGGER.debug("No contents to save in recovery chest for {}", this.tardis);
-            return;
-        }
-
-        DirectedBlockPos door = this.tardis.getDesktop().getDoorPos();
-
-        CachedDirectedGlobalPos safe = CachedDirectedGlobalPos.create(
-                this.tardis.asServer().world(),
-                door.getPos().offset(door.toMinecraftDirection(), 2),
-                door.getRotation()
-        );
-
-        SafePosSearch.wrapSafe(safe, SafePosSearch.Kind.MEDIAN, true,
-                result -> this.finishCreatingChest(result, contents));
-    }
-
-    private void finishCreatingChest(CachedDirectedGlobalPos safe, List<ItemStack> contents) {
-        // set block to chest
-        if (!(safe.getWorld().getBlockState(safe.getPos()).isAir())) {
-            AITMod.LOGGER.error("Failed to create recovery chest at {} for {}", safe, this.tardis);
-            return;
-        }
-
-        Direction doorDir = tardis.getDesktop().getDoorPos().toMinecraftDirection();
-        safe.getWorld().setBlockState(safe.getPos(), Blocks.CHEST.getDefaultState().with(ChestBlock.FACING, doorDir.getOpposite()), Block.NOTIFY_ALL);
-
-        // set chest contents
-        ChestBlockEntity chest = (ChestBlockEntity) safe.getWorld().getBlockEntity(safe.getPos());
-        List<ItemStack> overflow = new ArrayList<>(contents);
-
-        for (int i = 0; i < 27 && !overflow.isEmpty(); i++) {
-            chest.setStack(i, overflow.remove(0));
-        }
-
-        AITMod.LOGGER.debug("Created recovery chest at {} for {}", safe, this.tardis);
-
-        if (!overflow.isEmpty())
-            createChestAtInteriorDoor(overflow);
-    }
-
     @Override
     public void tick(MinecraftServer server) {
-        boolean isQueued = this.queued.get();
+        this.tickGrowth(server);
+        this.tickAutoLock();
 
-        if (server.getTicks() % 10 == 0 && this.tardis.isGrowth()) {
-            this.generateInteriorWithItem();
-
-            if (!isQueued) {
-                if (server.getTicks() % 200 == 0 && this.hasEnoughPlasmicMaterial())
-                    this.tardis.asServer().world().getPlayers().forEach(player ->
-                            player.sendMessage(HINT_TEXT, true));
-
-                if (this.tardis.door().isClosed()) {
-                    this.tardis.door().openDoors();
-                } else {
-                    this.tardis.door().setLocked(false);
-                }
-            }
-        }
-
-        if (!isQueued)
+        if (!this.queued.get())
             return;
 
         if (!this.canQueue()) {
@@ -368,20 +315,58 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
             return;
         }
 
-        if (!TardisUtil.isInteriorEmpty(tardis.asServer())) {
-            if (this.regenerating.get()) {
-                PlayerEntity target = TardisUtil.getAnyPlayerInsideInterior(tardis.asServer().world());
+        if (!TardisUtil.isInteriorEmpty(tardis.asServer()) && this.regenerating.get()) {
+            PlayerEntity target = TardisUtil.getAnyPlayerInsideInterior(tardis.asServer().world());
 
-                if (this.tardis().subsystems().lifeSupport().isEnabled()) {
-                    TardisUtil.teleportOutside(tardis.asServer(), target);
-                } else {
-                    target.damage(AITDamageTypes.of(target.getWorld(), AITDamageTypes.INTERIOR_CHANGE), Float.MAX_VALUE);
-                }
+            if (this.tardis().subsystems().lifeSupport().isEnabled()) {
+                TardisUtil.teleportOutside(tardis.asServer(), target);
+            } else {
+                target.damage(AITDamageTypes.of(target.getWorld(), AITDamageTypes.INTERIOR_CHANGE), Float.MAX_VALUE);
             }
         }
 
         if (!this.regenerating.get() && !this.countdownStarted) {
             this.startRegeneratingCountdown();
+        }
+    }
+
+    private void tickGrowth(MinecraftServer server) {
+        if (server.getTicks() % 10 != 0 || !this.tardis.isGrowth())
+            return;
+
+        this.generateInteriorWithItem();
+
+        if (this.queued.get())
+            return;
+
+        if (server.getTicks() % 200 == 0 && this.hasEnoughPlasmicMaterial())
+            this.tardis.asServer().world().getPlayers().forEach(player -> player.sendMessage(HINT_TEXT, true));
+
+        if (this.tardis.door().isClosed()) {
+            this.tardis.door().openDoors();
+        } else {
+            this.tardis.door().setLocked(false);
+        }
+    }
+
+    /**
+     * Locks the interior doors once no player has been inside the
+     * interior dimension for {@link #EMPTY_LOCK_DELAY_TICKS} ticks, then
+     * performs the queued interior change, if any.
+     */
+    private void tickAutoLock() {
+        if (this.tardis.isGrowth())
+            return;
+
+        if (TardisUtil.isInteriorEmpty(tardis.asServer())) {
+            if (++this.emptyInteriorTicks == EMPTY_LOCK_DELAY_TICKS) {
+                this.tardis.door().setLocked(true);
+
+                if (this.queued.get())
+                    this.changeInterior();
+            }
+        } else {
+            this.emptyInteriorTicks = 0;
         }
     }
 
@@ -430,6 +415,7 @@ public class InteriorChangingHandler extends KeyedTardisComponent implements Tar
                             SoundCategory.BLOCKS, 10.0F, 0.75F);
 
                     this.queueInteriorChange(DesktopRegistry.getInstance().get(AITMod.id("cave")));
+
                     if (stack.isOf(AITItems.TARDIS_MATRIX)) {
                         NbtCompound nbt = stack.getOrCreateNbt();
                         if (nbt.contains("name")) {


### PR DESCRIPTION
## About the PR
General optimizations and making the code cleaner, and fixing the exit -> lock -> start reconfiguring bit.

## Why / Balance
The TARDIS just wouldn't reconfigure when you stepped out for some reason, so I sought to fix that as it was bugging players.

## Technical details
Clean up methods and get rid of unused ones, as well as adding a EMPTY_LOCK_TICK delay.

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->