### PR TITLE
Fix incorrect Astral Map distance (measured from interior player position)

### DIFF
--- a/src/main/java/dev/amble/ait/core/blocks/AstralMapBlock.java
+++ b/src/main/java/dev/amble/ait/core/blocks/AstralMapBlock.java
@@ -141,7 +141,7 @@ public class AstralMapBlock extends BlockWithEntity implements BlockEntityProvid
                 if (newPos != null) {
                     player.sendMessage(Text.translatable(
                             "block.ait.astral_map.finder.found", newPos.getX(), newPos.getY(), newPos.getZ(),
-                            Math.round(Math.sqrt(newPos.getSquaredDistance(player.getPos())))), false);
+                            Math.round(Math.sqrt(newPos.getSquaredDistance(tPos.getPos())))), false);
                     tardis.travel().destination(destination -> destination.pos(newPos));
                 } else {
                     player.sendMessage(Text.translatable("block.ait.astral_map.finder.structure_not_found"), false);
@@ -169,7 +169,7 @@ public class AstralMapBlock extends BlockWithEntity implements BlockEntityProvid
 
             if (r != null) {
                 BlockPos locatedBiome = r.getFirst();
-                int distance = (int) Math.round(Math.sqrt(locatedBiome.getSquaredDistance(player.getPos())));
+                int distance = (int) Math.round(Math.sqrt(locatedBiome.getSquaredDistance(start)));
                 player.sendMessage(Text.translatable("block.ait.astral_map.finder.found",
                         locatedBiome.getX(), locatedBiome.getY(), locatedBiome.getZ(), distance), false);
                 tardis.travel().destination(destination -> destination.pos(locatedBiome));


### PR DESCRIPTION
## About the PR

The Astral Map's structure and biome finders reported wildly wrong "blocks away" numbers — the issue shows ~10,741 for a structure ~600 blocks away, and a second case of ~12,000 where ~1,658 was expected (the non-constant ratio ruled out a simple unit error).

I couldn't reproduce it live (no client in my build environment), so this is a reasoned fix against the coordinate model plus the reporter's numbers rather than an observed in-game before/after — worth a maintainer sanity-check in-game before merge.

*Disclosure: this contribution was made with AI assistance (Claude), reviewed and built by a human-directed process before submission.*

## Why / Balance
Fixes #2029.

## Technical details
<!-- Summary of code changes for easier review. -->
Root cause is a coordinate-space mix-up. Both `handleStructureRequest` and `handleBiomeRequest` in `AstralMapBlock.java` only run when the player is inside the TARDIS interior dimension (they're guarded by `TardisServerWorld.isTardisDimension(world)`). The search runs in the *target* world from the TARDIS's exterior position (`tPos.getPos()` / `currentPos.getPos()`), and the located structure/biome is a coordinate in that target world — but the distance was computed against `player.getPos()`, which is the player's position in the *interior* dimension, an unrelated coordinate space. Subtracting interior coords from target-world coords produces the garbage distance.

The fix measures the distance from the TARDIS's exterior search origin (the same reference the result was located from and reported relative to), in both finders:

- structure: `newPos.getSquaredDistance(player.getPos())` → `newPos.getSquaredDistance(tPos.getPos())`
- biome: `locatedBiome.getSquaredDistance(player.getPos())` → `locatedBiome.getSquaredDistance(start)`

(`tPos.getPos()` rather than the local `pos` because `pos` is reassigned and so isn't capturable by the async `thenOnServerThread` lambda; it holds the identical value.)

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: incorrect astral map distance calculation