### PR TITLE
Immersive Portals Wouldn't Get Removed When Unloaded

### DIFF
--- a/src/main/java/dev/amble/ait/compat/portal/PortalVisualizerUtil.java
+++ b/src/main/java/dev/amble/ait/compat/portal/PortalVisualizerUtil.java
@@ -8,6 +8,8 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.util.math.MathHelper;
 import org.joml.Matrix4f;
 import qouteall.imm_ptl.core.CHelper;
 import qouteall.imm_ptl.core.ClientWorldLoader;
@@ -141,7 +143,7 @@ public class PortalVisualizerUtil {
 
             context.drawTexture(TEXTURE, left, top, 0, 0, bgWidth, bgHeight);
 
-            double t1 = CHelper.getSmoothCycles(503);
+            double t1 = delta + MinecraftClient.getInstance().player.age;
 
             // Determine the camera transformation
             Matrix4f cameraTransformation = new Matrix4f();
@@ -149,7 +151,7 @@ public class PortalVisualizerUtil {
             cameraTransformation.mul(
                     DQuaternion.rotationByDegrees(
                             new Vec3d(0, 1, 0).normalize(),
-                            t1 * 360
+                            MathHelper.wrapDegrees(t1)
                     ).toMatrix()
             );
 

--- a/src/main/java/dev/amble/ait/compat/portal/PortalsHandler.java
+++ b/src/main/java/dev/amble/ait/compat/portal/PortalsHandler.java
@@ -126,17 +126,18 @@ public class PortalsHandler extends KeyedTardisComponent {
                 this.exteriorRef.setWorld(exteriorWorld);
             }
 
-            TardisPortal portal = this.exteriorRef.get();
-
-            if (portal != null) {
-                return portal;
-            } else {
-                ServerWorld exteriorWorld = this.exteriorRef.getWorld();
-                exteriorWorld.getChunk(tardis.travel().position().getPos());
-            }
+            return this.exteriorRef.get();
         }
 
         return null;
+    }
+
+    public @Nullable EntityRef<TardisPortal> getExteriorRef() {
+        return exteriorRef;
+    }
+
+    public @Nullable EntityRef<TardisPortal> getInteriorRef() {
+        return interiorRef;
     }
 
     private void generatePortals() {
@@ -164,7 +165,7 @@ public class PortalsHandler extends KeyedTardisComponent {
         Vec3d doorAdjust = adjustInteriorPos(variant.door(), doorPos, portalHeight);
         Vec3d exteriorAdjust = adjustExteriorPos(variant, exteriorPos, portalHeight);
 
-        TardisPortal portal = new TardisPortal(tardis.travel().getState() == TravelHandlerBase.State.FLIGHT ? WorldUtil.getTimeVortex() : exteriorPos.getWorld());
+        TardisPortal portal = new TardisPortal(tardis, tardis.travel().getState() == TravelHandlerBase.State.FLIGHT ? WorldUtil.getTimeVortex() : exteriorPos.getWorld());
 
         portal.setOrientationAndSize(
                 new Vec3d(1, 0, 0), // axisW
@@ -202,7 +203,7 @@ public class PortalsHandler extends KeyedTardisComponent {
         Vec3d doorAdjust = adjustInteriorPos(variant.door(), doorPos, portalHeight);
         Vec3d exteriorAdjust = adjustExteriorPos(variant, exteriorPos, portalHeight);
 
-        TardisPortal portal = new TardisPortal(tardis.asServer().world());
+        TardisPortal portal = new TardisPortal(tardis, tardis.asServer().world());
 
         portal.setOrientationAndSize(
                 new Vec3d(1, 0, 0), // axisW

--- a/src/main/java/dev/amble/ait/compat/portal/PortalsHandler.java
+++ b/src/main/java/dev/amble/ait/compat/portal/PortalsHandler.java
@@ -126,7 +126,14 @@ public class PortalsHandler extends KeyedTardisComponent {
                 this.exteriorRef.setWorld(exteriorWorld);
             }
 
-            return this.exteriorRef.get();
+            TardisPortal portal = this.exteriorRef.get();
+
+            if (portal != null) {
+                return portal;
+            } else {
+                ServerWorld exteriorWorld = this.exteriorRef.getWorld();
+                exteriorWorld.getChunk(tardis.travel().position().getPos());
+            }
         }
 
         return null;

--- a/src/main/java/dev/amble/ait/compat/portal/TardisPortal.java
+++ b/src/main/java/dev/amble/ait/compat/portal/TardisPortal.java
@@ -1,17 +1,30 @@
 package dev.amble.ait.compat.portal;
 
+import dev.amble.ait.core.tardis.ServerTardis;
+import dev.amble.ait.core.tardis.Tardis;
+import dev.amble.ait.core.tardis.manager.ServerTardisManager;
+import dev.amble.ait.core.util.EntityRef;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.server.world.ServerWorld;
 import qouteall.imm_ptl.core.portal.Portal;
 
 import net.minecraft.entity.EntityType;
 import net.minecraft.world.World;
 
 import dev.amble.ait.client.AITModClient;
+import qouteall.imm_ptl.core.portal.PortalManipulation;
+
+import java.util.UUID;
 
 public class TardisPortal extends Portal {
+
     public static EntityType<TardisPortal> ENTITY_TYPE = createPortalEntityType(TardisPortal::new);
 
-    public TardisPortal(World world) {
+    private Tardis tardis;
+
+    public TardisPortal(Tardis tardis, World world) {
         this(ENTITY_TYPE, world);
+        this.tardis = tardis;
     }
 
     public TardisPortal(EntityType<TardisPortal> type, World world) {
@@ -21,5 +34,42 @@ public class TardisPortal extends Portal {
     @Override
     public boolean isVisible() {
         return super.isVisible() && AITModClient.CONFIG.allowPortalsBoti;
+    }
+
+    @Override
+    protected void readCustomDataFromNbt(NbtCompound nbt) {
+        super.readCustomDataFromNbt(nbt);
+
+        if (!(this.getWorld() instanceof ServerWorld serverWorld) || !nbt.contains("Tardis"))
+            return;
+
+        this.tardis = ServerTardisManager.getInstance().demandTardis(serverWorld.getServer(), nbt.getUuid("Tardis"));
+
+        if (this.tardis == null) {
+            PortalManipulation.removeConnectedPortals(this, (p) -> {});
+            this.discard();
+            return;
+        }
+
+        PortalsHandler portalsHandler = this.tardis.handler(PortalsHandler.ID);
+
+        EntityRef<TardisPortal> extPortal = portalsHandler.getExteriorRef();
+        EntityRef<TardisPortal> intPortal = portalsHandler.getInteriorRef();
+
+        UUID id = this.getUuid();
+
+        if ((extPortal == null || !id.equals(extPortal.getId())) &&
+                (intPortal == null || !id.equals(intPortal.getId()))) {
+            PortalManipulation.removeConnectedPortals(this, (p) -> {});
+            this.discard();
+        }
+    }
+
+    @Override
+    protected void writeCustomDataToNbt(NbtCompound nbt) {
+        super.writeCustomDataToNbt(nbt);
+        if (tardis != null) {
+            nbt.putUuid("Tardis", tardis.getUuid());
+        }
     }
 }

--- a/src/main/java/dev/amble/ait/core/util/EntityRef.java
+++ b/src/main/java/dev/amble/ait/core/util/EntityRef.java
@@ -33,6 +33,10 @@ public class EntityRef<T extends Entity> {
         this.world = world;
     }
 
+    public ServerWorld getWorld() {
+        return this.world;
+    }
+
     public void setWorld(ServerWorld world) {
         this.world = world;
     }


### PR DESCRIPTION
## About the PR
Portals just wouldn't get removed if they were unloaded if the TARDIS was called with a sonic/stattenheim remote.

## Why / Balance
Leaves portals all over the place

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->