### PR TITLE
Add "ait:cable_block" into carryon blacklist

### DIFF
--- a/src/main/resources/data/carryon/tags/blocks/block_blacklist.json
+++ b/src/main/resources/data/carryon/tags/blocks/block_blacklist.json
@@ -13,6 +13,7 @@
     "ait:wall_monitor_block",
     "ait:monitor_block",
     "ait:generic_subsystem",
-    "ait:detector_block"
+    "ait:detector_block",
+    "ait:cable_block"
   ]
 }


### PR DESCRIPTION

## About the PR
Added a line of code to blacklist the artron cables from being able to be picked up via carryon

## Why / Balance
Players can no longer pick up the invisble artron cables at the base of the engine multiblock.

## Technical details
Literally just added one line of text lol.

## Media
N/A

## Requirements
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
none

**Changelog**
- fix: Artron Cables are now blocked from carryon pickup.