### PR TITLE
fix: sonic screwdriver now tells you the material and type of tool you need for a block

### DIFF
--- a/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
+++ b/src/main/java/dev/amble/ait/core/item/sonic/ScanningSonicMode.java
@@ -9,6 +9,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
@@ -122,22 +123,18 @@ public class ScanningSonicMode extends SonicMode {
             return true;
         }
 
-        String toolRequirement = "item.sonic.scanning.any_tool";
+        Text toolRequirement;
         if (block instanceof ICantBreak) {
-            toolRequirement = "item.sonic.scanning.cant_break";
+            toolRequirement = Text.translatable("item.sonic.scanning.cant_break");
+        } else if (!state.isToolRequired()) {
+            toolRequirement = Text.translatable("item.sonic.scanning.no_tool");
         } else {
-            if (state.isIn(BlockTags.NEEDS_DIAMOND_TOOL)) {
-                toolRequirement = "item.sonic.scanning.diamond_tool";
-            } else if (state.isIn(BlockTags.NEEDS_IRON_TOOL)) {
-                toolRequirement = "item.sonic.scanning.iron_tool";
-            } else if (state.isIn(BlockTags.NEEDS_STONE_TOOL)) {
-                toolRequirement = "item.sonic.scanning.stone_tool";
-            } else if (!block.getDefaultState().isToolRequired()) {
-                toolRequirement = "item.sonic.scanning.no_tool";
-            }
+            MutableText toolType = toolTypeText(state);
+            MutableText tier = tierText(state);
+            toolRequirement = tier != null ? tier.append(" ").append(toolType) : toolType;
         }
 
-        Text message = Text.literal("\uD83D\uDD25: " + blastRes + " ⛏: ").append(Text.translatable(toolRequirement)).formatted(Formatting.YELLOW)
+        Text message = Text.literal("\uD83D\uDD25: " + blastRes + " ⛏: ").append(toolRequirement).formatted(Formatting.YELLOW)
                 .formatted(Formatting.GOLD);
         user.sendMessage(message, true);
 
@@ -145,6 +142,32 @@ public class ScanningSonicMode extends SonicMode {
     }
 
 
+
+    /** The tool class needed to mine the block (pickaxe/axe/shovel/hoe), or "any tool" if untagged. */
+    private static MutableText toolTypeText(BlockState state) {
+        if (state.isIn(BlockTags.PICKAXE_MINEABLE))
+            return Text.translatable("item.sonic.scanning.tool.pickaxe");
+        if (state.isIn(BlockTags.AXE_MINEABLE))
+            return Text.translatable("item.sonic.scanning.tool.axe");
+        if (state.isIn(BlockTags.SHOVEL_MINEABLE))
+            return Text.translatable("item.sonic.scanning.tool.shovel");
+        if (state.isIn(BlockTags.HOE_MINEABLE))
+            return Text.translatable("item.sonic.scanning.tool.hoe");
+
+        return Text.translatable("item.sonic.scanning.any_tool");
+    }
+
+    /** The minimum material tier the block requires (diamond/iron/stone), or null if none. */
+    private static MutableText tierText(BlockState state) {
+        if (state.isIn(BlockTags.NEEDS_DIAMOND_TOOL))
+            return Text.translatable("item.sonic.scanning.tier.diamond");
+        if (state.isIn(BlockTags.NEEDS_IRON_TOOL))
+            return Text.translatable("item.sonic.scanning.tier.iron");
+        if (state.isIn(BlockTags.NEEDS_STONE_TOOL))
+            return Text.translatable("item.sonic.scanning.tier.stone");
+
+        return null;
+    }
 
     public boolean scanRegion(ItemStack stack, World world, PlayerEntity user, BlockPos pos) {
         if (world.isClient())

--- a/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
+++ b/src/main/java/dev/amble/ait/datagen/AITModDataGenerator.java
@@ -1134,9 +1134,13 @@ public class AITModDataGenerator implements DataGeneratorEntrypoint {
 
         // Sonic Scanning Mode
         provider.addTranslation("item.sonic.scanning.any_tool", "Any Tool");
-        provider.addTranslation("item.sonic.scanning.diamond_tool", "Diamond Tool");
-        provider.addTranslation("item.sonic.scanning.iron_tool", "Iron Tool");
-        provider.addTranslation("item.sonic.scanning.stone_tool", "Stone Tool");
+        provider.addTranslation("item.sonic.scanning.tool.pickaxe", "Pickaxe");
+        provider.addTranslation("item.sonic.scanning.tool.axe", "Axe");
+        provider.addTranslation("item.sonic.scanning.tool.shovel", "Shovel");
+        provider.addTranslation("item.sonic.scanning.tool.hoe", "Hoe");
+        provider.addTranslation("item.sonic.scanning.tier.diamond", "Diamond");
+        provider.addTranslation("item.sonic.scanning.tier.iron", "Iron");
+        provider.addTranslation("item.sonic.scanning.tier.stone", "Stone");
         provider.addTranslation("item.sonic.scanning.no_tool", "Hand (No Tool)");
         provider.addTranslation("item.sonic.scanning.cant_break", "Can't Break Block!");
         provider.addTranslation("item.sonic.scanning.locator_message.title", "TARDIS location: %s");


### PR DESCRIPTION
## About the PR
i fixed maketendos old code and made sure it actually scans for the right tool type and material.

## Why / Balance
it was meant to work like this all along

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (blocks, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in #teasers with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://amblelabs.github.io/ait-wiki/guidelines).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, class renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: sonic screwdriver wouldnt tell you the tool or material type you need to break a block